### PR TITLE
Change default timeout interval of AtomTestContext/waitForUpdate

### DIFF
--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -42,10 +42,10 @@ public struct AtomTestContext: AtomWatchableContext {
     /// ```
     ///
     /// - Parameter interval: The maximum timeout interval that this function can wait until
-    ///                      the next update. The default timeout interval is `60`.
+    ///                      the next update. The default timeout interval is `10`.
     /// - Returns: A boolean value indicating whether an update is done.
     @discardableResult
-    public func waitForUpdate(timeout interval: TimeInterval = 60) async -> Bool {
+    public func waitForUpdate(timeout interval: TimeInterval = 10) async -> Bool {
         let updates = AsyncStream<Void> { continuation in
             let cancellable = state.notifier.sink(
                 receiveCompletion: { completion in


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Changing the default timeout interval of `AtomContext/waitForUpdate` to 10s because 60s was too much in most cases.