### PR TITLE
Remove unnecessary @MainActor s

### DIFF
--- a/Sources/Atoms/AtomRelay.swift
+++ b/Sources/Atoms/AtomRelay.swift
@@ -38,7 +38,6 @@ import SwiftUI
 /// }
 /// ```
 ///
-@MainActor
 public struct AtomRelay<Content: View>: View {
     private let context: AtomViewContext?
     private var observers = [Observer]()

--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -43,7 +43,6 @@ import SwiftUI
 /// }
 /// ```
 ///
-@MainActor
 public struct AtomRoot<Content: View>: View {
     @StateObject
     private var state: State


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Allows AtomRoot and AtomRelay to be instantiated in MainActor non-isolated context.

## Motivation and Context

Currently, the above views are not allowed to be instantiated in MainActor non-isolated context because they have @\MainActor conformance at top-level, but it's sometimes inconvenient depending on an app architecture and how it is designed. That's obvious especially in the case that the app is mixed UIKit and SwiftUI.

## Impact on Existing Code

Nothing specific.
