### PR TITLE
Add ability to refresh modified atoms

### DIFF
--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Atoms/SearchAtoms.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Atoms/SearchAtoms.swift
@@ -7,19 +7,15 @@ struct SearchQueryAtom: StateAtom, Hashable {
     }
 }
 
-struct SearchMoviesAtom: PublisherAtom, Hashable {
-    func publisher(context: Context) -> AnyPublisher<[Movie], Error> {
+struct SearchMoviesAtom: ThrowingTaskAtom, Hashable {
+    func value(context: Context) async throws -> [Movie] {
         let api = context.watch(APIClientAtom())
         let query = context.watch(SearchQueryAtom())
 
-        if query.isEmpty {
-            return Just([])
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
+        guard !query.isEmpty else {
+            return []
         }
 
-        return api.getSearchMovies(query: query)
-            .map(\.results)
-            .eraseToAnyPublisher()
+        return try await api.getSearchMovies(query: query).results
     }
 }

--- a/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/SearchScreen.swift
+++ b/Examples/Packages/iOS/Sources/ExampleMovieDB/Screens/SearchScreen.swift
@@ -2,7 +2,7 @@ import Atoms
 import SwiftUI
 
 struct SearchScreen: View {
-    @Watch(SearchMoviesAtom())
+    @Watch(SearchMoviesAtom().phase)
     var movies
 
     @ViewContext
@@ -36,7 +36,7 @@ struct SearchScreen: View {
         .navigationTitle("Search Results")
         .listStyle(.insetGrouped)
         .refreshable {
-            await context.refresh(SearchMoviesAtom())
+            await context.refresh(SearchMoviesAtom().phase)
         }
         .sheet(item: $selectedMovie) { movie in
             DetailScreen(movie: movie)

--- a/Sources/Atoms/Core/Loader/AsyncSequenceAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/AsyncSequenceAtomLoader.swift
@@ -40,7 +40,7 @@ public struct AsyncSequenceAtomLoader<Node: AsyncSequenceAtom>: RefreshableAtomL
         value
     }
 
-    /// Refreshes and awaits for the passed value to be finished to yield values
+    /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
     public func refresh(context: Context) async -> Value {
         let sequence = context.transaction(atom.sequence)
@@ -70,7 +70,7 @@ public struct AsyncSequenceAtomLoader<Node: AsyncSequenceAtom>: RefreshableAtomL
         }
     }
 
-    /// Refreshes and awaits for the passed value to be finished to yield values
+    /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
     public func refreshOverridden(value: Value, context: Context) async -> Value {
         value

--- a/Sources/Atoms/Core/Loader/AsyncSequenceAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/AsyncSequenceAtomLoader.swift
@@ -72,7 +72,7 @@ public struct AsyncSequenceAtomLoader<Node: AsyncSequenceAtom>: RefreshableAtomL
 
     /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
-    public func refreshOverridden(value: Value, context: Context) async -> Value {
+    public func refresh(overridden value: Value, context: Context) async -> Value {
         value
     }
 }

--- a/Sources/Atoms/Core/Loader/AtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/AtomLoader.swift
@@ -30,10 +30,10 @@ public extension AtomLoader {
 /// A loader protocol that represents an actual implementation of the corresponding atom
 /// that provides values asynchronously.
 public protocol RefreshableAtomLoader: AtomLoader {
-    /// Refreshes and awaits until the asynchronous is finished and returns a final value.
+    /// Refreshes and waits until the asynchronous process is finished and returns a final value.
     func refresh(context: Context) async -> Value
 
-    /// Refreshes and awaits for the passed value to be finished to yield values
+    /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
     func refreshOverridden(value: Value, context: Context) async -> Value
 }

--- a/Sources/Atoms/Core/Loader/AtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/AtomLoader.swift
@@ -35,7 +35,7 @@ public protocol RefreshableAtomLoader: AtomLoader {
 
     /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
-    func refreshOverridden(value: Value, context: Context) async -> Value
+    func refresh(overridden value: Value, context: Context) async -> Value
 }
 
 /// A loader protocol that represents an actual implementation of the corresponding atom

--- a/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
@@ -44,7 +44,7 @@ extension ModifiedAtomLoader: RefreshableAtomLoader where Node.Loader: Refreshab
 
     /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
-    public func refreshOverridden(value: Value, context: Context) async -> Value {
+    public func refresh(overridden value: Value, context: Context) async -> Value {
         await modifier.refresh(overridden: value, context: context.modifierContext)
     }
 }

--- a/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
@@ -31,3 +31,17 @@ public struct ModifiedAtomLoader<Node: Atom, Modifier: AtomModifier>: AtomLoader
         modifier.shouldUpdate(newValue: newValue, oldValue: oldValue)
     }
 }
+
+extension ModifiedAtomLoader: RefreshableAtomLoader where Node.Loader: RefreshableAtomLoader, Modifier: RefreshableAtomModifier {
+    public func refresh(context: Context) async -> Value {
+        let value = await context.transaction { context in
+            await context.refresh(atom)
+            return context.watch(atom)
+        }
+        return await modifier.refresh(modifying: value, context: context.modifierContext)
+    }
+
+    public func refreshOverridden(value: Value, context: Context) async -> Value {
+        await modifier.refresh(overridden: value, context: context.modifierContext)
+    }
+}

--- a/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
@@ -33,6 +33,7 @@ public struct ModifiedAtomLoader<Node: Atom, Modifier: AtomModifier>: AtomLoader
 }
 
 extension ModifiedAtomLoader: RefreshableAtomLoader where Node.Loader: RefreshableAtomLoader, Modifier: RefreshableAtomModifier {
+    /// Refreshes and waits until the asynchronous process is finished and returns a final value.
     public func refresh(context: Context) async -> Value {
         let value = await context.transaction { context in
             await context.refresh(atom)
@@ -41,6 +42,8 @@ extension ModifiedAtomLoader: RefreshableAtomLoader where Node.Loader: Refreshab
         return await modifier.refresh(modifying: value, context: context.modifierContext)
     }
 
+    /// Refreshes and waits for the passed value to finish outputting values
+    /// and returns a final value.
     public func refreshOverridden(value: Value, context: Context) async -> Value {
         await modifier.refresh(overridden: value, context: context.modifierContext)
     }

--- a/Sources/Atoms/Core/Loader/PublisherAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/PublisherAtomLoader.swift
@@ -35,7 +35,7 @@ public struct PublisherAtomLoader<Node: PublisherAtom>: RefreshableAtomLoader {
         value
     }
 
-    /// Refreshes and awaits until the asynchronous is finished and returns a final value.
+    /// Refreshes and waits until the asynchronous process is finished and returns a final value.
     public func refresh(context: Context) async -> Value {
         let results = context.transaction(atom.publisher).results
         let task = Task {
@@ -59,7 +59,7 @@ public struct PublisherAtomLoader<Node: PublisherAtom>: RefreshableAtomLoader {
         }
     }
 
-    /// Refreshes and awaits for the passed value to be finished to yield values
+    /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
     public func refreshOverridden(value: Value, context: Context) async -> Value {
         value

--- a/Sources/Atoms/Core/Loader/PublisherAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/PublisherAtomLoader.swift
@@ -61,7 +61,7 @@ public struct PublisherAtomLoader<Node: PublisherAtom>: RefreshableAtomLoader {
 
     /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
-    public func refreshOverridden(value: Value, context: Context) async -> Value {
+    public func refresh(overridden value: Value, context: Context) async -> Value {
         value
     }
 }

--- a/Sources/Atoms/Core/Loader/TaskAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/TaskAtomLoader.swift
@@ -37,12 +37,12 @@ public struct TaskAtomLoader<Node: TaskAtom>: AsyncAtomLoader {
         let task = Task {
             await context.transaction(atom.value)
         }
-        return await refreshOverridden(value: task, context: context)
+        return await refresh(overridden: task, context: context)
     }
 
     /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
-    public func refreshOverridden(value: Value, context: Context) async -> Value {
+    public func refresh(overridden value: Value, context: Context) async -> Value {
         context.addTermination(value.cancel)
 
         return await withTaskCancellationHandler {

--- a/Sources/Atoms/Core/Loader/TaskAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/TaskAtomLoader.swift
@@ -32,7 +32,7 @@ public struct TaskAtomLoader<Node: TaskAtom>: AsyncAtomLoader {
         return value
     }
 
-    /// Refreshes and awaits until the asynchronous is finished and returns a final value.
+    /// Refreshes and waits until the asynchronous process is finished and returns a final value.
     public func refresh(context: Context) async -> Value {
         let task = Task {
             await context.transaction(atom.value)
@@ -40,7 +40,7 @@ public struct TaskAtomLoader<Node: TaskAtom>: AsyncAtomLoader {
         return await refreshOverridden(value: task, context: context)
     }
 
-    /// Refreshes and awaits for the passed value to be finished to yield values
+    /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
     public func refreshOverridden(value: Value, context: Context) async -> Value {
         context.addTermination(value.cancel)

--- a/Sources/Atoms/Core/Loader/ThrowingTaskAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ThrowingTaskAtomLoader.swift
@@ -37,12 +37,12 @@ public struct ThrowingTaskAtomLoader<Node: ThrowingTaskAtom>: AsyncAtomLoader {
         let task = Task {
             try await context.transaction(atom.value)
         }
-        return await refreshOverridden(value: task, context: context)
+        return await refresh(overridden: task, context: context)
     }
 
     /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
-    public func refreshOverridden(value: Value, context: Context) async -> Value {
+    public func refresh(overridden value: Value, context: Context) async -> Value {
         context.addTermination(value.cancel)
 
         return await withTaskCancellationHandler {

--- a/Sources/Atoms/Core/Loader/ThrowingTaskAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ThrowingTaskAtomLoader.swift
@@ -32,7 +32,7 @@ public struct ThrowingTaskAtomLoader<Node: ThrowingTaskAtom>: AsyncAtomLoader {
         return value
     }
 
-    /// Refreshes and awaits until the asynchronous is finished and returns a final value.
+    /// Refreshes and waits until the asynchronous process is finished and returns a final value.
     public func refresh(context: Context) async -> Value {
         let task = Task {
             try await context.transaction(atom.value)
@@ -40,7 +40,7 @@ public struct ThrowingTaskAtomLoader<Node: ThrowingTaskAtom>: AsyncAtomLoader {
         return await refreshOverridden(value: task, context: context)
     }
 
-    /// Refreshes and awaits for the passed value to be finished to yield values
+    /// Refreshes and waits for the passed value to finish outputting values
     /// and returns a final value.
     public func refreshOverridden(value: Value, context: Context) async -> Value {
         context.addTermination(value.cancel)

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -148,7 +148,7 @@ internal struct StoreContext {
         let value: Node.Loader.Value
 
         if let override {
-            value = await atom._loader.refreshOverridden(value: override.value(atom), context: context)
+            value = await atom._loader.refresh(overridden: override.value(atom), context: context)
         }
         else {
             value = await atom._loader.refresh(context: context)

--- a/Sources/Atoms/Modifier/AtomModifier.swift
+++ b/Sources/Atoms/Modifier/AtomModifier.swift
@@ -8,8 +8,7 @@ public extension Atom {
     }
 }
 
-/// A modifier that you apply to an atom, producing a  different version
-/// of the original value.
+/// A modifier that you apply to an atom, producing a new value modified from the original value.
 public protocol AtomModifier {
     /// A type representing the stable identity of this modifier.
     associatedtype Key: Hashable
@@ -46,9 +45,16 @@ public extension AtomModifier {
     }
 }
 
+/// A modifier that you apply to an atom, producing a new value modified from the original value,
+/// and waits until it has finished outputting values.
 public protocol RefreshableAtomModifier: AtomModifier {
+    /// Refreshes and waits for the passed original value to finish outputting values
+    /// and returns a final value.
     @MainActor
     func refresh(modifying value: BaseValue, context: Context) async -> Value
+
+    /// Refreshes and waits for the passed value to finish outputting values
+    /// and returns a final value.
     @MainActor
     func refresh(overridden value: Value, context: Context) async -> Value
 }

--- a/Sources/Atoms/Modifier/AtomModifier.swift
+++ b/Sources/Atoms/Modifier/AtomModifier.swift
@@ -45,3 +45,10 @@ public extension AtomModifier {
         true
     }
 }
+
+public protocol RefreshableAtomModifier: AtomModifier {
+    @MainActor
+    func refresh(modifying value: BaseValue, context: Context) async -> Value
+    @MainActor
+    func refresh(overridden value: Value, context: Context) async -> Value
+}

--- a/Sources/Atoms/Modifier/TaskPhaseModifier.swift
+++ b/Sources/Atoms/Modifier/TaskPhaseModifier.swift
@@ -70,6 +70,8 @@ public struct TaskPhaseModifier<Success, Failure: Error>: RefreshableAtomModifie
         value
     }
 
+    /// Refreshes and waits for the passed original value to finish outputting values
+    /// and returns a final value.
     public func refresh(modifying value: BaseValue, context: Context) async -> Value {
         context.addTermination(value.cancel)
 
@@ -80,6 +82,8 @@ public struct TaskPhaseModifier<Success, Failure: Error>: RefreshableAtomModifie
         }
     }
 
+    /// Refreshes and waits for the passed value to finish outputting values
+    /// and returns a final value.
     public func refresh(overridden value: Value, context: Context) async -> Value {
         value
     }

--- a/Sources/Atoms/Modifier/TaskPhaseModifier.swift
+++ b/Sources/Atoms/Modifier/TaskPhaseModifier.swift
@@ -35,7 +35,7 @@ public extension Atom where Loader: AsyncAtomLoader {
 /// representation ``AsyncPhase`` that changes overtime.
 ///
 /// Use ``Atom/phase`` instead of using this modifier directly.
-public struct TaskPhaseModifier<Success, Failure: Error>: AtomModifier {
+public struct TaskPhaseModifier<Success, Failure: Error>: RefreshableAtomModifier {
     /// A type of base value to be modified.
     public typealias BaseValue = Task<Success, Failure>
 
@@ -67,6 +67,20 @@ public struct TaskPhaseModifier<Success, Failure: Error>: AtomModifier {
 
     /// Associates given value and handle updates and cancellations.
     public func associateOverridden(value: Value, context: Context) -> Value {
+        value
+    }
+
+    public func refresh(modifying value: BaseValue, context: Context) async -> Value {
+        context.addTermination(value.cancel)
+
+        return await withTaskCancellationHandler {
+            await AsyncPhase(value.result)
+        } onCancel: {
+            value.cancel()
+        }
+    }
+
+    public func refresh(overridden value: Value, context: Context) async -> Value {
         value
     }
 }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -221,10 +221,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertEqual(store.graph.children, [dependency0Key: [key]])
         XCTAssertEqual((store.state.caches[dependency0Key] as? AtomCache<TestStateAtom<Int>>)?.value, 0)
         XCTAssertNotNil(store.state.states[dependency0Key])
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[dependency0Key: 0]]
-        )
+        XCTAssertTrue(snapshots.flatMap(\.caches).isEmpty)
 
         snapshots.removeAll()
         transaction.terminate()

--- a/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
@@ -54,15 +54,14 @@ final class TaskPhaseModifierTests: XCTestCase {
     }
 
     func testRefresh() async {
-        let parentAtom = TestTaskAtom(value: 0)
-        let atom = parentAtom.phase
+        let atom = TestTaskAtom(value: 0).phase
         let context = AtomTestContext()
 
         XCTAssertEqual(context.watch(atom), .suspending)
 
-        await context.wait(for: atom, until: \.isSuccess)
-        await context.refresh(parentAtom)
+        let phase = await context.refresh(atom)
 
+        XCTAssertEqual(phase, .success(0))
         XCTAssertEqual(context.watch(atom), .success(0))
     }
 }

--- a/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
@@ -52,4 +52,17 @@ final class TaskPhaseModifierTests: XCTestCase {
 
         XCTAssertEqual(phase, .success(100))
     }
+
+    func testRefresh() async {
+        let parentAtom = TestTaskAtom(value: 0)
+        let atom = parentAtom.phase
+        let context = AtomTestContext()
+
+        XCTAssertEqual(context.watch(atom), .suspending)
+
+        await context.wait(for: atom, until: \.isSuccess)
+        await context.refresh(parentAtom)
+
+        XCTAssertEqual(context.watch(atom), .success(0))
+    }
 }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Add the ability to refresh modified atoms.
Now TaskAtom/ThrowingTaskAtom modified by `.phase` modifier can be refresh.
