### PR TITLE
Add lookup function to AtomTestContext

### DIFF
--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -188,6 +188,15 @@ internal struct StoreContext {
     }
 
     @usableFromInline
+    func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
+        let override = lookupOverride(of: atom)
+        let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)
+        let cache = lookupCache(of: atom, for: key)
+
+        return cache?.value
+    }
+
+    @usableFromInline
     func unwatch(_ atom: some Atom, container: SubscriptionContainer.Wrapper) {
         let override = lookupOverride(of: atom)
         let key = AtomKey(atom, overrideScopeKey: override?.scopeKey)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Add a new testing function `lookup` to AtomTestContext such that testing code can access already cached value without any side effects.
It is convenient when you want to print current the state without starting a side-effect-full process initiated by `read` or `watch`.

## Motivation and Context

`read` was supposed to be enough for dumping the current state of an atom but it actually initiates a side-effect-full process for a moment while it will be terminated immediately.
So, this PR is to add a useful, side-effect-free function for applications such as adding a print to debug the current state without changing the testing result.

## Impact on Existing Code

`AtomTestContext.wait(for:timeout:until:)` started using the new `lookup` instead of `read` to check the current state to determine that the state is matched with the expected condition.
This is a change to eliminate a side effect that was unnecessary while waiting for a state change in that method, and there are no counterintuitive negative effects from it.
