### PR TITLE
refactor: Remove observe(_:) function from AtomTestContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,6 @@ A context that can simulate any scenarios in which atoms are used from a view or
 |:--|:--|
 |[unwatch(_:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/unwatch(_:))|Simulates a scenario in which the atom is no longer watched.|
 |[override(_:with:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/override(_:with:)-1ce4h)|Overwrites the output of a specific atom or all atoms of the given type with the fixed value.|
-|[observe(_:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/observe(_:))|Observes updates with a snapshot that captures a specific set of values of atoms.|
 |[onUpdate](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/onupdate)|Sets a closure that notifies there has been an update to one of the atoms.|
 
 ---

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -256,15 +256,6 @@ public struct AtomTestContext: AtomWatchableContext {
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) {
         state.overrides.insert(atomType, with: value)
     }
-
-    /// Observes updates with a snapshot that captures specific set of values of atoms.
-    ///
-    /// Use this to monitor and debugging the atoms or for producing side effects.
-    ///
-    /// - Parameter onUpdate: A closure to handle a snapshot of recent updates.
-    public func observe(_ onUpdate: @escaping @MainActor (Snapshot) -> Void) {
-        state.observers.append(Observer(onUpdate: onUpdate))
-    }
 }
 
 private extension AtomTestContext {
@@ -274,16 +265,11 @@ private extension AtomTestContext {
         private let _container = SubscriptionContainer()
 
         var overrides = Overrides()
-        var observers = [Observer]()
         let notifier = PassthroughSubject<Void, Never>()
         var onUpdate: (() -> Void)?
 
         var store: StoreContext {
-            StoreContext(
-                _store,
-                overrides: overrides,
-                observers: observers
-            )
+            StoreContext(_store, overrides: overrides)
         }
 
         var container: SubscriptionContainer.Wrapper {

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -78,30 +78,6 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom1), 300)
     }
 
-    func testObserve() {
-        let atom = TestStateAtom(defaultValue: 100)
-        var snapshots0 = [Snapshot]()
-        var snapshots1 = [Snapshot]()
-        let context = AtomTestContext()
-
-        context.observe { snapshots0.append($0) }
-        context.observe { snapshots1.append($0) }
-        context.watch(atom)
-
-        XCTAssertEqual(snapshots0.count, 1)
-        XCTAssertEqual(snapshots1.count, 1)
-
-        context[atom] = 200
-
-        XCTAssertEqual(snapshots0.count, 2)
-        XCTAssertEqual(snapshots1.count, 2)
-
-        context.unwatch(atom)
-
-        XCTAssertEqual(snapshots0.count, 3)
-        XCTAssertEqual(snapshots1.count, 3)
-    }
-
     func testTerminate() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

- Remove `AtomTestContext/observe(_:)`.

## Motivation and Context

AtomTestContext is a class for testing so nobody won't needs observability in the test context.

## Impact on Existing Code

- `AtomTestContext/observe(_:)` is abolished.
