### PR TITLE
Flatten scoped stores

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -79,7 +79,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
+        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value) }
     }
 
     /// Overrides the atom value with the given value.
@@ -95,7 +95,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
+        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value) }
     }
 
     /// For debugging purposes, each time there is a change in the internal state,
@@ -114,6 +114,7 @@ private extension AtomRoot {
     @MainActor
     final class State: ObservableObject {
         let store = AtomStore()
+        let token = ScopeKey.Token()
     }
 
     func `mutating`(_ mutation: (inout Self) -> Void) -> Self {

--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -60,12 +60,24 @@ public struct AtomRoot<Content: View>: View {
     public var body: some View {
         content.environment(
             \.store,
-            StoreContext(
+            .scoped(
                 state.store,
-                overrides: overrides,
-                observers: observers
+                scopeKey: ScopeKey(token: state.token),
+                observers: observers,
+                overrides: overrides
             )
         )
+    }
+
+    /// For debugging purposes, each time there is a change in the internal state,
+    /// a snapshot is taken that captures the state of the atoms and their dependency graph
+    /// at that point in time.
+    ///
+    /// - Parameter onUpdate: A closure to handle a snapshot of recent updates.
+    ///
+    /// - Returns: The self instance.
+    public func observe(_ onUpdate: @escaping @MainActor (Snapshot) -> Void) -> Self {
+        mutating { $0.observers.append(Observer(onUpdate: onUpdate)) }
     }
 
     /// Overrides the atom value with the given value.
@@ -79,7 +91,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value) }
+        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
     }
 
     /// Overrides the atom value with the given value.
@@ -95,18 +107,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value) }
-    }
-
-    /// For debugging purposes, each time there is a change in the internal state,
-    /// a snapshot is taken that captures the state of the atoms and their dependency graph
-    /// at that point in time.
-    ///
-    /// - Parameter onUpdate: A closure to handle a snapshot of recent updates.
-    ///
-    /// - Returns: The self instance.
-    public func observe(_ onUpdate: @escaping @MainActor (Snapshot) -> Void) -> Self {
-        mutating { $0.observers.append(Observer(onUpdate: onUpdate)) }
+        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
     }
 }
 

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -101,7 +101,6 @@ public struct AtomScope<Content: View>: View {
         content.environment(
             \.store,
             (store ?? environmentStore).scoped(
-                store: state.store,
                 overrides: overrides,
                 observers: observers
             )
@@ -121,7 +120,7 @@ public struct AtomScope<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
+        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value) }
     }
 
     /// Override the atom value used in this scope with the given value.
@@ -139,7 +138,7 @@ public struct AtomScope<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
+        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value) }
     }
 
     /// For debugging purposes, each time there is a change in the internal state,
@@ -160,7 +159,7 @@ public struct AtomScope<Content: View>: View {
 private extension AtomScope {
     @MainActor
     final class State: ObservableObject {
-        let store = AtomStore()
+        let token = ScopeKey.Token()
     }
 
     func `mutating`(_ mutation: (inout Self) -> Void) -> Self {

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -263,7 +263,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///   - atom: An atom that to be overridden.
     ///   - value: A value that to be used instead of the atom's value.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) {
-        state.overrides[OverrideKey(atom)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value)
+        state.overrides[OverrideKey(atom)] = AtomOverride(value: value)
     }
 
     /// Overrides the atom value with the given value.
@@ -277,7 +277,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///   - atomType: An atom type that to be overridden.
     ///   - value: A value that to be used instead of the atom's value.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) {
-        state.overrides[OverrideKey(atomType)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value)
+        state.overrides[OverrideKey(atomType)] = AtomOverride(value: value)
     }
 }
 
