### PR TITLE
Fix Atoms link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - [Basic Tutorial](#basic-tutorial)
 - [Guides](#guides)
   - [AtomRoot](#atomroot)
-  - [Atoms](#atoms)
+  - [Atoms](#atoms-1)
   - [Modifiers](#modifiers)
   - [Attributes](#attributes)
   - [Property Wrappers](#property-wrappers)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [ ] Chore

## Description
Sorry for nitpicking PR. Link in for Atoms in README was set to README's header, not section's header 

## Motivation and Context
Link info on Atoms to correct section in README

## Impact on Existing Code
No impact