### PR TITLE
Add a new testing interface - wait(for:timeout:until)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,8 @@ A context that can simulate any scenarios in which atoms are used from a view or
 |:--|:--|
 |[unwatch(_:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/unwatch(_:))|Simulates a scenario in which the atom is no longer watched.|
 |[override(_:with:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/override(_:with:)-1ce4h)|Overwrites the output of a specific atom or all atoms of the given type with the fixed value.|
-|[waitForUpdate(timeout:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/waitforupdate(timeout:))|Waits until any of atoms watched through this context is updated.|
+|[waitForUpdate(timeout:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/waitforupdate(timeout:))|Waits until any of the atoms watched through this context have been updated.|
+|[wait(for:timeout:until:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/wait(for:timeout:until:))|Waits for the given atom until it will be a certain state.|
 |[onUpdate](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/onupdate)|Sets a closure that notifies there has been an update to one of the atoms.|
 
 <details><summary><code>📖 Expand to see example</code></summary>

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -99,7 +99,7 @@ public struct AtomTestContext: AtomWatchableContext {
     public func wait<Node: Atom>(
         for atom: Node,
         timeout duration: TimeInterval? = nil,
-        until predicate: @MainActor @escaping (Node.Loader.Value) -> Bool
+        until predicate: @escaping (Node.Loader.Value) -> Bool
     ) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
             let updates = state.makeUpdateStream()

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -23,7 +23,7 @@ public struct AtomTestContext: AtomWatchableContext {
         nonmutating set { state.onUpdate = newValue }
     }
 
-    /// Waits until any of the atoms watched through this context have been updated for up to the
+    /// Waits until any of the atoms watched through this context have been updated up to the
     /// specified timeout, and then returns a boolean value indicating whether an update is done.
     ///
     /// ```swift

--- a/Sources/Atoms/Core/TaskExtensions.swift
+++ b/Sources/Atoms/Core/TaskExtensions.swift
@@ -1,0 +1,5 @@
+internal extension Task where Success == Never, Failure == Never {
+    static func sleep(seconds duration: Double) async throws {
+        try await sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+    }
+}

--- a/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
@@ -16,7 +16,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         do {
             // Value
             pipe.continuation.yield(0)
-            await context.waitForUpdate()
+            await context.wait(for: atom, until: \.isSuccess)
 
             XCTAssertEqual(context.watch(atom).value, 0)
         }
@@ -24,7 +24,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         do {
             // Failure
             pipe.continuation.finish(throwing: URLError(.badURL))
-            await context.waitForUpdate()
+            await context.wait(for: atom, until: \.isFailure)
 
             XCTAssertEqual(context.watch(atom).error as? URLError, URLError(.badURL))
         }

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -20,7 +20,7 @@ final class PublisherAtomTests: XCTestCase {
             // Value
             subject.send(0)
 
-            await context.waitForUpdate()
+            await context.wait(for: atom, until: \.isSuccess)
             XCTAssertEqual(context.watch(atom), .success(0))
         }
 
@@ -28,7 +28,7 @@ final class PublisherAtomTests: XCTestCase {
             // Error
             subject.send(completion: .failure(URLError(.badURL)))
 
-            await context.waitForUpdate()
+            await context.wait(for: atom, until: \.isFailure)
             XCTAssertEqual(context.watch(atom), .failure(URLError(.badURL)))
         }
 

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -50,6 +50,44 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertFalse(didUpdate1)
     }
 
+    func testWaitUntil() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let context = AtomTestContext()
+
+        context.watch(atom)
+
+        for i in 0..<3 {
+            Task {
+                try? await Task.sleep(seconds: Double(i))
+                context[atom] += 1
+            }
+        }
+
+        let didUpdate0 = await context.wait {
+            context.read(atom) == 0
+        }
+
+        XCTAssertFalse(didUpdate0)
+
+        let didUpdate1 = await context.wait {
+            context.read(atom) == 3
+        }
+
+        XCTAssertTrue(didUpdate1)
+
+        let didUpdate2 = await context.wait(timeout: 1) {
+            context.read(atom) == 100
+        }
+
+        XCTAssertFalse(didUpdate2)
+
+        let didUpdate3 = await context.wait {
+            context.read(atom) == 3
+        }
+
+        XCTAssertFalse(didUpdate3)
+    }
+
     func testOverride() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -50,7 +50,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertFalse(didUpdate1)
     }
 
-    func testWaitUntil() async {
+    func testWaitFor() async {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
@@ -63,26 +63,26 @@ final class AtomTestContextTests: XCTestCase {
             }
         }
 
-        let didUpdate0 = await context.wait {
-            context.read(atom) == 0
+        let didUpdate0 = await context.wait(for: atom) {
+            $0 == 0
         }
 
         XCTAssertFalse(didUpdate0)
 
-        let didUpdate1 = await context.wait {
-            context.read(atom) == 3
+        let didUpdate1 = await context.wait(for: atom) {
+            $0 == 3
         }
 
         XCTAssertTrue(didUpdate1)
 
-        let didUpdate2 = await context.wait(timeout: 1) {
-            context.read(atom) == 100
+        let didUpdate2 = await context.wait(for: atom, timeout: 1) {
+            $0 == 100
         }
 
         XCTAssertFalse(didUpdate2)
 
-        let didUpdate3 = await context.wait {
-            context.read(atom) == 3
+        let didUpdate3 = await context.wait(for: atom) {
+            $0 == 3
         }
 
         XCTAssertFalse(didUpdate3)

--- a/Tests/AtomsTests/Core/Loader/AtomLoaderContextTests.swift
+++ b/Tests/AtomsTests/Core/Loader/AtomLoaderContextTests.swift
@@ -72,7 +72,7 @@ final class AtomLoaderContextTests: XCTestCase {
         ) { _, _ in }
 
         await context.transaction { _ in
-            try? await Task.sleep(nanoseconds: 0)
+            try? await Task.sleep(seconds: 0)
         }
 
         XCTAssertTrue(isCommitted)

--- a/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
@@ -6,14 +6,14 @@ import XCTest
 @MainActor
 final class TaskPhaseModifierTests: XCTestCase {
     func testPhase() async {
-        let atom = TestTaskAtom(value: 0)
+        let atom = TestTaskAtom(value: 0).phase
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom.phase), .suspending)
+        XCTAssertEqual(context.watch(atom), .suspending)
 
-        await context.waitForUpdate(timeout: 1)
+        await context.wait(for: atom, until: \.isSuccess)
 
-        XCTAssertEqual(context.watch(atom.phase), .success(0))
+        XCTAssertEqual(context.watch(atom), .success(0))
     }
 
     func testKey() {


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Adds a new function in AtomTestContext that can wait for the given atom to be in a certain state.

## Motivation and Context

The existing `AtomTestContext.waitForUpdate` was insufficient in case your test case needs to wait for an atom to be in a certain state but doesn't want to know how many updates are required.
The new method also solves the issue of the flaky test case where async functions are completed synchronously or executed asynchronously since it can determine when to resume suspending on a state basis.

## Impact on Existing Code

N/A
