### PR TITLE
feat: Add a new side-effects management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,16 +458,6 @@ struct CounterAtom: StateAtom, Hashable {
     func defaultValue(context: Context) -> Int {
         0
     }
-
-    // Does nothing by default.
-    func willSet(newValue: Int, oldValue: Int, context: Context) {
-        print("Will change")
-    }
-
-    // Does nothing by default.
-    func didSet(newValue: Int, oldValue: Int, context: Context) {
-        print("Did change")
-    }
 }
 
 struct CounterView: View {

--- a/Sources/Atoms/Atom/Atom.swift
+++ b/Sources/Atoms/Atom/Atom.swift
@@ -19,6 +19,9 @@ public protocol Atom {
     /// with other atoms.
     typealias Context = AtomTransactionContext<Coordinator>
 
+    /// A type of the structure that to read value other atoms.
+    typealias Reader = AtomReader
+
     /// A boolean value indicating whether the atom value should be preserved even if
     /// no longer watched to.
     ///
@@ -41,7 +44,21 @@ public protocol Atom {
     /// the atom is no longer used and is deinitialized.
     ///
     /// - Returns: The atom's associated coordinator instance.
+    @MainActor
     func makeCoordinator() -> Coordinator
+
+    /// Notifies the atom that the associated value is updated.
+    ///
+    /// Use it to manage arbitrary side-effects of value updates, such as state persistence,
+    /// state synchronization, logging, and etc.
+    /// You can also access other atom values via `reader` passed as a parameter.
+    ///
+    /// - Parameters:
+    ///   - newValue: A new value after update.
+    ///   - oldValue: An old value before update.
+    ///   - reader: A structure that to read value other atoms.
+    @MainActor
+    func updated(newValue: Loader.Value, oldValue: Loader.Value, reader: Reader)
 
     // --- Internal ---
 
@@ -58,6 +75,8 @@ public extension Atom {
     func makeCoordinator() -> Coordinator where Coordinator == Void {
         ()
     }
+
+    func updated(newValue: Loader.Value, oldValue: Loader.Value, reader: Reader) {}
 }
 
 public extension Atom where Self == Key {

--- a/Sources/Atoms/Atom/StateAtom.swift
+++ b/Sources/Atoms/Atom/StateAtom.swift
@@ -2,8 +2,6 @@
 ///
 /// This atom provides a mutable state value that can be accessed from anywhere, and it notifies changes
 /// to downstream atoms and views.
-/// In addition, there are `willSet`/`didSet` functions to generate side effects in response before and
-/// after state changes.
 ///
 /// ## Output Value
 ///
@@ -15,14 +13,6 @@
 /// struct CounterAtom: StateAtom, Hashable {
 ///     func defaultValue(context: Context) -> Int {
 ///         0
-///     }
-///
-///     func willSet(newValue: Int, oldValue: Int, , context: Context) {
-///         print("Will change - newValue: \(newValue), oldValue: \(oldValue)")
-///     }
-///
-///     func didSet(newValue: Int, oldValue: Int, context: Context) {
-///         print("Did change - newValue: \(newValue), oldValue: \(oldValue)")
 ///     }
 /// }
 ///
@@ -51,28 +41,6 @@ public protocol StateAtom: Atom {
     /// - Returns: A default value of state.
     @MainActor
     func defaultValue(context: Context) -> Value
-
-    /// Observes and responds to changes in the state value which is called just before
-    /// the state is changed.
-    ///
-    /// - Parameters
-    ///   - newValue: A new value after update.
-    ///   - oldValue: A old value before update.
-    ///   - context: A context structure that to read, watch, and otherwise
-    ///              interacting with other atoms.
-    @MainActor
-    func willSet(newValue: Loader.Value, oldValue: Loader.Value, context: Context)
-
-    /// Observes and responds to changes in the state value which is called just after
-    /// the state is changed.
-    ///
-    /// - Parameters
-    ///   - newValue: A new value after update.
-    ///   - oldValue: A old value before update.
-    ///   - context: A context structure that to read, watch, and otherwise
-    ///              interacting with other atoms.
-    @MainActor
-    func didSet(newValue: Loader.Value, oldValue: Loader.Value, context: Context)
 }
 
 public extension StateAtom {
@@ -80,10 +48,4 @@ public extension StateAtom {
     var _loader: StateAtomLoader<Self> {
         StateAtomLoader(atom: self)
     }
-
-    @MainActor
-    func willSet(newValue: Loader.Value, oldValue: Loader.Value, context: Context) {}
-
-    @MainActor
-    func didSet(newValue: Loader.Value, oldValue: Loader.Value, context: Context) {}
 }

--- a/Sources/Atoms/AtomReader.swift
+++ b/Sources/Atoms/AtomReader.swift
@@ -1,0 +1,29 @@
+/// A structure that to read value other atoms.
+@MainActor
+public struct AtomReader {
+    @usableFromInline
+    internal let _store: StoreContext
+
+    internal init(store: StoreContext) {
+        self._store = store
+    }
+
+    /// Accesses the value associated with the given atom without watching to it.
+    ///
+    /// This method returns a value for the given atom. Even if you access to a value with this method,
+    /// it doesn't initiating watch the atom, so if none of other atoms or views is watching as well,
+    /// the value will not be cached.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// print(context.read(TextAtom()))  // Prints the current value associated with `TextAtom`.
+    /// ```
+    ///
+    /// - Parameter atom: An atom that associates the value.
+    ///
+    /// - Returns: The value associated with the given atom.
+    @inlinable
+    public func read<Node: Atom>(_ atom: Node) -> Node.Loader.Value {
+        _store.read(atom)
+    }
+}

--- a/Sources/Atoms/Core/Loader/AtomLoaderContext.swift
+++ b/Sources/Atoms/Core/Loader/AtomLoaderContext.swift
@@ -22,8 +22,8 @@ public struct AtomLoaderContext<Value, Coordinator> {
         _update = update
     }
 
-    internal func update(with value: Value, updatesChildrenOnNextRunLoop: Bool = false) {
-        _update(value, updatesChildrenOnNextRunLoop)
+    internal func update(with value: Value, needsEnsureValueUpdate: Bool = false) {
+        _update(value, needsEnsureValueUpdate)
     }
 
     internal func addTermination(_ termination: @MainActor @escaping () -> Void) {

--- a/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
@@ -28,7 +28,7 @@ public struct ObservableObjectAtomLoader<Node: ObservableObjectAtom>: AtomLoader
                 return
             }
 
-            context.update(with: object, updatesChildrenOnNextRunLoop: true)
+            context.update(with: object, needsEnsureValueUpdate: true)
         }
 
         context.addTermination(cancellable.cancel)

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -29,6 +29,7 @@ internal struct StoreContext {
     func set<Node: StateAtom>(_ value: Node.Loader.Value, for atom: Node) {
         let key = AtomKey(atom)
         update(atom: atom, for: key, with: value)
+        checkRelease(for: key)
     }
 
     @usableFromInline

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -28,40 +28,7 @@ internal struct StoreContext {
     @usableFromInline
     func set<Node: StateAtom>(_ value: Node.Loader.Value, for atom: Node) {
         let key = AtomKey(atom)
-        let cache = peekCache(of: atom, for: key)
-
-        // Do nothing if the atom is not yet to be registered.
-        guard let oldValue = cache?.value else {
-            return
-        }
-
-        // Note that this is special handling for `willSet/didSet` because the dependencies could be invalidated
-        // by `prepareTransaction` here and there's no timing to restore them.
-        // The dependencies added by `willSet/didSet` will not be released until the value is invalidated and
-        // is going to be a bug, so `AtomTransactionContenxt` will no longer be passed soon.
-        // https://github.com/ra1028/swiftui-atom-properties/issues/18
-        let state = getState(of: atom, for: key)
-        let transaction = Transaction(key: key) {
-            // Do nothing.
-        }
-        let context = AtomLoaderContext(
-            store: self,
-            transaction: transaction,
-            coordinator: state.coordinator
-        ) { value, needsEnsureValueUpdate in
-            update(
-                atom: atom,
-                for: key,
-                with: value,
-                needsEnsureValueUpdate: needsEnsureValueUpdate
-            )
-        }
-
-        context.transaction { context in
-            atom.willSet(newValue: value, oldValue: oldValue, context: context)
-            update(atom: atom, for: key, with: value)
-            atom.didSet(newValue: value, oldValue: oldValue, context: context)
-        }
+        update(atom: atom, for: key, with: value)
     }
 
     @usableFromInline

--- a/Tests/AtomsTests/Atom/ModifiedAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ModifiedAtomTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @MainActor
 final class ModifiedAtomTests: XCTestCase {
     func testKey() {
-        let base = TestValueAtom(value: 0)
+        let base = TestAtom(value: 0)
         let modifier = SelectModifier<Int, String>(keyPath: \.description)
         let atom = ModifiedAtom(atom: base, modifier: modifier)
 

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -126,4 +126,38 @@ final class PublisherAtomTests: XCTestCase {
             XCTAssertEqual(updateCount, 1)
         }
     }
+
+    func testUpdated() async {
+        let subject = ResettableSubject<Int, URLError>()
+        var updatedValues = [Pair<Int?>]()
+        let atom = TestPublisherAtom {
+            subject
+        } onUpdated: { new, old in
+            let values = Pair(first: new.value, second: old.value)
+            updatedValues.append(values)
+        }
+        let context = AtomTestContext()
+
+        context.watch(atom)
+
+        XCTAssertTrue(updatedValues.isEmpty)
+
+        subject.send(0)
+        await context.waitUntilNextUpdate()
+
+        subject.send(1)
+        await context.waitUntilNextUpdate()
+
+        subject.send(2)
+        await context.waitUntilNextUpdate()
+
+        XCTAssertEqual(
+            updatedValues,
+            [
+                Pair(first: 0, second: nil),
+                Pair(first: 1, second: 0),
+                Pair(first: 2, second: 1),
+            ]
+        )
+    }
 }

--- a/Tests/AtomsTests/Atom/StateAtomTests.swift
+++ b/Tests/AtomsTests/Atom/StateAtomTests.swift
@@ -23,71 +23,27 @@ final class StateAtomTests: XCTestCase {
     }
 
     func testSet() {
-        var willSetNewValues = [Int]()
-        var willSetOldValues = [Int]()
-        var didSetNewValues = [Int]()
-        var didSetOldValues = [Int]()
-        let atom = TestStateAtom(
-            defaultValue: 0,
-            willSet: { newValue, oldValue in
-                willSetNewValues.append(newValue)
-                willSetOldValues.append(oldValue)
-            },
-            didSet: { newValue, oldValue in
-                didSetNewValues.append(newValue)
-                didSetOldValues.append(oldValue)
-            }
-        )
+        let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
         XCTAssertEqual(context.watch(atom), 0)
-        XCTAssertTrue(willSetNewValues.isEmpty)
-        XCTAssertTrue(willSetOldValues.isEmpty)
-        XCTAssertTrue(didSetNewValues.isEmpty)
-        XCTAssertTrue(didSetOldValues.isEmpty)
-
-        context.onUpdate = {
-            XCTAssertEqual(willSetNewValues, [100])
-            XCTAssertEqual(willSetOldValues, [0])
-            XCTAssertTrue(didSetNewValues.isEmpty)
-            XCTAssertTrue(didSetOldValues.isEmpty)
-        }
 
         context[atom] = 100
 
         XCTAssertEqual(context.watch(atom), 100)
-        XCTAssertEqual(willSetNewValues, [100])
-        XCTAssertEqual(willSetOldValues, [0])
-        XCTAssertEqual(didSetNewValues, [100])
-        XCTAssertEqual(didSetOldValues, [0])
     }
 
     func testSetOverride() {
-        var willSetCount = 0
-        var didSetCount = 0
-        let atom = TestStateAtom(
-            defaultValue: 0,
-            willSet: { _, _ in willSetCount += 1 },
-            didSet: { _, _ in didSetCount += 1 }
-        )
+        let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
         context.override(atom) { _ in 200 }
 
         XCTAssertEqual(context.watch(atom), 200)
-        XCTAssertEqual(willSetCount, 0)
-        XCTAssertEqual(didSetCount, 0)
-
-        context.onUpdate = {
-            XCTAssertEqual(willSetCount, 1)
-            XCTAssertEqual(didSetCount, 0)
-        }
 
         context[atom] = 100
 
         XCTAssertEqual(context.watch(atom), 100)
-        XCTAssertEqual(willSetCount, 1)
-        XCTAssertEqual(didSetCount, 1)
     }
 
     func testDependency() async {
@@ -97,29 +53,9 @@ final class StateAtomTests: XCTestCase {
             }
         }
 
-        struct Dependency2Atom: StateAtom, Hashable {
-            func defaultValue(context: Context) -> Int {
-                0
-            }
-        }
-
-        struct Dependency3Atom: StateAtom, Hashable {
-            func defaultValue(context: Context) -> Int {
-                0
-            }
-        }
-
         struct TestAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
                 context.watch(Dependency1Atom())
-            }
-
-            func willSet(newValue: Int, oldValue: Int, context: Context) {
-                context.watch(Dependency2Atom())
-            }
-
-            func didSet(newValue: Int, oldValue: Int, context: Context) {
-                context.watch(Dependency3Atom())
             }
         }
 
@@ -143,29 +79,5 @@ final class StateAtomTests: XCTestCase {
 
         let value2 = context.watch(TestAtom())
         XCTAssertEqual(value2, 0)
-
-        // Updated by the depenency update that is started to watch by `willSet`.
-
-        Task {
-            context[Dependency2Atom()] = 100
-        }
-
-        context[TestAtom()] = 1
-        await context.waitUntilNextUpdate()
-
-        let value3 = context.watch(TestAtom())
-        XCTAssertEqual(value3, 0)
-
-        // Updated by the depenency update that is started to watch by `didSet`.
-
-        Task {
-            context[Dependency3Atom()] = 200
-        }
-
-        context[TestAtom()] = 1
-        await context.waitUntilNextUpdate()
-
-        let value4 = context.watch(TestAtom())
-        XCTAssertEqual(value4, 0)
     }
 }

--- a/Tests/AtomsTests/Atom/StateAtomTests.swift
+++ b/Tests/AtomsTests/Atom/StateAtomTests.swift
@@ -80,4 +80,30 @@ final class StateAtomTests: XCTestCase {
         let value2 = context.watch(TestAtom())
         XCTAssertEqual(value2, 0)
     }
+
+    func testUpdated() {
+        var updatedValues = [Pair<Int>]()
+        let atom = TestStateAtom(defaultValue: 0) { new, old in
+            let values = Pair(first: new, second: old)
+            updatedValues.append(values)
+        }
+        let context = AtomTestContext()
+
+        context.watch(atom)
+
+        XCTAssertTrue(updatedValues.isEmpty)
+
+        context.set(1, for: atom)
+        context.set(2, for: atom)
+        context.set(3, for: atom)
+
+        XCTAssertEqual(
+            updatedValues,
+            [
+                Pair(first: 1, second: 0),
+                Pair(first: 2, second: 1),
+                Pair(first: 3, second: 2),
+            ]
+        )
+    }
 }

--- a/Tests/AtomsTests/Atom/TaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/TaskAtomTests.swift
@@ -141,4 +141,28 @@ final class TaskAtomTests: XCTestCase {
 
         XCTAssertEqual(dependencyValue, 0)
     }
+
+    func testUpdated() async {
+        var updatedTaskHashValues = [Int]()
+        let atom = TestTaskAtom {
+            0
+        } onUpdated: { new, _ in
+            updatedTaskHashValues.append(new.hashValue)
+        }
+        let context = AtomTestContext()
+
+        let task0 = context.watch(atom)
+
+        XCTAssertTrue(updatedTaskHashValues.isEmpty)
+
+        context.reset(atom)
+
+        let task1 = context.watch(atom)
+
+        // Ensures that the transactions are done, othewise the store context access to the store which is already released.
+        _ = await task0.value
+        _ = await task1.value
+
+        XCTAssertEqual(updatedTaskHashValues, [task1.hashValue])
+    }
 }

--- a/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
@@ -156,4 +156,28 @@ final class ThrowingTaskAtomTests: XCTestCase {
 
         XCTAssertEqual(dependencyValue, 0)
     }
+
+    func testUpdated() async {
+        var updatedTaskHashValues = [Int]()
+        let atom = TestThrowingTaskAtom {
+            .success(0)
+        } onUpdated: { new, _ in
+            updatedTaskHashValues.append(new.hashValue)
+        }
+        let context = AtomTestContext()
+
+        let task0 = context.watch(atom)
+
+        XCTAssertTrue(updatedTaskHashValues.isEmpty)
+
+        context.reset(atom)
+
+        let task1 = context.watch(atom)
+
+        // Ensures that the transactions are done, othewise the store context access to the store which is already released.
+        _ = await task0.result
+        _ = await task1.result
+
+        XCTAssertEqual(updatedTaskHashValues, [task1.hashValue])
+    }
 }

--- a/Tests/AtomsTests/Atom/ValueAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ValueAtomTests.swift
@@ -22,4 +22,21 @@ final class ValueAtomTests: XCTestCase {
             XCTAssertEqual(context.watch(atom), 1)
         }
     }
