### PR TITLE
refactor: Use ObservableObject more in examples

### DIFF
--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Atoms/DetailAtoms.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Atoms/DetailAtoms.swift
@@ -5,7 +5,7 @@ struct IsInMyListAtom: ValueAtom, Hashable {
 
     func value(context: Context) -> Bool {
         let myList = context.watch(MyListAtom())
-        return myList.contains(movie)
+        return myList.movies.contains(movie)
     }
 }
 

--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Atoms/MoviesAtoms.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Atoms/MoviesAtoms.swift
@@ -32,7 +32,7 @@ final class MoviePages: ObservableObject {
 
         let nextPage = try? await api.getMovies(filter: filter, page: currentPage + 1)
 
-        guard let nextPage = nextPage else{
+        guard let nextPage = nextPage else {
             return
         }
 

--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/DetailScreen.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/DetailScreen.swift
@@ -4,8 +4,8 @@ import SwiftUI
 struct DetailScreen: View {
     let movie: Movie
 
-    @Watch(MyListInsertAtom())
-    var myListInsert
+    @WatchStateObject(MyListAtom())
+    var myList
 
     @ViewContext
     var context
@@ -98,7 +98,7 @@ struct DetailScreen: View {
         let isOn = context.watch(IsInMyListAtom(movie: movie))
 
         Button {
-            myListInsert(movie: movie)
+            myList.insert(movie: movie)
         } label: {
             MyListButtonLabel(isOn: isOn)
         }

--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/MoviesScreen.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/MoviesScreen.swift
@@ -29,26 +29,26 @@ struct MoviesScreen: View {
                 FilterPicker()
 
                 switch pages.moviePages {
-                    case .success(let movies):
-                        ForEach(movies, id: \.page) { response in
-                            pageIndex(current: response.page, total: response.totalPages)
+                case .success(let movies):
+                    ForEach(movies, id: \.page) { response in
+                        pageIndex(current: response.page, total: response.totalPages)
 
-                            ForEach(response.results, id: \.id) { movie in
-                                movieRow(movie)
-                            }
+                        ForEach(response.results, id: \.id) { movie in
+                            movieRow(movie)
                         }
+                    }
 
-                        if let last = movies.last, last.hasNextPage {
-                            ProgressRow().task {
-                                await pages.loadNext()
-                            }
+                    if let last = movies.last, last.hasNextPage {
+                        ProgressRow().task {
+                            await pages.loadNext()
                         }
+                    }
 
-                    case .failure:
-                        CaveatRow(text: "Failed to get the data.")
+                case .failure:
+                    CaveatRow(text: "Failed to get the data.")
 
-                    case .suspending:
-                        ProgressRow()
+                case .suspending:
+                    ProgressRow()
                 }
             }
         }

--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/MoviesScreen.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/MoviesScreen.swift
@@ -2,8 +2,8 @@ import Atoms
 import SwiftUI
 
 struct MoviesScreen: View {
-    @WatchStateObject(MoviePagesAtom())
-    var pages
+    @WatchStateObject(MovieLoaderAtom())
+    var loader
 
     @WatchState(SearchQueryAtom())
     var searchQuery
@@ -28,9 +28,9 @@ struct MoviesScreen: View {
             Section {
                 FilterPicker()
 
-                switch pages.moviePages {
-                case .success(let movies):
-                    ForEach(movies, id: \.page) { response in
+                switch loader.pages {
+                case .success(let pages):
+                    ForEach(pages, id: \.page) { response in
                         pageIndex(current: response.page, total: response.totalPages)
 
                         ForEach(response.results, id: \.id) { movie in
@@ -38,9 +38,9 @@ struct MoviesScreen: View {
                         }
                     }
 
-                    if let last = movies.last, last.hasNextPage {
+                    if let last = pages.last, last.hasNextPage {
                         ProgressRow().task {
-                            await pages.loadNext()
+                            await loader.loadNext()
                         }
                     }
 
@@ -66,11 +66,11 @@ struct MoviesScreen: View {
         .onSubmit(of: .search) { [$isShowingSearchScreen] in
             $isShowingSearchScreen.wrappedValue = true
         }
-        .task(id: pages.filter) {
-            await pages.refresh()
+        .task(id: loader.filter) {
+            await loader.refresh()
         }
-        .refreshable { [pages] in
-            await pages.refresh()
+        .refreshable { [loader] in
+            await loader.refresh()
         }
         .background {
             NavigationLink(

--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Views/MyMovieList.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Views/MyMovieList.swift
@@ -2,19 +2,19 @@ import Atoms
 import SwiftUI
 
 struct MyMovieList: View {
-    @Watch(MyListAtom())
+    @WatchStateObject(MyListAtom())
     var myList
 
     var onSelect: (Movie) -> Void
 
     var body: some View {
-        if myList.isEmpty {
+        if myList.movies.isEmpty {
             emptyContent
         }
         else {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack {
-                    ForEach(myList, id: \.id) { movie in
+                    ForEach(myList.movies, id: \.id) { movie in
                         item(movie: movie)
                     }
                 }

--- a/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
@@ -29,9 +29,9 @@ final class ExampleMovieDBTests: XCTestCase {
         XCTAssertEqual(failurePhase.error as? URLError, error)
     }
 
-    func testFirstPageAtom() async {
+    func testMoviePages() async {
         let apiClient = MockAPIClient()
-        let atom = FirstPageAtom()
+        let atom = MoviePagesAtom()
         let context = AtomTestContext()
 
         context.override(APIClientAtom()) { _ in apiClient }
@@ -44,85 +44,46 @@ final class ExampleMovieDBTests: XCTestCase {
 
             apiClient.filteredMovieResponse = .success(expected)
 
-            let successPhase = await AsyncPhase(context.watch(atom).result)
+            await context.watch(atom).refresh()
 
-            XCTAssertEqual(successPhase.value, expected)
+            XCTAssertEqual(context.watch(atom).moviePages.value, [expected])
+
+            await context.watch(atom).loadNext()
+
+            XCTAssertEqual(context.watch(atom).moviePages.value, [expected, expected])
 
             context.reset(atom)
             apiClient.filteredMovieResponse = .failure(error)
 
-            let failurePhase = await AsyncPhase(context.watch(atom).result)
+            await context.watch(atom).refresh()
 
-            XCTAssertEqual(failurePhase.error as? URLError, error)
+            XCTAssertEqual(context.watch(atom).moviePages.error as? URLError, error)
         }
     }
 
-    func testNextPagesAtom() {
-        let atom = NextPagesAtom()
-        let context = AtomTestContext()
-        let pages = [
-            PagedResponse<Movie>(page: 1, totalPages: 100, results: [])
-        ]
-
-        XCTAssertEqual(context.watch(atom), [])
-
-        context[atom] = pages
-
-        XCTAssertEqual(context.watch(atom), pages)
-
-        context.reset(FirstPageAtom())
-
-        XCTAssertEqual(context.watch(atom), [])
-    }
-
-    func testLoadNextAtom() async {
-        let apiClient = MockAPIClient()
-        let atom = LoadNextAtom()
+    func testMyListAtom() {
+        let atom = MyListAtom()
         let context = AtomTestContext()
 
-        context.override(APIClientAtom()) { _ in apiClient }
+        XCTAssertEqual(context.watch(atom).movies, [])
 
-        apiClient.filteredMovieResponse = .success(.stub())
+        context.watch(atom).insert(movie: .stub(id: 0))
 
-        let loadNext = context.watch(atom)
+        XCTAssertEqual(context.watch(atom).movies, [.stub(id: 0)])
 
-        XCTAssertEqual(context.watch(NextPagesAtom()), [])
+        context.watch(atom).insert(movie: .stub(id: 1))
 
-        await loadNext()
+        XCTAssertEqual(context.watch(atom).movies, [.stub(id: 0), .stub(id: 1)])
 
-        XCTAssertEqual(context.watch(NextPagesAtom()), [.stub()])
+        context.watch(atom).insert(movie: .stub(id: 0))
 
-        await loadNext()
-
-        XCTAssertEqual(context.watch(NextPagesAtom()), [.stub(), .stub()])
-    }
-
-    func testMyListInsertAtom() {
-        let atom = MyListInsertAtom()
-        let context = AtomTestContext()
-        let action = context.watch(atom)
-
-        XCTAssertEqual(context.watch(MyListAtom()), [])
-
-        action(movie: .stub(id: 0))
-
-        XCTAssertEqual(context.watch(MyListAtom()), [.stub(id: 0)])
-
-        action(movie: .stub(id: 1))
-
-        XCTAssertEqual(context.watch(MyListAtom()), [.stub(id: 0), .stub(id: 1)])
-
-        action(movie: .stub(id: 0))
-
-        XCTAssertEqual(context.watch(MyListAtom()), [.stub(id: 1)])
+        XCTAssertEqual(context.watch(atom).movies, [.stub(id: 1)])
     }
 
     func testIsInMyListAtom() {
         let context = AtomTestContext()
 
-        XCTAssertFalse(context.watch(IsInMyListAtom(movie: .stub(id: 0))))
-
-        context[MyListAtom()].append(.stub(id: 0))
+        context.watch(MyListAtom()).insert(movie: .stub(id: 0))
 
         XCTAssertTrue(context.watch(IsInMyListAtom(movie: .stub(id: 0))))
         XCTAssertFalse(context.watch(IsInMyListAtom(movie: .stub(id: 1))))

--- a/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
@@ -29,9 +29,9 @@ final class ExampleMovieDBTests: XCTestCase {
         XCTAssertEqual(failurePhase.error as? URLError, error)
     }
 
-    func testMoviePages() async {
+    func testMovieLoader() async {
         let apiClient = MockAPIClient()
-        let atom = MoviePagesAtom()
+        let atom = MovieLoaderAtom()
         let context = AtomTestContext()
 
         context.override(APIClientAtom()) { _ in apiClient }
@@ -46,18 +46,18 @@ final class ExampleMovieDBTests: XCTestCase {
 
             await context.watch(atom).refresh()
 
-            XCTAssertEqual(context.watch(atom).moviePages.value, [expected])
+            XCTAssertEqual(context.watch(atom).pages.value, [expected])
 
             await context.watch(atom).loadNext()
 
-            XCTAssertEqual(context.watch(atom).moviePages.value, [expected, expected])
+            XCTAssertEqual(context.watch(atom).pages.value, [expected, expected])
 
             context.reset(atom)
             apiClient.filteredMovieResponse = .failure(error)
 
             await context.watch(atom).refresh()
 
-            XCTAssertEqual(context.watch(atom).moviePages.error as? URLError, error)
+            XCTAssertEqual(context.watch(atom).pages.error as? URLError, error)
         }
     }
 


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Use ObservableObject more in example apps so that users can understand how to use Atoms if they want to define interactive atoms.

## Impact on Existing Code

N/A

## Blocker

#10 fixes the bug of ObservableObjectAtom that doesn't update other atoms depending on it correctly.