### PR TITLE
Enable store missing assertion only for default store context

### DIFF
--- a/Sources/Atoms/Core/Environment.swift
+++ b/Sources/Atoms/Core/Environment.swift
@@ -9,6 +9,6 @@ internal extension EnvironmentValues {
 
 private struct StoreEnvironmentKey: EnvironmentKey {
     static var defaultValue: StoreContext {
-        StoreContext()
+        StoreContext(enablesAssertion: true)
     }
 }

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -6,15 +6,18 @@ internal struct StoreContext {
     private weak var weakStore: Store?
     private let overrides: Overrides?
     private let observers: [AtomObserver]
+    private let enablesAssertion: Bool
 
     nonisolated init(
         _ store: Store? = nil,
         overrides: Overrides? = nil,
-        observers: [AtomObserver] = []
+        observers: [AtomObserver] = [],
+        enablesAssertion: Bool = false
     ) {
         self.weakStore = store
         self.overrides = overrides
         self.observers = observers
+        self.enablesAssertion = enablesAssertion
     }
 
     @usableFromInline
@@ -416,7 +419,8 @@ private extension StoreContext {
             return store
         }
 
-        assertionFailure(
+        assert(
+            !enablesAssertion,
             """
             [Atoms]
             There is no store provided on the current view tree.

--- a/Tests/AtomsTests/Atom/TaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/TaskAtomTests.swift
@@ -142,7 +142,7 @@ final class TaskAtomTests: XCTestCase {
         XCTAssertEqual(dependencyValue, 0)
     }
 
-    func testUpdated() async {
+    func testUpdated() {
         var updatedTaskHashValues = [Int]()
         let atom = TestTaskAtom {
             0
@@ -151,18 +151,14 @@ final class TaskAtomTests: XCTestCase {
         }
         let context = AtomTestContext()
 
-        let task0 = context.watch(atom)
+        context.watch(atom)
 
         XCTAssertTrue(updatedTaskHashValues.isEmpty)
 
         context.reset(atom)
 
-        let task1 = context.watch(atom)
+        let task = context.watch(atom)
 
-        // Ensures that the transactions are done, othewise the store context access to the store which is already released.
-        _ = await task0.value
-        _ = await task1.value
-
-        XCTAssertEqual(updatedTaskHashValues, [task1.hashValue])
+        XCTAssertEqual(updatedTaskHashValues, [task.hashValue])
     }
 }

--- a/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
@@ -157,7 +157,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
         XCTAssertEqual(dependencyValue, 0)
     }
 
-    func testUpdated() async {
+    func testUpdated() {
         var updatedTaskHashValues = [Int]()
         let atom = TestThrowingTaskAtom {
             .success(0)
@@ -166,18 +166,14 @@ final class ThrowingTaskAtomTests: XCTestCase {
         }
         let context = AtomTestContext()
 
-        let task0 = context.watch(atom)
+        context.watch(atom)
 
         XCTAssertTrue(updatedTaskHashValues.isEmpty)
 
         context.reset(atom)
 
-        let task1 = context.watch(atom)
+        let task = context.watch(atom)
 
-        // Ensures that the transactions are done, othewise the store context access to the store which is already released.
-        _ = await task0.result
-        _ = await task1.result
-
-        XCTAssertEqual(updatedTaskHashValues, [task1.hashValue])
+        XCTAssertEqual(updatedTaskHashValues, [task.hashValue])
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Add `enablesAssertion` which is a flag to determine whether the it should assert when a store is missing.

## Motivation and Context

Unit tests could crash if some atom is updated asynchronously after AtomTestContext is released.