@@ -297,7 +297,12 @@ private extension AtomTestContext {
     }
 
     var store: StoreContext {
-        StoreContext(state.store, overrides: state.overrides)
+        .scoped(
+            state.store,
+            scopeKey: ScopeKey(token: state.token),
+            observers: [],
+            overrides: state.overrides
+        )
     }
 
     var container: SubscriptionContainer.Wrapper {

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -250,9 +250,8 @@ public struct AtomTestContext: AtomWatchableContext {
     /// It simulates cases where other atoms or views no longer watches to the atom.
     ///
     /// - Parameter atom: An atom that associates the value.
-    public func unwatch<Node: Atom>(_ atom: Node) {
-        let key = AtomKey(atom)
-        container.subscriptions.removeValue(forKey: key)?.unsubscribe()
+    public func unwatch(_ atom: some Atom) {
+        store.unwatch(atom, container: container)
     }
 
     /// Overrides the atom value with the given value.
@@ -264,7 +263,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///   - atom: An atom that to be overridden.
     ///   - value: A value that to be used instead of the atom's value.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) {
-        state.overrides[OverrideKey(atom)] = AtomOverride(value: value)
+        state.overrides[OverrideKey(atom)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value)
     }
 
     /// Overrides the atom value with the given value.
@@ -278,13 +277,14 @@ public struct AtomTestContext: AtomWatchableContext {
     ///   - atomType: An atom type that to be overridden.
     ///   - value: A value that to be used instead of the atom's value.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) {
-        state.overrides[OverrideKey(atomType)] = AtomOverride(value: value)
+        state.overrides[OverrideKey(atomType)] = AtomOverride(scopeKey: ScopeKey(token: state.token), value: value)
     }
 }
 
 private extension AtomTestContext {
     final class State {
         let store = AtomStore()
+        let token = ScopeKey.Token()
         let container = SubscriptionContainer()
         let notifier = PassthroughSubject<Void, Never>()
         var overrides = [OverrideKey: any AtomOverrideProtocol]()

--- a/Sources/Atoms/Core/AtomKey.swift
+++ b/Sources/Atoms/Core/AtomKey.swift
@@ -1,11 +1,18 @@
-internal struct AtomKey: Hashable {
+internal struct AtomKey: Hashable, CustomStringConvertible {
     private let key: AnyHashable
     private let type: ObjectIdentifier
     private let overrideScopeKey: ScopeKey?
     private let getName: () -> String
 
-    var name: String {
-        getName()
+    var description: String {
+        if let overrideScopeKey {
+            let name = getName()
+            let id = String(overrideScopeKey.hashValue, radix: 36, uppercase: false)
+            return name + "-override:\(id)"
+        }
+        else {
+            return getName()
+        }
     }
 
     init<Node: Atom>(_ atom: Node, overrideScopeKey: ScopeKey?) {

--- a/Sources/Atoms/Core/AtomKey.swift
+++ b/Sources/Atoms/Core/AtomKey.swift
@@ -4,6 +4,10 @@ internal struct AtomKey: Hashable, CustomStringConvertible {
     private let overrideScopeKey: ScopeKey?
     private let getName: () -> String
 
+    var isOverridden: Bool {
+        overrideScopeKey != nil
+    }
+
     var description: String {
         if let overrideScopeKey {
             let name = getName()

--- a/Sources/Atoms/Core/AtomKey.swift
+++ b/Sources/Atoms/Core/AtomKey.swift
@@ -1,24 +1,27 @@
 internal struct AtomKey: Hashable {
     private let key: AnyHashable
     private let type: ObjectIdentifier
+    private let overrideScopeKey: ScopeKey?
     private let getName: () -> String
 
     var name: String {
         getName()
     }
 
-    init<Node: Atom>(_ atom: Node) {
-        key = AnyHashable(atom.key)
-        type = ObjectIdentifier(Node.self)
-        getName = { String(describing: Node.self) }
+    init<Node: Atom>(_ atom: Node, overrideScopeKey: ScopeKey?) {
+        self.key = AnyHashable(atom.key)
+        self.type = ObjectIdentifier(Node.self)
+        self.overrideScopeKey = overrideScopeKey
+        self.getName = { String(describing: Node.self) }
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(key)
         hasher.combine(type)
+        hasher.combine(overrideScopeKey)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.key == rhs.key && lhs.type == rhs.type
+        lhs.key == rhs.key && lhs.type == rhs.type && lhs.overrideScopeKey == rhs.overrideScopeKey
     }
 }

--- a/Sources/Atoms/Core/AtomKey.swift
+++ b/Sources/Atoms/Core/AtomKey.swift
@@ -10,9 +10,7 @@ internal struct AtomKey: Hashable, CustomStringConvertible {
 
     var description: String {
         if let overrideScopeKey {
-            let name = getName()
-            let id = String(overrideScopeKey.hashValue, radix: 36, uppercase: false)
-            return name + "-override:\(id)"
+            return getName() + "-override:\(overrideScopeKey.id)"
         }
         else {
             return getName()

--- a/Sources/Atoms/Core/AtomOverride.swift
+++ b/Sources/Atoms/Core/AtomOverride.swift
@@ -1,12 +1,30 @@
-@MainActor
 internal protocol AtomOverrideProtocol {
     associatedtype Node: Atom
 
-    var scopeKey: ScopeKey { get }
     var value: (Node) -> Node.Loader.Value { get }
+
+    func scoped(key: ScopeKey) -> any AtomScopedOverrideProtocol
 }
 
 internal struct AtomOverride<Node: Atom>: AtomOverrideProtocol {
+    let value: (Node) -> Node.Loader.Value
+
+    func scoped(key: ScopeKey) -> any AtomScopedOverrideProtocol {
+        AtomScopedOverride<Node>(scopeKey: key, value: value)
+    }
+}
+
+/// As a workaround to the problem of not getting ScopeKey synchronously
+/// when the AtomRoot or AtomScope's override modifier is called, those modifiers
+/// temporarily register AtomOverride and convert them to AtomScopedOverride when
+/// their View body is evaluated. This is not ideal from a performance standpoint,
+/// so it will be improved as soon as an alternative way to grant per-scope keys
+/// independent of the SwiftUI lifecycle is came up.
+internal protocol AtomScopedOverrideProtocol {
+    var scopeKey: ScopeKey { get }
+}
+
+internal struct AtomScopedOverride<Node: Atom>: AtomScopedOverrideProtocol {
     let scopeKey: ScopeKey
     let value: (Node) -> Node.Loader.Value
 }

--- a/Sources/Atoms/Core/AtomOverride.swift
+++ b/Sources/Atoms/Core/AtomOverride.swift
@@ -2,9 +2,11 @@
 internal protocol AtomOverrideProtocol {
     associatedtype Node: Atom
 
+    var scopeKey: ScopeKey { get }
     var value: (Node) -> Node.Loader.Value { get }
 }
 
 internal struct AtomOverride<Node: Atom>: AtomOverrideProtocol {
+    let scopeKey: ScopeKey
     let value: (Node) -> Node.Loader.Value
 }

--- a/Sources/Atoms/Core/AtomOverride.swift
+++ b/Sources/Atoms/Core/AtomOverride.swift
@@ -14,12 +14,12 @@ internal struct AtomOverride<Node: Atom>: AtomOverrideProtocol {
     }
 }
 
-/// As a workaround to the problem of not getting ScopeKey synchronously
-/// when the AtomRoot or AtomScope's override modifier is called, those modifiers
-/// temporarily register AtomOverride and convert them to AtomScopedOverride when
-/// their View body is evaluated. This is not ideal from a performance standpoint,
-/// so it will be improved as soon as an alternative way to grant per-scope keys
-/// independent of the SwiftUI lifecycle is came up.
+// As a workaround to the problem of not getting ScopeKey synchronously
+// when the AtomRoot or AtomScope's override modifier is called, those modifiers
+// temporarily register AtomOverride and convert them to AtomScopedOverride when
+// their View body is evaluated. This is not ideal from a performance standpoint,
+// so it will be improved as soon as an alternative way to grant per-scope keys
+// independent of the SwiftUI lifecycle is came up.
 internal protocol AtomScopedOverrideProtocol {
     var scopeKey: ScopeKey { get }
 }

--- a/Sources/Atoms/Core/ScopeKey.swift
+++ b/Sources/Atoms/Core/ScopeKey.swift
@@ -3,6 +3,10 @@ internal struct ScopeKey: Hashable {
 
     private let identifier: ObjectIdentifier
 
+    var id: String {
+        String(hashValue, radix: 36, uppercase: false)
+    }
+
     init(token: Token) {
         identifier = ObjectIdentifier(token)
     }

--- a/Sources/Atoms/Core/ScopeKey.swift
+++ b/Sources/Atoms/Core/ScopeKey.swift
@@ -1,0 +1,9 @@
+internal struct ScopeKey: Hashable {
+    final class Token {}
+
+    private let identifier: ObjectIdentifier
+
+    init(token: Token) {
+        identifier = ObjectIdentifier(token)
+    }
+}

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -387,10 +387,10 @@ private extension StoreContext {
         let store = getStore()
 
         // The condition under which an atom may be released are as follows:
-        //     1. It's not marked as `KeepAlive`.
+        //     1. It's not marked as `KeepAlive` or is overridden.
         //     2. It has no downstream atoms.
         //     3. It has no subscriptions from views.
-        let shouldKeepAlive = store.state.caches[key].map { $0.atom is any KeepAlive } ?? false
+        let shouldKeepAlive = !key.isOverridden && store.state.caches[key].map { $0.atom is any KeepAlive } ?? false
         let isChildrenEmpty = store.graph.children[key]?.isEmpty ?? true
         let isSubscriptionEmpty = store.state.subscriptions[key]?.isEmpty ?? true
         let shouldRelease = !shouldKeepAlive && isChildrenEmpty && isSubscriptionEmpty

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -3,8 +3,10 @@ import Foundation
 @usableFromInline
 @MainActor
 internal struct StoreContext {
-    private let current: Scope
+    private(set) weak var weakStore: AtomStore?
+    private let overrides: [OverrideKey: any AtomOverrideProtocol]
     private let observers: [Observer]
+    private let enablesAssertion: Bool
 
     nonisolated init(
         _ store: AtomStore? = nil,
@@ -12,43 +14,73 @@ internal struct StoreContext {
         observers: [Observer] = [],
         enablesAssertion: Bool = false
     ) {
-        self.init(
-            current: Scope(
-                store: store,
-                overrides: overrides,
-                parent: nil,
-                enablesAssertion: enablesAssertion
-            ),
-            observers: observers
-        )
-    }
-
-    nonisolated private init(
-        current: Scope,
-        observers: [Observer] = []
-    ) {
-        self.current = current
+        self.weakStore = store
+        self.overrides = overrides
         self.observers = observers
+        self.enablesAssertion = enablesAssertion
     }
 
     @usableFromInline
     func read<Node: Atom>(_ atom: Node) -> Node.Loader.Value {
-        read(atom, scope: current)
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+
+        if let cache = lookupCache(of: atom, for: key) {
+            return cache.value
+        }
+        else {
+            let cache = makeNewCache(of: atom, for: key, override: override)
+            notifyUpdateToObservers()
+            checkRelease(for: key)
+            return cache.value
+        }
     }
 
     @usableFromInline
     func set<Node: StateAtom>(_ value: Node.Loader.Value, for atom: Node) {
-        set(value, for: atom, scope: current)
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+
+        if let cache = lookupCache(of: atom, for: key) {
+            update(atom: atom, for: key, value: value, cache: cache)
+            checkRelease(for: key)
+        }
     }
 
     @usableFromInline
     func modify<Node: StateAtom>(_ atom: Node, body: (inout Node.Loader.Value) -> Void) {
-        modify(atom, scope: current, body: body)
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+
+        if let cache = lookupCache(of: atom, for: key) {
+            var value = cache.value
+            body(&value)
+            update(atom: atom, for: key, value: value, cache: cache)
+            checkRelease(for: key)
+        }
     }
 
     @usableFromInline
     func watch<Node: Atom>(_ atom: Node, in transaction: Transaction) -> Node.Loader.Value {
-        watch(atom, in: transaction, scope: current)
+        guard !transaction.isTerminated else {
+            return read(atom)
+        }
+
+        let store = getStore()
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+        let cache = lookupCache(of: atom, for: key)
+        let newCache = cache ?? makeNewCache(of: atom, for: key, override: override)
+        let isInserted = store.graph.children[key, default: []].insert(transaction.key).inserted
+
+        // Add an `Edge` from the upstream to downstream.
+        store.graph.dependencies[transaction.key, default: []].insert(key)
+
+        if isInserted || cache == nil {
+            notifyUpdateToObservers()
+        }
+
+        return newCache.value
     }
 
     @usableFromInline
@@ -57,207 +89,38 @@ internal struct StoreContext {
         container: SubscriptionContainer.Wrapper,
         notifyUpdate: @escaping () -> Void
     ) -> Node.Loader.Value {
-        watch(atom, container: container, notifyUpdate: notifyUpdate, scope: current)
-    }
-
-    @usableFromInline
-    func refresh<Node: Atom>(_ atom: Node) async -> Node.Loader.Value where Node.Loader: RefreshableAtomLoader {
-        await refresh(atom, scope: current)
-    }
-
-    @usableFromInline
-    func reset(_ atom: some Atom) {
-        reset(atom, scope: current)
-    }
-
-    @usableFromInline
-    func snapshot() -> Snapshot {
-        snapshot(scope: current)
-    }
-
-    func scoped(
-        store: AtomStore,
-        overrides: [OverrideKey: any AtomOverrideProtocol],
-        observers: [Observer]
-    ) -> Self {
-        Self(
-            current: Scope(
-                store: store,
-                overrides: overrides,
-                parent: current,
-                enablesAssertion: current.enablesAssertion
-            ),
-            observers: self.observers + observers
-        )
-    }
-}
-
-private extension StoreContext {
-    func read<Node: Atom>(_ atom: Node, scope: Scope) -> Node.Loader.Value {
-        let key = AtomKey(atom)
-        let override: AtomOverride<Node>?
-
-        if let cache = peekCache(of: atom, for: key, scope: scope) {
-            return cache.value
-        }
-        else if let _override = peekOverride(of: atom, scope: scope) {
-            override = _override
-        }
-        else if let parent = scope.parent {
-            return read(atom, scope: parent)
-        }
-        else {
-            override = nil
-        }
-
-        let cache = makeNewCache(of: atom, for: key, override: override, scope: scope)
-        notifyUpdateToObservers(scope: scope)
-        checkRelease(for: key, scope: scope)
-        return cache.value
-    }
-
-    func set<Node: StateAtom>(_ value: Node.Loader.Value, for atom: Node, scope: Scope) {
-        let key = AtomKey(atom)
-
-        if let cache = peekCache(of: atom, for: key, scope: scope) {
-            update(atom: atom, for: key, value: value, cache: cache, scope: scope)
-            checkRelease(for: key, scope: scope)
-        }
-        else if isOverridden(atom, scope: scope) {
-            // Do nothing if the atom is overridden.
-            return
-        }
-        else if let parent = scope.parent {
-            return set(value, for: atom, scope: parent)
-        }
-    }
-
-    func modify<Node: StateAtom>(_ atom: Node, scope: Scope, body: (inout Node.Loader.Value) -> Void) {
-        let key = AtomKey(atom)
-
-        if let cache = peekCache(of: atom, for: key, scope: scope) {
-            var value = cache.value
-            body(&value)
-            update(atom: atom, for: key, value: value, cache: cache, scope: scope)
-            checkRelease(for: key, scope: scope)
-        }
-        else if isOverridden(atom, scope: scope) {
-            // Do nothing if the atom is overridden.
-            return
-        }
-        else if let parent = scope.parent {
-            return modify(atom, scope: parent, body: body)
-        }
-    }
-
-    func watch<Node: Atom>(_ atom: Node, in transaction: Transaction, scope: Scope) -> Node.Loader.Value {
-        guard !transaction.isTerminated else {
-            return read(atom)
-        }
-
-        let key = AtomKey(atom)
-        let cache: AtomCache<Node>?
-        let override: AtomOverride<Node>?
-
-        if let oldCache = peekCache(of: atom, for: key, scope: scope) {
-            cache = oldCache
-            override = nil
-        }
-        else if let _override = peekOverride(of: atom, scope: scope) {
-            cache = nil
-            override = _override
-        }
-        else if let parent = scope.parent {
-            return watch(atom, in: transaction, scope: parent)
-        }
-        else {
-            cache = nil
-            override = nil
-        }
-
-        let newCache = cache ?? makeNewCache(of: atom, for: key, override: override, scope: scope)
-        let isInserted = scope.store.graph.children[key, default: []].insert(transaction.key).inserted
-
-        // Add an `Edge` from the upstream to downstream.
-        scope.store.graph.dependencies[transaction.key, default: []].insert(key)
-
-        if isInserted || cache == nil {
-            notifyUpdateToObservers(scope: scope)
-        }
-
-        return newCache.value
-    }
-
-    func watch<Node: Atom>(
-        _ atom: Node,
-        container: SubscriptionContainer.Wrapper,
-        notifyUpdate: @escaping () -> Void,
-        scope: Scope
-    ) -> Node.Loader.Value {
-        let key = AtomKey(atom)
-        let cache: AtomCache<Node>?
-        let override: AtomOverride<Node>?
-
-        if let oldCache = peekCache(of: atom, for: key, scope: scope) {
-            cache = oldCache
-            override = nil
-        }
-        else if let _override = peekOverride(of: atom, scope: scope) {
-            cache = nil
-            override = _override
-        }
-        else if let parent = scope.parent {
-            return watch(atom, container: container, notifyUpdate: notifyUpdate, scope: parent)
-        }
-        else {
-            cache = nil
-            override = nil
-        }
-
-        let newCache = cache ?? makeNewCache(of: atom, for: key, override: override, scope: scope)
+        let store = getStore()
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+        let cache = lookupCache(of: atom, for: key)
+        let newCache = cache ?? makeNewCache(of: atom, for: key, override: override)
         let subscription = Subscription(
             location: container.location,
             notifyUpdate: notifyUpdate
         ) {
+            let store = getStore()
             // Unsubscribe and release if it's no longer used.
-            scope.store.state.subscriptions[key]?.removeValue(forKey: container.key)
-            notifyUpdateToObservers(scope: scope)
-            checkRelease(for: key, scope: scope)
+            store.state.subscriptions[key]?.removeValue(forKey: container.key)
+            notifyUpdateToObservers()
+            checkRelease(for: key)
         }
-        let isInserted = scope.store.state.subscriptions[key, default: [:]].updateValue(subscription, forKey: container.key) == nil
+        let isInserted = store.state.subscriptions[key, default: [:]].updateValue(subscription, forKey: container.key) == nil
 
         // Register the subscription to both the store and the container.
         container.subscriptions[key] = subscription
 
         if isInserted || cache == nil {
-            notifyUpdateToObservers(scope: scope)
+            notifyUpdateToObservers()
         }
 
         return newCache.value
     }
 
-    func refresh<Node: Atom>(_ atom: Node, scope: Scope) async -> Node.Loader.Value where Node.Loader: RefreshableAtomLoader {
-        let key = AtomKey(atom)
-        let cache: AtomCache<Node>?
-        let override: AtomOverride<Node>?
-
-        if let oldCache = peekCache(of: atom, for: key, scope: scope) {
-            cache = oldCache
-            override = peekOverride(of: atom, scope: scope)
-        }
-        else if let _override = peekOverride(of: atom, scope: scope) {
-            cache = nil
-            override = _override
-        }
-        else if let parent = scope.parent {
-            return await refresh(atom, scope: parent)
-        }
-        else {
-            cache = nil
-            override = nil
-        }
-
-        let context = prepareTransaction(of: atom, for: key, scope: scope)
+    @usableFromInline
+    func refresh<Node: Atom>(_ atom: Node) async -> Node.Loader.Value where Node.Loader: RefreshableAtomLoader {
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+        let context = prepareTransaction(of: atom, for: key)
         let value: Node.Loader.Value
 
         if let override {
@@ -267,48 +130,102 @@ private extension StoreContext {
             value = await atom._loader.refresh(context: context)
         }
 
-        if let cache {
-            update(atom: atom, for: key, value: value, cache: cache, scope: scope)
+        if let cache = lookupCache(of: atom, for: key) {
+            update(atom: atom, for: key, value: value, cache: cache)
         }
 
-        checkRelease(for: key, scope: scope)
+        checkRelease(for: key)
         return value
     }
 
-    func reset(_ atom: some Atom, scope: Scope) {
-        let key = AtomKey(atom)
+    @usableFromInline
+    func reset(_ atom: some Atom) {
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
 
-        if let cache = peekCache(of: atom, for: key, scope: scope) {
-            let override = peekOverride(of: atom, scope: scope)
-            let newCache = makeNewCache(of: atom, for: key, override: override, scope: scope)
-            update(atom: atom, for: key, value: newCache.value, cache: cache, scope: scope)
-            checkRelease(for: key, scope: scope)
-        }
-        else if isOverridden(atom, scope: scope) {
-            // Do nothing if the atom is overridden.
-            return
-        }
-        else if let parent = scope.parent {
-            reset(atom, scope: parent)
+        if let cache = lookupCache(of: atom, for: key) {
+            let override = lookupOverride(of: atom)
+            let newCache = makeNewCache(of: atom, for: key, override: override)
+            update(atom: atom, for: key, value: newCache.value, cache: cache)
+            checkRelease(for: key)
         }
     }
 
-    func reset(for key: AtomKey, scope: Scope) {
-        if let cache = scope.store.state.caches[key] {
-            reset(cache.atom, scope: scope)
-        }
-        else if let parent = scope.parent {
-            reset(for: key, scope: parent)
+    @usableFromInline
+    func unwatch(_ atom: some Atom, container: SubscriptionContainer.Wrapper) {
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+        container.subscriptions.removeValue(forKey: key)?.unsubscribe()
+    }
+
+    @usableFromInline
+    func snapshot() -> Snapshot {
+        let store = getStore()
+        let graph = store.graph
+        let caches = store.state.caches
+        let subscriptions = store.state.subscriptions
+
+        return Snapshot(
+            graph: graph,
+            caches: caches,
+            subscriptions: subscriptions,
+            overrides: overrides
+        ) {
+            let store = getStore()
+            let keys = ContiguousArray(caches.keys)
+            var obsoletedDependencies = [AtomKey: Set<AtomKey>]()
+
+            for key in keys {
+                let oldDependencies = store.graph.dependencies[key]
+                let newDependencies = graph.dependencies[key]
+
+                // Update atom values and the graph.
+                store.state.caches[key] = caches[key]
+                store.graph.dependencies[key] = newDependencies
+                store.graph.children[key] = graph.children[key]
+                obsoletedDependencies[key] = oldDependencies?.subtracting(newDependencies ?? [])
+            }
+
+            for key in keys {
+                // Release if the atom is no longer used.
+                checkRelease(for: key)
+
+                // Release dependencies that are no longer dependent.
+                if let dependencies = obsoletedDependencies[key] {
+                    checkReleaseDependencies(dependencies, for: key)
+                }
+
+                // Notify updates only for the subscriptions of restored atoms.
+                if let subscriptions = store.state.subscriptions[key] {
+                    for subscription in ContiguousArray(subscriptions.values) {
+                        subscription.notifyUpdate()
+                    }
+                }
+            }
         }
     }
 
+    func scoped(
+        overrides: [OverrideKey: any AtomOverrideProtocol],
+        observers: [Observer]
+    ) -> Self {
+        StoreContext(
+            weakStore,
+            overrides: self.overrides.merging(overrides) { $1 },
+            observers: self.observers + observers,
+            enablesAssertion: enablesAssertion
+        )
+    }
+}
+
+private extension StoreContext {
     func makeNewCache<Node: Atom>(
         of atom: Node,
         for key: AtomKey,
-        override: AtomOverride<Node>?,
-        scope: Scope
+        override: AtomOverride<Node>?
     ) -> AtomCache<Node> {
-        let context = prepareTransaction(of: atom, for: key, scope: scope)
+        let store = getStore()
+        let context = prepareTransaction(of: atom, for: key)
         let value: Node.Loader.Value
 
         if let override {
@@ -319,29 +236,25 @@ private extension StoreContext {
         }
 
         let cache = AtomCache(atom: atom, value: value)
-        scope.store.state.caches[key] = cache
+        store.state.caches[key] = cache
 
         return cache
     }
 
-    func prepareTransaction<Node: Atom>(
-        of atom: Node,
-        for key: AtomKey,
-        scope: Scope
-    ) -> AtomLoaderContext<Node.Loader.Value, Node.Loader.Coordinator> {
-        let state = getState(of: atom, for: key, scope: scope)
-
+    func prepareTransaction<Node: Atom>(of atom: Node, for key: AtomKey) -> AtomLoaderContext<Node.Loader.Value, Node.Loader.Coordinator> {
         // Invalidate dependencies and an ongoing transaction.
-        let oldDependencies = invalidate(for: key, scope: scope)
+        let oldDependencies = invalidate(for: key)
         let transaction = Transaction(key: key) {
-            let dependencies = scope.store.graph.dependencies[key] ?? []
+            let store = getStore()
+            let dependencies = store.graph.dependencies[key] ?? []
             let obsoletedDependencies = oldDependencies.subtracting(dependencies)
 
             // Check if the dependencies that are no longer used and release them if possible.
-            checkReleaseDependencies(obsoletedDependencies, for: key, scope: scope)
+            checkReleaseDependencies(obsoletedDependencies, for: key)
         }
 
         // Register the transaction state so it can be terminated from anywhere.
+        let state = getState(of: atom, for: key)
         state.transaction = transaction
 
         return AtomLoaderContext(
@@ -349,7 +262,7 @@ private extension StoreContext {
             transaction: transaction,
             coordinator: state.coordinator
         ) { value, needsEnsureValueUpdate in
-            guard let cache = peekCache(of: atom, for: key, scope: scope) else {
+            guard let cache = lookupCache(of: atom, for: key) else {
                 return
             }
 
@@ -358,8 +271,7 @@ private extension StoreContext {
                 for: key,
                 value: value,
                 cache: cache,
-                needsEnsureValueUpdate: needsEnsureValueUpdate,
-                scope: scope
+                needsEnsureValueUpdate: needsEnsureValueUpdate
             )
         }
     }
@@ -369,15 +281,15 @@ private extension StoreContext {
         for key: AtomKey,
         value: Node.Loader.Value,
         cache: AtomCache<Node>,
-        needsEnsureValueUpdate: Bool = false,
-        scope: Scope
+        needsEnsureValueUpdate: Bool = false
     ) {
+        let store = getStore()
         let oldValue = cache.value
         var cache = cache
 
         // Update the current value with the new value.
         cache.value = value
-        scope.store.state.caches[key] = cache
+        store.state.caches[key] = cache
 
         // Do not notify update if the new value and the old value are equivalent.
         if !atom._loader.shouldUpdate(newValue: value, oldValue: oldValue) {
@@ -385,13 +297,13 @@ private extension StoreContext {
         }
 
         // Notify update to the downstream atoms or views.
-        notifyUpdate(for: key, needsEnsureValueUpdate: needsEnsureValueUpdate, scope: scope)
+        notifyUpdate(for: key, needsEnsureValueUpdate: needsEnsureValueUpdate)
 
         // Notify value update to observers.
-        notifyUpdateToObservers(scope: scope)
+        notifyUpdateToObservers()
 
         func notifyUpdated() {
-            let state = getState(of: atom, for: key, scope: scope)
+            let state = getState(of: atom, for: key)
             let context = AtomUpdatedContext(store: self, coordinator: state.coordinator)
             atom.updated(newValue: value, oldValue: oldValue, context: context)
         }
@@ -407,26 +319,26 @@ private extension StoreContext {
         }
     }
 
-    func notifyUpdate(
-        for key: AtomKey,
-        needsEnsureValueUpdate: Bool,
-        scope: Scope
-    ) {
+    func notifyUpdate(for key: AtomKey, needsEnsureValueUpdate: Bool) {
+        let store = getStore()
+
         // Notifying update to view subscriptions first.
-        if let subscriptions = scope.store.state.subscriptions[key], !subscriptions.isEmpty {
+        if let subscriptions = store.state.subscriptions[key], !subscriptions.isEmpty {
             for subscription in ContiguousArray(subscriptions.values) {
                 subscription.notifyUpdate()
             }
         }
 
-        guard let children = scope.store.graph.children[key], !children.isEmpty else {
+        guard let children = store.graph.children[key], !children.isEmpty else {
             return
         }
 
         func notifyUpdate() {
             for child in children {
                 // Reset the atom value and then notify update to downstream atoms.
-                reset(for: child, scope: scope)
+                if let cache = store.state.caches[child] {
+                    reset(cache.atom)
+                }
             }
         }
 
@@ -444,69 +356,76 @@ private extension StoreContext {
         }
     }
 
-    func getState<Node: Atom>(of atom: Node, for key: AtomKey, scope: Scope) -> AtomState<Node.Coordinator> {
-        func makeState() -> AtomState<Node.Coordinator> {
-            let coordinator = atom.makeCoordinator()
-            let state = AtomState(coordinator: coordinator)
-            scope.store.state.states[key] = state
-            return state
-        }
+    func invalidate(for key: AtomKey) -> Set<AtomKey> {
+        let store = getStore()
 
-        guard let baseState = scope.store.state.states[key] else {
-            return makeState()
-        }
-
-        guard let state = baseState as? AtomState<Node.Coordinator> else {
-            assertionFailure(
-                """
-                [Atoms]
-                The type of the given atom's value and the state did not match.
-                There might be duplicate keys, make sure that the keys for all atom types are unique.
-
-                Atom: \(Node.self)
-                Key: \(type(of: atom.key))
-                Detected: \(type(of: baseState))
-                Expected: AtomState<\(Node.Coordinator.self)>
-                """
-            )
-
-            // Release the invalid registration as a fallback.
-            release(for: key, scope: scope)
-            return makeState()
-        }
-
-        return state
+        // Remove the current transaction and then terminate to prevent it to watch new atoms
+        // or add new terminations.
+        // Then, temporarily remove dependencies but do not release them recursively here.
+        store.state.states[key]?.transaction?.terminate()
+        return store.graph.dependencies.removeValue(forKey: key) ?? []
     }
 
-    func peekCache<Node: Atom>(of atom: Node, for key: AtomKey, scope: Scope) -> AtomCache<Node>? {
-        guard let baseCache = scope.store.state.caches[key] else {
-            return nil
-        }
+    func release(for key: AtomKey) {
+        let store = getStore()
 
-        guard let cache = baseCache as? AtomCache<Node> else {
-            assertionFailure(
-                """
-                [Atoms]
-                The type of the given atom's value and the cache did not match.
-                There might be duplicate keys, make sure that the keys for all atom types are unique.
+        // Invalidate transactions, dependencies, and the atom state.
+        let dependencies = invalidate(for: key)
+        store.graph.children.removeValue(forKey: key)
+        store.state.caches.removeValue(forKey: key)
+        store.state.states.removeValue(forKey: key)
+        store.state.subscriptions.removeValue(forKey: key)
 
-                Atom: \(Node.self)
-                Key: \(type(of: atom.key))
-                Detected: \(type(of: baseCache))
-                Expected: AtomCache<\(Node.self)>
-                """
-            )
+        // Check if the dependencies are releasable.
+        checkReleaseDependencies(dependencies, for: key)
 
-            // Release the invalid registration as a fallback.
-            release(for: key, scope: scope)
-            return nil
-        }
-
-        return cache
+        // Notify release.
+        notifyUpdateToObservers()
     }
 
-    func peekOverride<Node: Atom>(of atom: Node, scope: Scope) -> AtomOverride<Node>? {
-        let baseOverride = scope.overrides[OverrideKey(atom)] ?? scope.overrides[OverrideKey(Node.self)]
+    func checkRelease(for key: AtomKey) {
+        let store = getStore()
+
+        // The condition under which an atom may be released are as follows:
+        //     1. It's not marked as `KeepAlive`.
+        //     2. It has no downstream atoms.
+        //     3. It has no subscriptions from views.
+        let shouldKeepAlive = store.state.caches[key].map { $0.atom is any KeepAlive } ?? false
+        let isChildrenEmpty = store.graph.children[key]?.isEmpty ?? true
+        let isSubscriptionEmpty = store.state.subscriptions[key]?.isEmpty ?? true
+        let shouldRelease = !shouldKeepAlive && isChildrenEmpty && isSubscriptionEmpty
+
+        guard shouldRelease else {
+            return
+        }
+
+        release(for: key)
+    }
+
+    func checkReleaseDependencies(_ dependencies: Set<AtomKey>, for key: AtomKey) {
+        let store = getStore()
+
+        // Recursively release dependencies while unlinking the dependent.
+        for dependency in dependencies {
+            store.graph.children[dependency]?.remove(key)
+            checkRelease(for: dependency)
+        }
+    }
+
+    func notifyUpdateToObservers() {
+        guard !observers.isEmpty else {
+            return
+        }
+
+        let snapshot = snapshot()
+
+        for observer in observers {
+            observer.onUpdate(snapshot)
+        }
+    }
+
+    func lookupOverride<Node: Atom>(of atom: Node) -> AtomOverride<Node>? {
+        let baseOverride = overrides[OverrideKey(atom)] ?? overrides[OverrideKey(Node.self)]
 
         guard let baseOverride else {
             return nil
@@ -529,133 +448,72 @@ private extension StoreContext {
         return override
     }
 
-    func isOverridden<Node: Atom>(_ atom: Node, scope: Scope) -> Bool {
-        scope.overrides[OverrideKey(atom)] != nil || scope.overrides[OverrideKey(Node.self)] != nil
-    }
+    func getState<Node: Atom>(of atom: Node, for key: AtomKey) -> AtomState<Node.Coordinator> {
+        let store = getStore()
 
-    func invalidate(for key: AtomKey, scope: Scope) -> Set<AtomKey> {
-        // Remove the current transaction and then terminate to prevent it to watch new atoms
-        // or add new terminations.
-        // Then, temporarily remove dependencies but do not release them recursively here.
-        scope.store.state.states[key]?.transaction?.terminate()
-        return scope.store.graph.dependencies.removeValue(forKey: key) ?? []
-    }
-
-    func release(for key: AtomKey, scope: Scope) {
-        // Invalidate transactions, dependencies, and the atom state.
-        let dependencies = invalidate(for: key, scope: scope)
-        scope.store.graph.children.removeValue(forKey: key)
-        scope.store.state.caches.removeValue(forKey: key)
-        scope.store.state.states.removeValue(forKey: key)
-        scope.store.state.subscriptions.removeValue(forKey: key)
-
-        // Check if the dependencies are releasable.
-        checkReleaseDependencies(dependencies, for: key, scope: scope)
-
-        // Notify release.
-        notifyUpdateToObservers(scope: scope)
-    }
-
-    func checkRelease(for key: AtomKey, scope: Scope) {
-        // The condition under which an atom may be released are as follows:
-        //     1. It's not marked as `KeepAlive`.
-        //     2. It has no downstream atoms.
-        //     3. It has no subscriptions from views.
-        let shouldKeepAlive = scope.store.state.caches[key].map { $0.atom is any KeepAlive } ?? false
-        let isChildrenEmpty = scope.store.graph.children[key]?.isEmpty ?? true
-        let isSubscriptionEmpty = scope.store.state.subscriptions[key]?.isEmpty ?? true
-        let shouldRelease = !shouldKeepAlive && isChildrenEmpty && isSubscriptionEmpty
-
-        guard shouldRelease else {
-            return
+        func makeState() -> AtomState<Node.Coordinator> {
+            let coordinator = atom.makeCoordinator()
+            let state = AtomState(coordinator: coordinator)
+            store.state.states[key] = state
+            return state
         }
 
-        release(for: key, scope: scope)
-    }
-
-    func checkReleaseDependencies(_ dependencies: Set<AtomKey>, for key: AtomKey, scope: Scope) {
-        // Recursively release dependencies while unlinking the dependent.
-        for dependency in dependencies {
-            scope.store.graph.children[dependency]?.remove(key)
-            checkRelease(for: dependency, scope: scope)
-        }
-    }
-
-    func notifyUpdateToObservers(scope: Scope) {
-        guard !observers.isEmpty else {
-            return
+        guard let baseState = store.state.states[key] else {
+            return makeState()
         }
 
-        let snapshot = snapshot(scope: scope)
+        guard let state = baseState as? AtomState<Node.Coordinator> else {
+            assertionFailure(
+                """
+                [Atoms]
+                The type of the given atom's value and the state did not match.
+                There might be duplicate keys, make sure that the keys for all atom types are unique.
 
-        for observer in observers {
-            observer.onUpdate(snapshot)
+                Atom: \(Node.self)
+                Key: \(type(of: atom.key))
+                Detected: \(type(of: baseState))
+                Expected: AtomState<\(Node.Coordinator.self)>
+                """
+            )
+
+            // Release the invalid registration as a fallback.
+            release(for: key)
+            return makeState()
         }
+
+        return state
     }
 
-    func snapshot(scope: Scope) -> Snapshot {
-        let graph = scope.store.graph
-        let caches = scope.store.state.caches
-        let subscriptions = scope.store.state.subscriptions
+    func lookupCache<Node: Atom>(of atom: Node, for key: AtomKey) -> AtomCache<Node>? {
+        let store = getStore()
 
-        return Snapshot(
-            graph: graph,
-            caches: caches,
-            subscriptions: subscriptions
-        ) {
-            let keys = ContiguousArray(caches.keys)
-            var obsoletedDependencies = [AtomKey: Set<AtomKey>]()
-
-            for key in keys {
-                let oldDependencies = scope.store.graph.dependencies[key]
-                let newDependencies = graph.dependencies[key]
-
-                // Update atom values and the graph.
-                scope.store.state.caches[key] = caches[key]
-                scope.store.graph.dependencies[key] = newDependencies
-                scope.store.graph.children[key] = graph.children[key]
-                obsoletedDependencies[key] = oldDependencies?.subtracting(newDependencies ?? [])
-            }
-
-            for key in keys {
-                // Release if the atom is no longer used.
-                checkRelease(for: key, scope: scope)
-
-                // Release dependencies that are no longer dependent.
-                if let dependencies = obsoletedDependencies[key] {
-                    checkReleaseDependencies(dependencies, for: key, scope: scope)
-                }
-
-                // Notify updates only for the subscriptions of restored atoms.
-                if let subscriptions = scope.store.state.subscriptions[key] {
-                    for subscription in ContiguousArray(subscriptions.values) {
-                        subscription.notifyUpdate()
-                    }
-                }
-            }
+        guard let baseCache = store.state.caches[key] else {
+            return nil
         }
+
+        guard let cache = baseCache as? AtomCache<Node> else {
+            assertionFailure(
+                """
+                [Atoms]
+                The type of the given atom's value and the cache did not match.
+                There might be duplicate keys, make sure that the keys for all atom types are unique.
+
+                Atom: \(Node.self)
+                Key: \(type(of: atom.key))
+                Detected: \(type(of: baseCache))
+                Expected: AtomCache<\(Node.self)>
+                """
+            )
+
+            // Release the invalid registration as a fallback.
+            release(for: key)
+            return nil
+        }
+
+        return cache
     }
-}
 
-private final class Scope {
-    private(set) weak var weakStore: AtomStore?
-    let overrides: [OverrideKey: any AtomOverrideProtocol]
-    let parent: Scope?
-    let enablesAssertion: Bool
-
-    init(
-        store: AtomStore?,
-        overrides: [OverrideKey: any AtomOverrideProtocol],
-        parent: Scope?,
-        enablesAssertion: Bool
-    ) {
-        self.weakStore = store
-        self.overrides = overrides
-        self.parent = parent
-        self.enablesAssertion = enablesAssertion
-    }
-
-    var store: AtomStore {
+    func getStore() -> AtomStore {
         if let store = weakStore {
             return store
         }

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -198,8 +198,7 @@ internal struct StoreContext {
         return Snapshot(
             graph: graph,
             caches: caches,
-            subscriptions: subscriptions,
-            overrides: overrides
+            subscriptions: subscriptions
         ) {
             let store = getStore()
             let keys = ContiguousArray(caches.keys)

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -407,10 +407,10 @@ private extension StoreContext {
         //     1. It's not marked as `KeepAlive` or is overridden.
         //     2. It has no downstream atoms.
         //     3. It has no subscriptions from views.
-        let shouldKeepAlive = !key.isOverridden && store.state.caches[key].map { $0.atom is any KeepAlive } ?? false
-        let isChildrenEmpty = store.graph.children[key]?.isEmpty ?? true
-        let isSubscriptionEmpty = store.state.subscriptions[key]?.isEmpty ?? true
-        let shouldRelease = !shouldKeepAlive && isChildrenEmpty && isSubscriptionEmpty
+        lazy var shouldKeepAlive = !key.isOverridden && store.state.caches[key].map { $0.atom is any KeepAlive } ?? false
+        lazy var isChildrenEmpty = store.graph.children[key]?.isEmpty ?? true
+        lazy var isSubscriptionEmpty = store.state.subscriptions[key]?.isEmpty ?? true
+        lazy var shouldRelease = !shouldKeepAlive && isChildrenEmpty && isSubscriptionEmpty
 
         guard shouldRelease else {
             return

--- a/Sources/Atoms/KeepAlive.swift
+++ b/Sources/Atoms/KeepAlive.swift
@@ -1,6 +1,8 @@
 /// A marker protocol that indicates that the value of atoms conform with this protocol
 /// will continue to be retained even after they are no longer watched to.
 ///
+/// Note that this protocol doesn't apply to overridden atoms.
+///
 /// ## Example
 ///
 /// ```swift

--- a/Sources/Atoms/Snapshot.swift
+++ b/Sources/Atoms/Snapshot.swift
@@ -34,7 +34,7 @@ public struct Snapshot: CustomStringConvertible {
 
     /// Lookup a value associated with the given atom from the set captured in this snapshot..
     ///
-    /// Note that this does not look up overridden atoms.
+    /// Note that this does not look up a overridden atom.
     ///
     /// - Parameter atom: An atom that associates the value.
     ///

--- a/Sources/Atoms/Snapshot.swift
+++ b/Sources/Atoms/Snapshot.swift
@@ -3,20 +3,17 @@ public struct Snapshot: CustomStringConvertible {
     internal let graph: Graph
     internal let caches: [AtomKey: any AtomCacheProtocol]
     internal let subscriptions: [AtomKey: [SubscriptionKey: Subscription]]
-    internal let overrides: [OverrideKey: any AtomScopedOverrideProtocol]
     private let _restore: @MainActor () -> Void
 
     internal init(
         graph: Graph,
         caches: [AtomKey: any AtomCacheProtocol],
         subscriptions: [AtomKey: [SubscriptionKey: Subscription]],
-        overrides: [OverrideKey: any AtomScopedOverrideProtocol],
         restore: @MainActor @escaping () -> Void
     ) {
         self.graph = graph
         self.caches = caches
         self.subscriptions = subscriptions
-        self.overrides = overrides
         self._restore = restore
     }
 
@@ -37,13 +34,14 @@ public struct Snapshot: CustomStringConvertible {
 
     /// Lookup a value associated with the given atom from the set captured in this snapshot..
     ///
+    /// Note that this does not look up overridden atoms.
+    ///
     /// - Parameter atom: An atom that associates the value.
     ///
     /// - Returns: The captured value associated with the given atom if it exists.
     @MainActor
     public func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
-        let override = overrides[OverrideKey(atom)] ?? overrides[OverrideKey(Node.self)]
-        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+        let key = AtomKey(atom, overrideScopeKey: nil)
         let cache = caches[key] as? AtomCache<Node>
         return cache?.value
     }

--- a/Sources/Atoms/Snapshot.swift
+++ b/Sources/Atoms/Snapshot.swift
@@ -80,11 +80,11 @@ public struct Snapshot: CustomStringConvertible {
         var statements = Set<String>()
 
         for key in caches.keys {
-            statements.insert(key.name.quoted)
+            statements.insert(key.description.quoted)
 
             if let children = graph.children[key] {
                 for child in children {
-                    statements.insert("\(key.name.quoted) -> \(child.name.quoted)")
+                    statements.insert("\(key.description.quoted) -> \(child.description.quoted)")
                 }
             }
 
@@ -92,7 +92,7 @@ public struct Snapshot: CustomStringConvertible {
                 for subscription in subscriptions {
                     let label = "line:\(subscription.location.line)".quoted
                     statements.insert("\(subscription.location.fileID.quoted) [style=filled]")
-                    statements.insert("\(key.name.quoted) -> \(subscription.location.fileID.quoted) [label=\(label)]")
+                    statements.insert("\(key.description.quoted) -> \(subscription.location.fileID.quoted) [label=\(label)]")
                 }
             }
         }

--- a/Sources/Atoms/Snapshot.swift
+++ b/Sources/Atoms/Snapshot.swift
@@ -3,14 +3,14 @@ public struct Snapshot: CustomStringConvertible {
     internal let graph: Graph
     internal let caches: [AtomKey: any AtomCacheProtocol]
     internal let subscriptions: [AtomKey: [SubscriptionKey: Subscription]]
-    internal let overrides: [OverrideKey: any AtomOverrideProtocol]
+    internal let overrides: [OverrideKey: any AtomScopedOverrideProtocol]
     private let _restore: @MainActor () -> Void
 
     internal init(
         graph: Graph,
         caches: [AtomKey: any AtomCacheProtocol],
         subscriptions: [AtomKey: [SubscriptionKey: Subscription]],
-        overrides: [OverrideKey: any AtomOverrideProtocol],
+        overrides: [OverrideKey: any AtomScopedOverrideProtocol],
         restore: @MainActor @escaping () -> Void
     ) {
         self.graph = graph

--- a/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
@@ -121,6 +121,8 @@ final class AsyncSequenceAtomTests: XCTestCase {
             context.override(atom) { _ in .success(200) }
             pipe.reset()
 
+            XCTAssertEqual(context.watch(atom).value, 200)
+
             let phase = await context.refresh(atom)
 
             XCTAssertEqual(phase.value, 200)

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -118,8 +118,10 @@ final class PublisherAtomTests: XCTestCase {
             var updateCount = 0
             context.onUpdate = { updateCount += 1 }
             context.override(atom) { _ in .success(200) }
-
             subject.reset()
+
+            XCTAssertEqual(context.watch(atom).value, 200)
+
             let phase = await context.refresh(atom)
 
             XCTAssertEqual(phase.value, 200)

--- a/Tests/AtomsTests/Core/AtomKeyTests.swift
+++ b/Tests/AtomsTests/Core/AtomKeyTests.swift
@@ -39,10 +39,15 @@ final class AtomKeyTests: XCTestCase {
         XCTAssertEqual(dictionary[key2], 300)
     }
 
-    func testName() {
+    func testDescription() {
         let atom = TestAtom(value: 0)
-        let key = AtomKey(atom)
+        let token = ScopeKey.Token()
+        let scopeKey = ScopeKey(token: token)
+        let key0 = AtomKey(atom)
+        let key1 = AtomKey(atom, overrideScopeKey: scopeKey)
+        let scopeID = String(scopeKey.hashValue, radix: 36, uppercase: false)
 
-        XCTAssertEqual(key.name, "TestAtom<Int>")
+        XCTAssertEqual(key0.description, "TestAtom<Int>")
+        XCTAssertEqual(key1.description, "TestAtom<Int>-override:\(scopeID)")
     }
 }

--- a/Tests/AtomsTests/Core/AtomKeyTests.swift
+++ b/Tests/AtomsTests/Core/AtomKeyTests.swift
@@ -45,9 +45,8 @@ final class AtomKeyTests: XCTestCase {
         let scopeKey = ScopeKey(token: token)
         let key0 = AtomKey(atom)
         let key1 = AtomKey(atom, overrideScopeKey: scopeKey)
-        let scopeID = String(scopeKey.hashValue, radix: 36, uppercase: false)
 
         XCTAssertEqual(key0.description, "TestAtom<Int>")
-        XCTAssertEqual(key1.description, "TestAtom<Int>-override:\(scopeID)")
+        XCTAssertEqual(key1.description, "TestAtom<Int>-override:\(scopeKey.id)")
     }
 }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -598,11 +598,33 @@ final class StoreContextTests: XCTestCase {
             let transaction = Transaction(key: key) {}
 
             _ = context.watch(atom, in: transaction)
-
             XCTAssertNotNil(store.state.caches[key])
 
             context.reset(atom)
             XCTAssertNotNil(store.state.caches[key])
+        }
+
+        XCTContext.runActivity(named: "Overridden KeepAlive atoms should not be released.") { _ in
+            let atom = KeepAliveAtom(value: 0)
+            let token = ScopeKey.Token()
+            let scopeKey = ScopeKey(token: token)
+            let key = AtomKey(atom, overrideScopeKey: scopeKey)
+            let context = context.scoped(
+                overrides: [
+                    OverrideKey(atom): AtomOverride<KeepAliveAtom<Int>>(
+                        scopeKey: scopeKey,
+                        value: { _ in 10 }
+                    )
+                ],
+                observers: []
+            )
+            let transaction = Transaction(key: key) {}
+
+            _ = context.watch(atom, in: transaction)
+            XCTAssertNotNil(store.state.caches[key])
+
+            context.reset(atom)
+            XCTAssertNil(store.state.caches[key])
         }
     }
 

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -9,8 +9,7 @@ final class SnapshotTests: XCTestCase {
         let snapshot = Snapshot(
             graph: Graph(),
             caches: [:],
-            subscriptions: [:],
-            overrides: [:]
+            subscriptions: [:]
         ) {
             isRestoreCalled = true
         }
@@ -23,36 +22,24 @@ final class SnapshotTests: XCTestCase {
     func testLookup() {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
-        let atom2 = TestAtom(value: 2)
-        let atom3 = TestAtom(value: 3)
-        let token = ScopeKey.Token()
-        let scopeKey = ScopeKey(token: token)
         let atomCache = [
             AtomKey(atom0): AtomCache(atom: atom0, value: 0),
-            AtomKey(atom2, overrideScopeKey: scopeKey): AtomCache(atom: atom2, value: 20),
-        ]
-        let overrides = [
-            OverrideKey(atom2): AtomScopedOverride<TestAtom<Int>>(scopeKey: scopeKey) { _ in 0 }
         ]
         let snapshot = Snapshot(
             graph: Graph(),
             caches: atomCache,
-            subscriptions: [:],
-            overrides: overrides
+            subscriptions: [:]
         ) {}
 
         XCTAssertEqual(snapshot.lookup(atom0), 0)
         XCTAssertNil(snapshot.lookup(atom1))
-        XCTAssertEqual(snapshot.lookup(atom2), 20)
-        XCTAssertNil(snapshot.lookup(atom3))
     }
 
     func testEmptyGraphDescription() {
         let snapshot = Snapshot(
             graph: Graph(),
             caches: [:],
-            subscriptions: [:],
-            overrides: [:]
+            subscriptions: [:]
         ) {}
 
         XCTAssertEqual(snapshot.graphDescription(), "digraph {}")
@@ -106,8 +93,7 @@ final class SnapshotTests: XCTestCase {
                 key2: [subscriber: subscription],
                 key3: [subscriber: subscription],
                 key4: [subscriber: subscription],
-            ],
-            overrides: [:]
+            ]
         ) {}
 
         XCTAssertEqual(

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -66,7 +66,8 @@ final class SnapshotTests: XCTestCase {
         struct Value4: Hashable {}
 
         let scopeToken = ScopeKey.Token()
-        let overrideScopeKey = ScopeKey(token: scopeToken)
+        let scopeKey = ScopeKey(token: scopeToken)
+        let scopeID = String(scopeKey.hashValue, radix: 36, uppercase: false)
         let atom0 = TestAtom(value: Value0())
         let atom1 = TestAtom(value: Value1())
         let atom2 = TestAtom(value: Value2())
@@ -76,7 +77,7 @@ final class SnapshotTests: XCTestCase {
         let key1 = AtomKey(atom1)
         let key2 = AtomKey(atom2)
         let key3 = AtomKey(atom3)
-        let key4 = AtomKey(atom4, overrideScopeKey: overrideScopeKey)
+        let key4 = AtomKey(atom4, overrideScopeKey: scopeKey)
         let location = SourceLocation(fileID: "Module/View.swift", line: 10)
         let subscriptionToken = SubscriptionKey.Token()
         let subscriber = SubscriptionKey(token: subscriptionToken)
@@ -124,8 +125,8 @@ final class SnapshotTests: XCTestCase {
               "TestAtom<Value2>" -> "TestAtom<Value3>"
               "TestAtom<Value3>"
               "TestAtom<Value3>" -> "Module/View.swift" [label="line:10"]
-              "TestAtom<Value4>"
-              "TestAtom<Value4>" -> "Module/View.swift" [label="line:10"]
+              "TestAtom<Value4>-override:\(scopeID)"
+              "TestAtom<Value4>-override:\(scopeID)" -> "Module/View.swift" [label="line:10"]
             }
             """
         )

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -54,7 +54,6 @@ final class SnapshotTests: XCTestCase {
 
         let scopeToken = ScopeKey.Token()
         let scopeKey = ScopeKey(token: scopeToken)
-        let scopeID = String(scopeKey.hashValue, radix: 36, uppercase: false)
         let atom0 = TestAtom(value: Value0())
         let atom1 = TestAtom(value: Value1())
         let atom2 = TestAtom(value: Value2())
@@ -111,8 +110,8 @@ final class SnapshotTests: XCTestCase {
               "TestAtom<Value2>" -> "TestAtom<Value3>"
               "TestAtom<Value3>"
               "TestAtom<Value3>" -> "Module/View.swift" [label="line:10"]
-              "TestAtom<Value4>-override:\(scopeID)"
-              "TestAtom<Value4>-override:\(scopeID)" -> "Module/View.swift" [label="line:10"]
+              "TestAtom<Value4>-override:\(scopeKey.id)"
+              "TestAtom<Value4>-override:\(scopeKey.id)" -> "Module/View.swift" [label="line:10"]
             }
             """
         )

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -6,7 +6,12 @@ import XCTest
 final class SnapshotTests: XCTestCase {
     func testRestore() {
         var isRestoreCalled = false
-        let snapshot = Snapshot(graph: Graph(), caches: [:], subscriptions: [:]) {
+        let snapshot = Snapshot(
+            graph: Graph(),
+            caches: [:],
+            subscriptions: [:],
+            overrides: [:]
+        ) {
             isRestoreCalled = true
         }
 
@@ -18,17 +23,37 @@ final class SnapshotTests: XCTestCase {
     func testLookup() {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
+        let atom2 = TestAtom(value: 2)
+        let atom3 = TestAtom(value: 3)
+        let token = ScopeKey.Token()
+        let scopeKey = ScopeKey(token: token)
         let atomCache = [
-            AtomKey(atom0): AtomCache(atom: atom0, value: 0)
+            AtomKey(atom0): AtomCache(atom: atom0, value: 0),
+            AtomKey(atom2, overrideScopeKey: scopeKey): AtomCache(atom: atom2, value: 20),
         ]
-        let snapshot = Snapshot(graph: Graph(), caches: atomCache, subscriptions: [:]) {}
+        let overrides = [
+            OverrideKey(atom2): AtomOverride<TestAtom<Int>>(scopeKey: scopeKey) { _ in 0 }
+        ]
+        let snapshot = Snapshot(
+            graph: Graph(),
+            caches: atomCache,
+            subscriptions: [:],
+            overrides: overrides
+        ) {}
 
         XCTAssertEqual(snapshot.lookup(atom0), 0)
         XCTAssertNil(snapshot.lookup(atom1))
+        XCTAssertEqual(snapshot.lookup(atom2), 20)
+        XCTAssertNil(snapshot.lookup(atom3))
     }
 
     func testEmptyGraphDescription() {
-        let snapshot = Snapshot(graph: Graph(), caches: [:], subscriptions: [:]) {}
+        let snapshot = Snapshot(
+            graph: Graph(),
+            caches: [:],
+            subscriptions: [:],
+            overrides: [:]
+        ) {}
 
         XCTAssertEqual(snapshot.graphDescription(), "digraph {}")
     }
@@ -38,18 +63,23 @@ final class SnapshotTests: XCTestCase {
         struct Value1: Hashable {}
         struct Value2: Hashable {}
         struct Value3: Hashable {}
+        struct Value4: Hashable {}
 
+        let scopeToken = ScopeKey.Token()
+        let overrideScopeKey = ScopeKey(token: scopeToken)
         let atom0 = TestAtom(value: Value0())
         let atom1 = TestAtom(value: Value1())
         let atom2 = TestAtom(value: Value2())
         let atom3 = TestAtom(value: Value3())
+        let atom4 = TestAtom(value: Value4())
         let key0 = AtomKey(atom0)
         let key1 = AtomKey(atom1)
         let key2 = AtomKey(atom2)
         let key3 = AtomKey(atom3)
+        let key4 = AtomKey(atom4, overrideScopeKey: overrideScopeKey)
         let location = SourceLocation(fileID: "Module/View.swift", line: 10)
-        let token = SubscriptionKey.Token()
-        let subscriber = SubscriptionKey(token: token)
+        let subscriptionToken = SubscriptionKey.Token()
+        let subscriber = SubscriptionKey(token: subscriptionToken)
         let subscription = Subscription(location: location, notifyUpdate: {}, unsubscribe: {})
         let snapshot = Snapshot(
             graph: Graph(
@@ -69,11 +99,14 @@ final class SnapshotTests: XCTestCase {
                 key1: AtomCache(atom: atom1, value: Value1()),
                 key2: AtomCache(atom: atom2, value: Value2()),
                 key3: AtomCache(atom: atom3, value: Value3()),
+                key4: AtomCache(atom: atom4, value: Value4()),
             ],
             subscriptions: [
                 key2: [subscriber: subscription],
                 key3: [subscriber: subscription],
-            ]
+                key4: [subscriber: subscription],
+            ],
+            overrides: [:]
         ) {}
 
         XCTAssertEqual(
@@ -91,6 +124,8 @@ final class SnapshotTests: XCTestCase {
               "TestAtom<Value2>" -> "TestAtom<Value3>"
               "TestAtom<Value3>"
               "TestAtom<Value3>" -> "Module/View.swift" [label="line:10"]
+              "TestAtom<Value4>"
+              "TestAtom<Value4>" -> "Module/View.swift" [label="line:10"]
             }
             """
         )

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -32,7 +32,7 @@ final class SnapshotTests: XCTestCase {
             AtomKey(atom2, overrideScopeKey: scopeKey): AtomCache(atom: atom2, value: 20),
         ]
         let overrides = [
-            OverrideKey(atom2): AtomOverride<TestAtom<Int>>(scopeKey: scopeKey) { _ in 0 }
+            OverrideKey(atom2): AtomScopedOverride<TestAtom<Int>>(scopeKey: scopeKey) { _ in 0 }
         ]
         let snapshot = Snapshot(
             graph: Graph(),

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -23,7 +23,7 @@ final class SnapshotTests: XCTestCase {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
         let atomCache = [
-            AtomKey(atom0): AtomCache(atom: atom0, value: 0),
+            AtomKey(atom0): AtomCache(atom: atom0, value: 0)
         ]
         let snapshot = Snapshot(
             graph: Graph(),

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -57,6 +57,12 @@ final class ResettableSubject<Output, Failure: Error>: Publisher, Subject {
     }
 }
 
+extension AtomKey {
+    init(_ atom: some Atom) {
+        self.init(atom, overrideScopeKey: nil)
+    }
+}
+
 extension SubscriptionContainer {
     var wrapper: Wrapper {
         let location = SourceLocation(fileID: #fileID, line: #line)


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

The Scoped override implemented in #47 didn't allow taking a snapshot for the entire atoms state because the state management was not purely centralized in that way. There was also concern about possible performance degradation due to deep AtomScope nesting.
This PR allows overridden atoms to be cashed into the centralized store by identifying them by unique key of scopes, and snapshot of entire atom stats can now be taken from anywhere in constant time.