### PR TITLE
Rename AtomTextContext/waitUntilNextUpdate to waitForUpdate

### DIFF
--- a/Examples/Packages/iOS/Tests/ExampleMapTests/ExampleMapTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMapTests/ExampleMapTests.swift
@@ -60,12 +60,12 @@ final class ExampleMapTests: XCTestCase {
             observer.objectWillChange.send()
         }
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(context.watch(atom), .authorizedAlways)
 
         observer.objectWillChange.send()
-        let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+        let didUpdate = await context.waitForUpdate(timeout: 1)
 
         // Should not update if authorizationStatus is not changed.
         XCTAssertFalse(didUpdate)

--- a/Examples/Packages/iOS/Tests/ExampleVoiceMemoTests/ExampleVoiceMemoTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleVoiceMemoTests/ExampleVoiceMemoTests.swift
@@ -65,7 +65,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
 
         XCTAssertEqual(context.watch(atom), .suspending)
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(context.watch(atom), .success(.zero))
 
@@ -74,7 +74,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
 
         XCTAssertEqual(context.watch(atom), .suspending)
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(context.watch(atom), .success(10))
     }
@@ -178,7 +178,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
 
         XCTAssertEqual(context.watch(atom), .suspending)
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(context.watch(atom), .success(.zero))
 
@@ -187,7 +187,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
 
         XCTAssertEqual(context.watch(atom), .suspending)
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(context.watch(atom), .success(10))
     }

