### PR TITLE
fix: Lifecycle and unsubscription problem

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -42,7 +42,7 @@ import SwiftUI
 public struct AtomRoot<Content: View>: View {
     @StateObject
     private var state: State
-    private var overrides: Overrides
+    private var overrides = Overrides()
     private var observers = [AtomObserver]()
     private let content: Content
 
@@ -51,7 +51,6 @@ public struct AtomRoot<Content: View>: View {
     /// - Parameter content: The content that uses atoms.
     public init(@ViewBuilder content: () -> Content) {
         self._state = StateObject(wrappedValue: State())
-        self.overrides = Overrides()
         self.content = content()
     }
 

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -275,17 +275,12 @@ private extension AtomTestContext {
     @MainActor
     final class State {
         private let _store = Store()
+        private let _container = SubscriptionContainer()
 
-        let container: SubscriptionContainer
-        var overrides: Overrides
+        var overrides = Overrides()
         var observers = [AtomObserver]()
         let notifier = PassthroughSubject<Void, Never>()
         var onUpdate: (() -> Void)?
-
-        init() {
-            overrides = Overrides()
-            container = SubscriptionContainer()
-        }
 
         var store: StoreContext {
             StoreContext(
@@ -293,6 +288,10 @@ private extension AtomTestContext {
                 overrides: overrides,
                 observers: observers
             )
+        }
+
+        var container: SubscriptionContainer.Wrapper {
+            _container.wrapper
         }
 
         func notifyUpdate() {

--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -7,13 +7,13 @@ public struct AtomViewContext: AtomWatchableContext {
     @usableFromInline
     internal let _store: StoreContext
     @usableFromInline
-    internal let _container: SubscriptionContainer
+    internal let _container: SubscriptionContainer.Wrapper
     @usableFromInline
     internal let _notifyUpdate: () -> Void
 
     internal init(
         store: StoreContext,
-        container: SubscriptionContainer,
+        container: SubscriptionContainer.Wrapper,
         notifyUpdate: @escaping () -> Void
     ) {
         _store = store

--- a/Sources/Atoms/Core/Overrides.swift
+++ b/Sources/Atoms/Core/Overrides.swift
@@ -3,6 +3,8 @@ internal struct Overrides {
     private var _entriesForNode = [AtomKey: Override]()
     private var _entriesForType = [AtomTypeKey: Override]()
 
+    nonisolated init() {}
+
     mutating func insert<Node: Atom>(
         _ atom: Node,
         with value: @escaping (Node) -> Node.Loader.Value

--- a/Sources/Atoms/Core/SubscriptionContainer.swift
+++ b/Sources/Atoms/Core/SubscriptionContainer.swift
@@ -1,11 +1,37 @@
 @usableFromInline
 @MainActor
 internal final class SubscriptionContainer {
-    var subscriptions = [AtomKey: Subscription]()
+    private var subscriptions = [AtomKey: Subscription]()
+
+    var wrapper: Wrapper {
+        Wrapper(self)
+    }
+
+    nonisolated init() {}
 
     deinit {
         for subscription in ContiguousArray(subscriptions.values) {
             subscription.unsubscribe()
+        }
+    }
+}
+
+internal extension SubscriptionContainer {
+    @usableFromInline
+    @MainActor
+    struct Wrapper {
+        private weak var container: SubscriptionContainer?
+
+        let key: SubscriptionKey
+
+        var subscriptions: [AtomKey: Subscription] {
+            get { container?.subscriptions ?? [:] }
+            nonmutating set { container?.subscriptions = newValue }
+        }
+
+        init(_ container: SubscriptionContainer) {
+            self.container = container
+            self.key = SubscriptionKey(container)
         }
     }
 }

--- a/Sources/Atoms/PropertyWrapper/ViewContext.swift
+++ b/Sources/Atoms/PropertyWrapper/ViewContext.swift
@@ -52,7 +52,7 @@ public struct ViewContext: DynamicProperty {
     public var wrappedValue: AtomViewContext {
         AtomViewContext(
             store: _store,
-            container: state.container,
+            container: state.container.wrapper,
             notifyUpdate: state.objectWillChange.send
         )
     }
@@ -61,10 +61,6 @@ public struct ViewContext: DynamicProperty {
 private extension ViewContext {
     @MainActor
     final class State: ObservableObject {
-        let container: SubscriptionContainer
-
-        init() {
-            container = SubscriptionContainer()
-        }
+        let container = SubscriptionContainer()
     }
 }

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -92,7 +92,7 @@ final class AtomTestContextTests: XCTestCase {
 
         for observer in observers {
             XCTAssertEqual(observer.assignedAtomKeys, [key])
-            XCTAssertEqual(observer.unassignedAtomKeys, [])
+            XCTAssertTrue(observer.unassignedAtomKeys.isEmpty)
             XCTAssertEqual(observer.changedAtomKeys, [key])
         }
 
@@ -100,7 +100,7 @@ final class AtomTestContextTests: XCTestCase {
 
         for observer in observers {
             XCTAssertEqual(observer.assignedAtomKeys, [key])
-            XCTAssertEqual(observer.unassignedAtomKeys, [])
+            XCTAssertTrue(observer.unassignedAtomKeys.isEmpty)
             XCTAssertEqual(observer.changedAtomKeys, [key, key])
         }
 

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -10,7 +10,7 @@ final class AtomViewContextTests: XCTestCase {
         let container = SubscriptionContainer()
         let context = AtomViewContext(
             store: StoreContext(store),
-            container: container,
+            container: container.wrapper,
             notifyUpdate: {}
         )
 
@@ -23,7 +23,7 @@ final class AtomViewContextTests: XCTestCase {
         let container = SubscriptionContainer()
         let context = AtomViewContext(
             store: StoreContext(store),
-            container: container,
+            container: container.wrapper,
             notifyUpdate: {}
         )
 
@@ -40,7 +40,7 @@ final class AtomViewContextTests: XCTestCase {
         let container = SubscriptionContainer()
         let context = AtomViewContext(
             store: StoreContext(store),
-            container: container,
+            container: container.wrapper,
             notifyUpdate: {}
         )
 
@@ -57,7 +57,7 @@ final class AtomViewContextTests: XCTestCase {
         let container = SubscriptionContainer()
         let context = AtomViewContext(
             store: StoreContext(store),
-            container: container,
+            container: container.wrapper,
             notifyUpdate: {}
         )
 
@@ -78,7 +78,7 @@ final class AtomViewContextTests: XCTestCase {
         let container = SubscriptionContainer()
         let context = AtomViewContext(
             store: StoreContext(store),
-            container: container,
+            container: container.wrapper,
             notifyUpdate: {}
         )
 
@@ -87,5 +87,23 @@ final class AtomViewContextTests: XCTestCase {
         context[atom] = 200
 
         XCTAssertEqual(context.watch(atom), 200)
+    }
+
+    func testUnsubscription() {
+        let atom = TestValueAtom(value: 100)
+        let key = AtomKey(atom)
+        let store = Store()
+        var container: SubscriptionContainer? = SubscriptionContainer()
+        let context = AtomViewContext(
+            store: StoreContext(store),
+            container: container!.wrapper,
+            notifyUpdate: {}
+        )
+
+        context.watch(atom)
+        XCTAssertNotNil(store.state.atomStates[key])
+
+        container = nil
+        XCTAssertNil(store.state.atomStates[key])
     }
 }

--- a/Tests/AtomsTests/Core/SubscriptionContainerTests.swift
+++ b/Tests/AtomsTests/Core/SubscriptionContainerTests.swift
@@ -13,7 +13,7 @@ final class SubscriptionContainerTests: XCTestCase {
         let atom0 = TestValueAtom(value: 0)
         let atom1 = TestValueAtom(value: 1)
 
-        container?.subscriptions = [
+        container?.wrapper.subscriptions = [
             AtomKey(atom0): subscription,
             AtomKey(atom1): subscription,
         ]


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

- Ensure that the atom is registered for `read`, `reset`, and `refresh` even if it has no downstream.
- Fixes a problem that AtomViewContext doesn't release if it's retained by a Binding.

## Impact on Existing Code

Fixes the bugs that describe above.
