### PR TITLE
Support create AtomRoot with specified store [#75]

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -44,16 +44,19 @@ import SwiftUI
 ///
 public struct AtomRoot<Content: View>: View {
     @StateObject
-    private var state = State()
+    private var state: State
     private var overrides = [OverrideKey: any AtomOverrideProtocol]()
     private var observers = [Observer]()
     private let content: Content
 
-    /// Creates an atom root with the specified content that will be allowed to use atoms.
+    /// Creates an atom root with the specified store and content that will be allowed to use atoms.
+    ///
+    /// - Parameter store: The atom store.
     ///
     /// - Parameter content: The content that uses atoms.
-    public init(@ViewBuilder content: () -> Content) {
+    public init(store: AtomStore = AtomStore(), @ViewBuilder content: () -> Content) {
         self.content = content()
+        _state = StateObject(wrappedValue: State(store: store))
     }
 
     /// The content and behavior of the view.
@@ -114,8 +117,12 @@ public struct AtomRoot<Content: View>: View {
 private extension AtomRoot {
     @MainActor
     final class State: ObservableObject {
-        let store = AtomStore()
+        let store: AtomStore
         let token = ScopeKey.Token()
+        
+        init(store: AtomStore = AtomStore()) {
+            self.store = store
+        }
     }
 
     func `mutating`(_ mutation: (inout Self) -> Void) -> Self {


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Issue for this PR

Link:[#75]

## Motivation and Context
Share store between windows
```swift
struct AwsomeApp: App {
    
    @State var store = AtomStore()
    
    var body: some Scene {
        WindowGroup {
            AtomRoot(store: store) {
                Text("Regular Window")
            }
        }
        
        Settings {
            AtomRoot(store: store) {
                Text("Settings")
            }
        }
    }
}
```

## Impact on Existing Code
No Impact