--- a/README.md
+++ b/README.md
@@ -1109,7 +1109,7 @@ A context that can simulate any scenarios in which atoms are used from a view or
 |:--|:--|
 |[unwatch(_:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/unwatch(_:))|Simulates a scenario in which the atom is no longer watched.|
 |[override(_:with:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/override(_:with:)-1ce4h)|Overwrites the output of a specific atom or all atoms of the given type with the fixed value.|
-|[waitUntilNextUpdate(timeout:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/waituntilnextupdate(timeout:))|Waits until any of atoms watched through this context is updated.|
+|[waitForUpdate(timeout:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/waitforupdate(timeout:))|Waits until any of atoms watched through this context is updated.|
 |[onUpdate](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/onupdate)|Sets a closure that notifies there has been an update to one of the atoms.|
 
 ---

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -33,7 +33,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
     ///     XCTAssertEqual(initialPhase, .suspending)
     ///
-    ///     let didUpdate = await context.waitUntilNextUpdate()
+    ///     let didUpdate = await context.waitForUpdate()
     ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
     ///
     ///     XCTAssertTure(didUpdate)
@@ -45,7 +45,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///                      the next update. The default timeout interval is `60`.
     /// - Returns: A boolean value indicating whether an update is done.
     @discardableResult
-    public func waitUntilNextUpdate(timeout interval: TimeInterval = 60) async -> Bool {
+    public func waitForUpdate(timeout interval: TimeInterval = 60) async -> Bool {
         let updates = AsyncStream<Void> { continuation in
             let cancellable = state.notifier.sink(
                 receiveCompletion: { completion in

--- a/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
@@ -16,7 +16,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         do {
             // Value
             pipe.continuation.yield(0)
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
 
             XCTAssertEqual(context.watch(atom).value, 0)
         }
@@ -24,7 +24,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         do {
             // Failure
             pipe.continuation.finish(throwing: URLError(.badURL))
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
 
             XCTAssertEqual(context.watch(atom).error as? URLError, URLError(.badURL))
         }
@@ -32,7 +32,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         do {
             // Yield value after finish
             pipe.continuation.yield(1)
-            let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+            let didUpdate = await context.waitForUpdate(timeout: 1)
 
             XCTAssertFalse(didUpdate)
         }
@@ -43,7 +43,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             context.unwatch(atom)
 
             pipe.continuation.yield(0)
-            let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+            let didUpdate = await context.waitForUpdate(timeout: 1)
 
             XCTAssertFalse(didUpdate)
         }
@@ -54,7 +54,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             context.unwatch(atom)
 
             pipe.continuation.finish(throwing: URLError(.badURL))
-            let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+            let didUpdate = await context.waitForUpdate(timeout: 1)
 
             XCTAssertFalse(didUpdate)
         }
@@ -144,13 +144,13 @@ final class AsyncSequenceAtomTests: XCTestCase {
         XCTAssertTrue(updatedValues.isEmpty)
 
         pipe.continuation.yield(0)
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         pipe.continuation.yield(1)
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         pipe.continuation.yield(2)
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(
             updatedValues,

--- a/Tests/AtomsTests/Atom/ModifiedAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ModifiedAtomTests.swift
@@ -34,7 +34,7 @@ final class ModifiedAtomTests: XCTestCase {
                 context[base] = "testtest"
             }
 
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
             XCTAssertEqual(context.watch(atom), 8)
         }
 

--- a/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
@@ -51,7 +51,7 @@ final class ObservableObjectAtomTests: XCTestCase {
             }
 
             object.update()
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
 
             XCTAssertEqual(snapshot, 1)
         }
@@ -68,7 +68,7 @@ final class ObservableObjectAtomTests: XCTestCase {
             }
 
             object.update()
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
 
             XCTAssertEqual(updateCount, 1)
         }
@@ -86,7 +86,7 @@ final class ObservableObjectAtomTests: XCTestCase {
                 updateCount = object.updatedCount
             }
             object.update()
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
 
             XCTAssertTrue(object === overrideObject)
             XCTAssertEqual(updateCount, 1)
@@ -105,7 +105,7 @@ final class ObservableObjectAtomTests: XCTestCase {
                 updateCount = object.updatedCount
             }
             object.update()
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
 
             XCTAssertTrue(object === overrideObject)
             XCTAssertEqual(updateCount, 1)
@@ -123,7 +123,7 @@ final class ObservableObjectAtomTests: XCTestCase {
         XCTAssertTrue(updatedObjects.isEmpty)
         object.update()
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(updatedObjects.last?.updatedCount, 1)
     }

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -20,7 +20,7 @@ final class PublisherAtomTests: XCTestCase {
             // Value
             subject.send(0)
 
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
             XCTAssertEqual(context.watch(atom), .success(0))
         }
 
@@ -28,7 +28,7 @@ final class PublisherAtomTests: XCTestCase {
             // Error
             subject.send(completion: .failure(URLError(.badURL)))
 
-            await context.waitUntilNextUpdate()
+            await context.waitForUpdate()
             XCTAssertEqual(context.watch(atom), .failure(URLError(.badURL)))
         }
 
@@ -36,7 +36,7 @@ final class PublisherAtomTests: XCTestCase {
             // Send value after completion
             subject.send(1)
 
-            let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+            let didUpdate = await context.waitForUpdate(timeout: 1)
             XCTAssertFalse(didUpdate)
         }
 
@@ -45,7 +45,7 @@ final class PublisherAtomTests: XCTestCase {
             context.unwatch(atom)
             subject.send(0)
 
-            let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+            let didUpdate = await context.waitForUpdate(timeout: 1)
             XCTAssertFalse(didUpdate)
         }
 
@@ -54,7 +54,7 @@ final class PublisherAtomTests: XCTestCase {
             context.unwatch(atom)
             subject.send(completion: .failure(URLError(.badURL)))
 
-            let didUpdate = await context.waitUntilNextUpdate(timeout: 1)
+            let didUpdate = await context.waitForUpdate(timeout: 1)
             XCTAssertFalse(didUpdate)
         }
 
@@ -143,13 +143,13 @@ final class PublisherAtomTests: XCTestCase {
         XCTAssertTrue(updatedValues.isEmpty)
 
         subject.send(0)
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         subject.send(1)
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         subject.send(2)
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         XCTAssertEqual(
             updatedValues,

--- a/Tests/AtomsTests/Atom/StateAtomTests.swift
+++ b/Tests/AtomsTests/Atom/StateAtomTests.swift
@@ -75,7 +75,7 @@ final class StateAtomTests: XCTestCase {
             context[Dependency1Atom()] = 0
         }
 
-        await context.waitUntilNextUpdate()
+        await context.waitForUpdate()
 
         let value2 = context.watch(TestAtom())
         XCTAssertEqual(value2, 0)

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -31,7 +31,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertTrue(isCalled)
     }
 
-    func testWaitUntilNextUpdate() async {
+    func testWaitForUpdate() async {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
@@ -41,11 +41,11 @@ final class AtomTestContextTests: XCTestCase {
             context[atom] = 1
         }
 
-        let didUpdate0 = await context.waitUntilNextUpdate()
+        let didUpdate0 = await context.waitForUpdate()
 
         XCTAssertTrue(didUpdate0)
 
-        let didUpdate1 = await context.waitUntilNextUpdate(timeout: 1)
+        let didUpdate1 = await context.waitForUpdate(timeout: 1)
 
         XCTAssertFalse(didUpdate1)
     }

--- a/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
@@ -11,7 +11,7 @@ final class TaskPhaseModifierTests: XCTestCase {
 
         XCTAssertEqual(context.watch(atom.phase), .suspending)
 
-        await context.waitUntilNextUpdate(timeout: 1)
+        await context.waitForUpdate(timeout: 1)
 
         XCTAssertEqual(context.watch(atom.phase), .success(0))
     }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Renaming the `AtomTestContext/waitUntilNextUpdate(timeout:)` to `waitForUpdate(timeout:)` to mitigate its feeling of redundancy. 

## Impact on Existing Code

[Breaking change] Need to migrate the existing use of `AtomTestContext/waitUntilNextUpdate(timeout:)` to `AtomTestContext/waitForUpdate(timeout:)`.
