### PR TITLE
Fix snapshots to be taken when the atom is marked as KeepAlive

### DIFF
--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -79,6 +79,7 @@ internal struct StoreContext {
 
             // Unsubscribe and release if it's no longer used.
             store.state.subscriptions[key]?.removeValue(forKey: container.key)
+            notifyUpdateToObservers()
             checkRelease(for: key)
         }
 

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -302,7 +302,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(
             snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
             [
-                [key0: AtomCache(atom: atom0, value: 0)]
+                [key0: AtomCache(atom: atom0, value: 0)] // Brand new value
             ]
         )
 
@@ -313,12 +313,12 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(
             snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
             [
-                [key0: AtomCache(atom: atom0, value: 0)],
-                [key0: AtomCache(atom: atom0, value: 0)],
+                [key0: AtomCache(atom: atom0, value: 0)], // Brand new value
+                [key0: AtomCache(atom: atom0, value: 0)], // Reset
             ]
         )
 
-        // Release.
+        // Unsubscribe and release.
 
         for subscription in container.wrapper.subscriptions.values {
             subscription.unsubscribe()
@@ -327,9 +327,10 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(
             snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
             [
-                [key0: AtomCache(atom: atom0, value: 0)],
-                [key0: AtomCache(atom: atom0, value: 0)],
-                [:],
+                [key0: AtomCache(atom: atom0, value: 0)], // Brand new value
+                [key0: AtomCache(atom: atom0, value: 0)], // Reset
+                [key0: AtomCache(atom: atom0, value: 0)], // Unsubscribed
+                [:],                                      // Released
             ]
         )
 

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -302,7 +302,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(
             snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
             [
-                [key0: AtomCache(atom: atom0, value: 0)] // Brand new value
+                [key0: AtomCache(atom: atom0, value: 0)]  // Brand new value
             ]
         )
 
@@ -313,8 +313,8 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(
             snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
             [
-                [key0: AtomCache(atom: atom0, value: 0)], // Brand new value
-                [key0: AtomCache(atom: atom0, value: 0)], // Reset
+                [key0: AtomCache(atom: atom0, value: 0)],  // Brand new value
+                [key0: AtomCache(atom: atom0, value: 0)],  // Reset
             ]
         )
 
@@ -327,10 +327,10 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(
             snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
             [
-                [key0: AtomCache(atom: atom0, value: 0)], // Brand new value
-                [key0: AtomCache(atom: atom0, value: 0)], // Reset
-                [key0: AtomCache(atom: atom0, value: 0)], // Unsubscribed
-                [:],                                      // Released
+                [key0: AtomCache(atom: atom0, value: 0)],  // Brand new value
+                [key0: AtomCache(atom: atom0, value: 0)],  // Reset
+                [key0: AtomCache(atom: atom0, value: 0)],  // Unsubscribed
+                [:],  // Released
             ]
         )
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

A snapshot wasn't taken when it's unsubscribed in case the target atom is marked as KeepAlive.
