### PR TITLE
Make the default timeout interval nil

### DIFF
--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -42,10 +42,10 @@ public struct AtomTestContext: AtomWatchableContext {
     /// ```
     ///
     /// - Parameter interval: The maximum timeout interval that this function can wait until
-    ///                      the next update. The default timeout interval is `10`.
+    ///                      the next update. The default timeout interval is nil.
     /// - Returns: A boolean value indicating whether an update is done.
     @discardableResult
-    public func waitForUpdate(timeout interval: TimeInterval = 10) async -> Bool {
+    public func waitForUpdate(timeout interval: TimeInterval? = nil) async -> Bool {
         let updates = AsyncStream<Void> { continuation in
             let cancellable = state.notifier.sink(
                 receiveCompletion: { completion in
@@ -77,9 +77,11 @@ public struct AtomTestContext: AtomWatchableContext {
                 return true
             }
 
-            group.addTask {
-                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
-                return false
+            if let interval {
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                    return false
+                }
             }
 
             let didUpdate = await group.next() ?? false


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

The short default timeout lost the opportunity to remind developers that they had inadvertently added an unnecessary `waitForUpdate`. Therefore, this PR changes the default timeout to nil, so that it will wait forever unless a timeout interval is explicitly specified.