### PR TITLE
Add lookup method to all contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ Context is a structure for using and interacting with atom values from views or 
 |[state](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomwatchablecontext/state(_:))|Gets a binding to the atom state.|
 |[refresh](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/refresh(_:))|Reset an atom and await until asynchronous operation is complete.|
 |[reset](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/reset(_:))|Reset an atom to the default value or a first output.|
+|[lookup](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/lookup(_:))|Lookup an already cached atom value.|
 
 There are the following types context as different contextual environments.  
 The APIs described in each section below are their own specific functionality depending on the environment in which it is used, in addition to the above common APIs.  

--- a/Sources/Atoms/Context/AtomContext.swift
+++ b/Sources/Atoms/Context/AtomContext.swift
@@ -99,6 +99,23 @@ public protocol AtomContext {
     ///
     /// - Parameter atom: An atom that associates the value.
     func reset(_ atom: some Atom)
+
+    /// Returns the already cached value associated with a given atom without side effects.
+    ///
+    /// This method returns the value only when it is already cached, otherwise, it returns `nil`.
+    /// It has no side effects such as the creation of new values or watching to atoms.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// if let text = context.lookup(TextAtom()) {
+    ///     print(text)  // Prints the cached value associated with `TextAtom`.
+    /// }
+    /// ```
+    ///
+    /// - Parameter atom: An atom that associates the value.
+    ///
+    /// - Returns: The already cached value associated with the given atom.
+    func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value?
 }
 
 public extension AtomContext {

--- a/Sources/Atoms/Context/AtomTransactionContext.swift
+++ b/Sources/Atoms/Context/AtomTransactionContext.swift
@@ -154,4 +154,23 @@ public struct AtomTransactionContext<Coordinator>: AtomWatchableContext {
     public func watch<Node: Atom>(_ atom: Node) -> Node.Loader.Value {
         _store.watch(atom, in: _transaction)
     }
+
+    /// Returns the already cached value associated with a given atom without side effects.
+    ///
+    /// This method returns the value only when it is already cached, otherwise, it returns `nil`.
+    /// It has no side effects such as the creation of new values or watching to atoms.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// if let text = context.lookup(TextAtom()) {
+    ///     print(text)  // Prints the cached value associated with `TextAtom`.
+    /// }
+    /// ```
+    ///
+    /// - Parameter atom: An atom that associates the value.
+    ///
+    /// - Returns: The already cached value associated with the given atom.
+    public func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
+        _store.lookup(atom)
+    }
 }

--- a/Sources/Atoms/Context/AtomUpdatedContext.swift
+++ b/Sources/Atoms/Context/AtomUpdatedContext.swift
@@ -122,4 +122,23 @@ public struct AtomUpdatedContext<Coordinator>: AtomContext {
     public func reset(_ atom: some Atom) {
         _store.reset(atom)
     }
+
+    /// Returns the already cached value associated with a given atom without side effects.
+    ///
+    /// This method returns the value only when it is already cached, otherwise, it returns `nil`.
+    /// It has no side effects such as the creation of new values or watching to atoms.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// if let text = context.lookup(TextAtom()) {
+    ///     print(text)  // Prints the cached value associated with `TextAtom`.
+    /// }
+    /// ```
+    ///
+    /// - Parameter atom: An atom that associates the value.
+    ///
+    /// - Returns: The already cached value associated with the given atom.
+    public func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
+        _store.lookup(atom)
+    }
 }

--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -159,6 +159,25 @@ public struct AtomViewContext: AtomWatchableContext {
         )
     }
 
+    /// Returns the already cached value associated with a given atom without side effects.
+    ///
+    /// This method returns the value only when it is already cached, otherwise, it returns `nil`.
+    /// It has no side effects such as the creation of new values or watching to atoms.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// if let text = context.lookup(TextAtom()) {
+    ///     print(text)  // Prints the cached value associated with `TextAtom`.
+    /// }
+    /// ```
+    ///
+    /// - Parameter atom: An atom that associates the value.
+    ///
+    /// - Returns: The already cached value associated with the given atom.
+    public func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
+        _store.lookup(atom)
+    }
+
     /// For debugging, takes a snapshot that captures specific set of values of atoms.
     ///
     /// This method captures all atom values and dependencies currently in use somewhere in

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -69,4 +69,17 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(store.graph.children, [AtomKey(atom1): [AtomKey(atom0)]])
         XCTAssertEqual(store.graph.dependencies, [AtomKey(atom0): [AtomKey(atom1)]])
     }
+
+    func testLookup() {
+        let atom = TestValueAtom(value: 100)
+        let store = AtomStore()
+        let transaction = Transaction(key: AtomKey(atom)) {}
+        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+
+        XCTAssertNil(context.lookup(atom))
+
+        context.watch(atom)
+
+        XCTAssertEqual(context.lookup(atom), 100)
+    }
 }

--- a/Tests/AtomsTests/Context/AtomUpdatedContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomUpdatedContextTests.swift
@@ -55,4 +55,18 @@ final class AtomUpdatedContextTests: XCTestCase {
 
         XCTAssertEqual(context.read(dependency), 0)
     }
+
+    func testLookup() {
+        let atom = TestValueAtom(value: 100)
+        let store = AtomStore()
+        let storeContext = StoreContext(store)
+        let context = AtomUpdatedContext(store: storeContext, coordinator: ())
+        let transaction = Transaction(key: AtomKey(atom)) {}
+
+        XCTAssertNil(context.lookup(atom))
+
+        _ = storeContext.watch(atom, in: transaction)
+
+        XCTAssertEqual(context.lookup(atom), 100)
+    }
 }

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -89,6 +89,23 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), 200)
     }
 
+    func testLookup() {
+        let atom = TestValueAtom(value: 100)
+        let store = AtomStore()
+        let container = SubscriptionContainer()
+        let context = AtomViewContext(
+            store: StoreContext(store),
+            container: container.wrapper,
+            notifyUpdate: {}
+        )
+
+        XCTAssertNil(context.lookup(atom))
+
+        context.watch(atom)
+
+        XCTAssertEqual(context.lookup(atom), 100)
+    }
+
     func testSnapshot() {
         let store = AtomStore()
         let container = SubscriptionContainer()


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Add `lookup(_:)` to all context types to support an ability to find an already cached atom value.
