### PR TITLE
Rename AtomRelay to AtomScope

### DIFF
--- a/Examples/Packages/iOS/Sources/ExampleTimeTravel/ExampleTimeTravel.swift
+++ b/Examples/Packages/iOS/Sources/ExampleTimeTravel/ExampleTimeTravel.swift
@@ -79,7 +79,7 @@ struct TimeTravelDebug<Content: View>: View {
     var position = 0
 
     var body: some View {
-        AtomRelay {
+        AtomScope {
             ZStack(alignment: .bottom) {
                 content()
                 slider

--- a/README.md
+++ b/README.md
@@ -1229,8 +1229,8 @@ var debugButton: some View {
 }
 ```
 
-Or, you can observe all updates of atoms and always continue to receive `Snapshots` at that point in time through `observe(_:)` modifier of [AtomRoot](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomroot) or [AtomRelay](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomrelay).  
-Note that observing in `AtomRoot` will receive all atom updates that happened in the whole app, but observing in `AtomRelay` will only receive atoms used in the descendant views.  
+Or, you can observe all updates of atoms and always continue to receive `Snapshots` at that point in time through `observe(_:)` modifier of [AtomRoot](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomroot) or [AtomScope](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomscope).  
+Note that observing in `AtomRoot` will receive all atom updates that happened in the whole app, but observing in `AtomScope` will only receive atoms used in the descendant views.  
 
 ```swift
 AtomRoot {
@@ -1447,7 +1447,7 @@ struct RootView: View {
             Text("Example View")
         }
         .sheet(isPresented: $isPresented) {
-            AtomRelay(context) {
+            AtomScope(context) {
                 MailView()
             }
         }
@@ -1458,7 +1458,7 @@ struct RootView: View {
 </details>
 
 Unfortunately, SwiftUI has a bug in iOS14 or lower where the `EnvironmentValue` is removed from a screen presented with `.sheet` just before dismissing it. Since this library is designed based on `EnvironmentValue`, this bug end up triggering the friendly `assertionFailure` that is added so that developers can easily aware of forgotten `AtomRoot` implementation.  
-As a workaround, `AtomRelay` has the ability to explicitly inherit the internal store through `AtomViewContext` from the parent view.
+As a workaround, `AtomScope` has the ability to explicitly inherit the internal store through `AtomViewContext` from the parent view.
 
 #### Some SwiftUI modifiers cause memory leak (Fixed in iOS16)
 

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -44,7 +44,7 @@ public struct AtomScope<Content: View>: View {
     @Environment(\.store)
     private var inheritedStore
 
-    /// Creates an atom relay with the specified content that will be allowed to use atoms by
+    /// Creates an new scope with the specified content that will be allowed to use atoms by
     /// passing a view context to explicitly make the descendant views inherit an internal store.
     ///
     /// - Parameters:
@@ -63,7 +63,7 @@ public struct AtomScope<Content: View>: View {
     public var body: some View {
         content.environment(
             \.store,
-            (context?._store ?? inheritedStore).relay(observers: observers)
+            (context?._store ?? inheritedStore).scoped(observers: observers)
         )
     }
 

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
-/// A view that relays an internal store from the passed view context or from environment values.
+/// A view to override or monitor atoms in scope.
 ///
 /// For some reasons, sometimes SwiftUI can fail to pass environment values in the view-tree.
 /// The typical example is that, if you use SwiftUI view inside UIKit view, it could fail as
 /// SwiftUI can't pass environment values across UIKit.
-/// In that case, you can wrap the view with ``AtomRelay`` and pass a view context to it so that
-/// the descendant views can explicitly inherit an internal store.
+/// In that case, you can wrap the view with ``AtomScope`` and pass a view context to it so that
+/// the descendant views can explicitly inherit the store.
 ///
 /// ```swift
 /// @ViewContext
@@ -14,21 +14,19 @@ import SwiftUI
 ///
 /// var body: some View {
 ///     MyUIViewWrappingView {
-///         AtomRelay(context) {
+///         AtomScope(context) {
 ///             MySwiftUIView()
 ///         }
 ///     }
 /// }
 /// ```
 ///
-/// Also, ``AtomRelay`` can be created without passing a view context, and in this case, it relays
-/// an internal store from environment values.
-/// Relaying from environment values means that does actually nothing and just inherits an internal
-/// store from ``AtomRoot`` as same as usual views, but ``AtomRelay`` provides the modifier
-/// ``AtomRelay/observe(_:)`` to monitor all changes in atoms used in descendant views.
+/// ``AtomScope`` can be created without passing a view context, and in this case, it inherits
+/// from an internal store through environment values from ``AtomRoot.
+/// It allows you to monitor changes of atoms used in descendant views by``AtomScope/observe(_:)``.
 ///
 /// ```swift
-/// AtomRelay {
+/// AtomScope {
 ///     MyView()
 /// }
 /// .observe { snapshot in
@@ -38,7 +36,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-public struct AtomRelay<Content: View>: View {
+public struct AtomScope<Content: View>: View {
     private let context: AtomViewContext?
     private var observers = [Observer]()
     private let content: Content
@@ -81,7 +79,7 @@ public struct AtomRelay<Content: View>: View {
     }
 }
 
-private extension AtomRelay {
+private extension AtomScope {
     func `mutating`(_ mutation: (inout Self) -> Void) -> Self {
         var view = self
         mutation(&view)

--- a/Sources/Atoms/Atoms.docc/Atoms.md
+++ b/Sources/Atoms/Atoms.docc/Atoms.md
@@ -42,7 +42,7 @@ SwiftUI Atom Properties offers practical capabilities to manage the complexity o
 ### Views
 
 - ``AtomRoot``
-- ``AtomRelay``
+- ``AtomScope``
 - ``Suspense``
 
 ### Values

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -167,7 +167,7 @@ internal struct StoreContext {
     }
 
     @usableFromInline
-    func relay(observers: [Observer]) -> Self {
+    func scoped(observers: [Observer]) -> Self {
         Self(
             weakStore,
             overrides: overrides,

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -493,7 +493,7 @@ private extension StoreContext {
             ```
 
             If for some reason the view tree is formed that does not inherit from `EnvironmentValues`,
-            consider using `AtomRelay` to pass it.
+            consider using `AtomScope` to pass it.
             That happens when using SwiftUI view wrapped with `UIHostingController`.
 
             ```
@@ -503,7 +503,7 @@ private extension StoreContext {
 
                 var body: some View {
                     UIViewWrappingView {
-                        AtomRelay(context) {
+                        AtomScope(context) {
                             WrappedView()
                         }
                     }
@@ -513,11 +513,11 @@ private extension StoreContext {
 
             The modal screen presented by the `.sheet` modifier or etc, inherits from the environment values,
             but only in iOS14, there is a bug where the environment values will be dismantled during it is
-            dismissing. This also can be avoided by using `AtomRelay` to explicitly inherit from it.
+            dismissing. This also can be avoided by using `AtomScope` to explicitly inherit from it.
 
             ```
             .sheet(isPresented: ...) {
-                AtomRelay(context) {
+                AtomScope(context) {
                     ExampleView()
                 }
             }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -237,7 +237,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertTrue(store.state.caches.isEmpty)
     }
 
-    func testRelay() {
+    func testScoped() {
         let store = Store()
         let container = SubscriptionContainer()
         let atom = TestValueAtom(value: 0)
@@ -246,9 +246,9 @@ final class StoreContextTests: XCTestCase {
         let observer0 = Observer { snapshots0.append($0) }
         let observer1 = Observer { snapshots1.append($0) }
         let context = StoreContext(store, observers: [observer0])
-        let relayedContext = context.relay(observers: [observer1])
+        let scopedContext = context.scoped(observers: [observer1])
 
-        _ = relayedContext.watch(atom, container: container.wrapper) {}
+        _ = scopedContext.watch(atom, container: container.wrapper) {}
 
         XCTAssertFalse(snapshots0.isEmpty)
         XCTAssertFalse(snapshots1.isEmpty)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Renames `AtomRelay` to `AtomScope` to make the name more appropriate for the new atom override API which will be supported soon.