+
+    func testUpdated() async {
+        var updatedValues = [Pair<Int>]()
+        let atom = TestValueAtom(value: 0) { new, old in
+            let values = Pair(first: new, second: old)
+            updatedValues.append(values)
+        }
+        let context = AtomTestContext()
+
+        context.watch(atom)
+
+        XCTAssertTrue(updatedValues.isEmpty)
+
+        context.reset(atom)
+
+        XCTAssertEqual(updatedValues, [Pair(first: 0, second: 0)])
+    }
 }

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -52,7 +52,7 @@ final class AtomTestContextTests: XCTestCase {
 
     func testOverride() {
         let atom0 = TestValueAtom(value: 100)
-        let atom1 = TestValueAtom(value: 200)
+        let atom1 = TestStateAtom(defaultValue: 200)
         let context = AtomTestContext()
 
         XCTAssertEqual(context.read(atom0), 100)

--- a/Tests/AtomsTests/Core/AtomKeyTests.swift
+++ b/Tests/AtomsTests/Core/AtomKeyTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class AtomKeyTests: XCTestCase {
     func testKeyHashableForSameAtoms() {
-        let atom = TestValueAtom(value: 0)
+        let atom = TestAtom(value: 0)
         let key0 = AtomKey(atom)
         let key1 = AtomKey(atom)
 
@@ -15,8 +15,8 @@ final class AtomKeyTests: XCTestCase {
     }
 
     func testKeyHashableForDifferentAtoms() {
-        let atom0 = TestValueAtom(value: 0)
-        let atom1 = TestValueAtom(value: 1)
+        let atom0 = TestAtom(value: 0)
+        let atom1 = TestAtom(value: 1)
         let key0 = AtomKey(atom0)
         let key1 = AtomKey(atom1)
 
@@ -27,8 +27,8 @@ final class AtomKeyTests: XCTestCase {
     }
 
     func testDictionaryKey() {
-        let atom0 = TestValueAtom(value: 0)
-        let atom1 = TestValueAtom(value: 1)
+        let atom0 = TestAtom(value: 0)
+        let atom1 = TestAtom(value: 1)
         let key0 = AtomKey(atom0)
         let key1 = AtomKey(atom1)
         let key2 = AtomKey(atom1)

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -25,11 +25,6 @@ final class StoreContextTests: XCTestCase {
     }
 
     func testSet() {
-        struct Values<T: Equatable>: Equatable {
-            let old: T
-            let new: T
-        }
-
         let store = Store()
         let observer = TestObserver()
         let context = StoreContext(store, observers: [observer])
@@ -79,9 +74,9 @@ final class StoreContextTests: XCTestCase {
         let store = Store()
         let observer = TestObserver()
         let context = StoreContext(store, observers: [observer])
-        let atom = TestValueAtom(value: 0)
+        let atom = TestAtom(value: 0)
         let dependency0 = TestStateAtom(defaultValue: 0)
-        let dependency1 = TestValueAtom(value: 1)
+        let dependency1 = TestAtom(value: 1)
         let key = AtomKey(atom)
         let dependency0Key = AtomKey(dependency0)
         let dependency1Key = AtomKey(dependency1)

--- a/Tests/AtomsTests/Core/SubscriptionContainerTests.swift
+++ b/Tests/AtomsTests/Core/SubscriptionContainerTests.swift
@@ -11,7 +11,7 @@ final class SubscriptionContainerTests: XCTestCase {
             unsubscribedCount += 1
         }
         let atom0 = TestValueAtom(value: 0)
-        let atom1 = TestValueAtom(value: 1)
+        let atom1 = TestStateAtom(defaultValue: 0)
 
         container?.wrapper.subscriptions = [
             AtomKey(atom0): subscription,

--- a/Tests/AtomsTests/Utilities/TestAtom.swift
+++ b/Tests/AtomsTests/Utilities/TestAtom.swift
@@ -11,8 +11,6 @@ struct TestValueAtom<T: Hashable>: ValueAtom, Hashable {
 
 struct TestStateAtom<T>: StateAtom {
     var defaultValue: T
-    var willSet: ((T, T) -> Void)?
-    var didSet: ((T, T) -> Void)?
 
     var key: UniqueKey {
         UniqueKey()
@@ -20,14 +18,6 @@ struct TestStateAtom<T>: StateAtom {
 
     func defaultValue(context: Context) -> T {
         defaultValue
-    }
-
-    func willSet(newValue: T, oldValue: T, context: Context) {
-        willSet?(newValue, oldValue)
-    }
-
-    func didSet(newValue: T, oldValue: T, context: Context) {
-        didSet?(newValue, oldValue)
     }
 }
 

--- a/Tests/AtomsTests/Utilities/TestAtom.swift
+++ b/Tests/AtomsTests/Utilities/TestAtom.swift
@@ -1,7 +1,7 @@
 import Atoms
 import Combine
 
-struct TestValueAtom<T: Hashable>: ValueAtom, Hashable {
+struct TestAtom<T: Hashable>: ValueAtom, Hashable {
     var value: T
 
     func value(context: Context) -> T {
@@ -9,8 +9,26 @@ struct TestValueAtom<T: Hashable>: ValueAtom, Hashable {
     }
 }
 
+struct TestValueAtom<T>: ValueAtom {
+    var value: T
+    var onUpdated: ((T, T) -> Void)?
+
+    var key: UniqueKey {
+        UniqueKey()
+    }
+
+    func value(context: Context) -> T {
+        value
+    }
+
+    func updated(newValue: T, oldValue: T, reader: Reader) {
+        onUpdated?(newValue, oldValue)
+    }
+}
+
 struct TestStateAtom<T>: StateAtom {
     var defaultValue: T
+    var onUpdated: ((T, T) -> Void)?
 
     var key: UniqueKey {
         UniqueKey()
@@ -19,30 +37,48 @@ struct TestStateAtom<T>: StateAtom {
     func defaultValue(context: Context) -> T {
         defaultValue
     }
+
+    func updated(newValue: T, oldValue: T, reader: Reader) {
+        onUpdated?(newValue, oldValue)
+    }
 }
 
-struct TestTaskAtom<T>: TaskAtom {
+struct TestTaskAtom<T: Sendable>: TaskAtom {
     var getValue: () -> T
+    var onUpdated: ((Task<T, Never>, Task<T, Never>) -> Void)?
 
     var key: UniqueKey {
         UniqueKey()
     }
 
     init(value: T) {
-        self.getValue = { value }
+        self.init { value }
     }
 
-    init(getValue: @escaping () -> T) {
+    init(
+        getValue: @escaping () -> T,
+        onUpdated: ((Task<T, Never>, Task<T, Never>) -> Void)? = nil
+    ) {
         self.getValue = getValue
+        self.onUpdated = onUpdated
     }
 
     func value(context: Context) async -> T {
         getValue()
     }
+
+    func updated(
+        newValue: Task<T, Never>,
+        oldValue: Task<T, Never>,
+        reader: Reader
+    ) {
+        onUpdated?(newValue, oldValue)
+    }
 }
 
-struct TestThrowingTaskAtom<Success>: ThrowingTaskAtom {
+struct TestThrowingTaskAtom<Success: Sendable>: ThrowingTaskAtom {
     var getResult: () -> Result<Success, Error>
+    var onUpdated: ((Task<Success, Error>, Task<Success, Error>) -> Void)?
 
     var key: UniqueKey {
         UniqueKey()
@@ -52,17 +88,30 @@ struct TestThrowingTaskAtom<Success>: ThrowingTaskAtom {
         self.getResult = { result }
     }
 
-    init(getResult: @escaping () -> Result<Success, Error>) {
+    init(
+        getResult: @escaping () -> Result<Success, Error>,
+        onUpdated: ((Task<Success, Error>, Task<Success, Error>) -> Void)? = nil
+    ) {
         self.getResult = getResult
+        self.onUpdated = onUpdated
     }
 
     func value(context: Context) async throws -> Success {
         try getResult().get()
     }
+
+    func updated(
+        newValue: Task<Success, Error>,
+        oldValue: Task<Success, Error>,
+        reader: Reader
+    ) {
+        onUpdated?(newValue, oldValue)
+    }
 }
 
 struct TestPublisherAtom<Publisher: Combine.Publisher>: PublisherAtom {
     var makePublisher: () -> Publisher
+    var onUpdated: ((AsyncPhase<Publisher.Output, Publisher.Failure>, AsyncPhase<Publisher.Output, Publisher.Failure>) -> Void)?
 
     var key: UniqueKey {
         UniqueKey()
@@ -71,10 +120,19 @@ struct TestPublisherAtom<Publisher: Combine.Publisher>: PublisherAtom {
     func publisher(context: Context) -> Publisher {
         makePublisher()
     }
+
+    func updated(
+        newValue: AsyncPhase<Publisher.Output, Publisher.Failure>,
+        oldValue: AsyncPhase<Publisher.Output, Publisher.Failure>,
+        reader: Reader
+    ) {
+        onUpdated?(newValue, oldValue)
+    }
 }
 
 struct TestAsyncSequenceAtom<Sequence: AsyncSequence>: AsyncSequenceAtom {
     var makeSequence: () -> Sequence
+    var onUpdated: ((AsyncPhase<Sequence.Element, Error>, AsyncPhase<Sequence.Element, Error>) -> Void)?
 
     var key: UniqueKey {
         UniqueKey()
@@ -82,5 +140,13 @@ struct TestAsyncSequenceAtom<Sequence: AsyncSequence>: AsyncSequenceAtom {
 
     func sequence(context: Context) -> Sequence {
         makeSequence()
+    }
+
+    func updated(
+        newValue: AsyncPhase<Sequence.Element, Error>,
+        oldValue: AsyncPhase<Sequence.Element, Error>,
+        reader: Reader
+    ) {
+        onUpdated?(newValue, oldValue)
     }
 }

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -2,8 +2,14 @@ import Combine
 
 @testable import Atoms
 
-struct UniqueKey: Hashable {}
 final class Object {}
+
+struct UniqueKey: Hashable {}
+
+struct Pair<T: Equatable>: Equatable {
+    let first: T
+    let second: T
+}
 
 final class TestObserver: AtomObserver {
     var assignedAtomKeys = [AtomKey]()


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Issue for this PR

close #18

## Description

All atoms can now implement `updated(newValue:oldValue:reader:` method to declaratively manage side-effects when its value is updated.
The method can use other atoms but doesn't allow initiating to watch another atom for safety.
This API overwraps the usage of `StateAtom/willSet-didSet`, so they are now abolished, and it also solves a problem described in #18.

## Impact on Existing Code

These existing APIs have been abolished.

- `StateAtom/willSet(newValue:oldValue:context: Context)`
- `StateAtom/didSet(newValue:oldValue:context: Context)`
