### PR TITLE
Fix Xcode15.3 (Swift5.10) warning/Swift 6 error: Main actor-isolated class 'XXXTests' has different actor isolation from nonisolated superclass 'XCTestCase'; this is an error in Swift 6

### DIFF
--- a/Examples/Packages/CrossPlatform/Tests/ExampleCounterTests/ExampleCounterTests.swift
+++ b/Examples/Packages/CrossPlatform/Tests/ExampleCounterTests/ExampleCounterTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import ExampleCounter
 
-@MainActor
 final class ExampleCounterTests: XCTestCase {
+    @MainActor
     func testCounterAtom() {
         let context = AtomTestContext()
         let atom = CounterAtom()

--- a/Examples/Packages/CrossPlatform/Tests/ExampleTodoTests/ExampleTodoTests.swift
+++ b/Examples/Packages/CrossPlatform/Tests/ExampleTodoTests/ExampleTodoTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 @testable import ExampleTodo
 
-@MainActor
 final class ExampleTodoTests: XCTestCase {
     let completedTodos = [
         Todo(
@@ -30,6 +29,7 @@ final class ExampleTodoTests: XCTestCase {
         completedTodos + uncompleteTodos
     }
 
+    @MainActor
     func testFilteredTodosAtom() {
         let context = AtomTestContext()
         let atom = FilteredTodosAtom()
@@ -53,6 +53,7 @@ final class ExampleTodoTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), uncompleteTodos)
     }
 
+    @MainActor
     func testStatsAtom() {
         let context = AtomTestContext()
         let atom = StatsAtom()

--- a/Examples/Packages/iOS/Tests/ExampleMapTests/ExampleMapTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMapTests/ExampleMapTests.swift
@@ -4,8 +4,8 @@ import XCTest
 
 @testable import ExampleMap
 
-@MainActor
 final class ExampleMapTests: XCTestCase {
+    @MainActor
     func testLocationObserverAtom() {
         let atom = LocationObserverAtom()
         let context = AtomTestContext()
@@ -25,6 +25,7 @@ final class ExampleMapTests: XCTestCase {
         XCTAssertFalse(manager.isUpdatingLocation)
     }
 
+    @MainActor
     func testCoordinateAtom() {
         let atom = CoordinateAtom()
         let context = AtomTestContext()
@@ -40,6 +41,7 @@ final class ExampleMapTests: XCTestCase {
         XCTAssertEqual(context.watch(atom)?.longitude, 2)
     }
 
+    @MainActor
     func testAuthorizationStatusAtom() async {
         let atom = AuthorizationStatusAtom()
         let manager = MockLocationManager()

--- a/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import ExampleMovieDB
 
-@MainActor
 final class ExampleMovieDBTests: XCTestCase {
+    @MainActor
     func testImageAtom() async {
         let apiClient = MockAPIClient()
         let atom = ImageAtom(path: "", size: .original)
@@ -29,6 +29,7 @@ final class ExampleMovieDBTests: XCTestCase {
         XCTAssertEqual(failurePhase.error as? URLError, error)
     }
 
+    @MainActor
     func testMovieLoader() async {
         let apiClient = MockAPIClient()
         let atom = MovieLoaderAtom()
@@ -61,6 +62,7 @@ final class ExampleMovieDBTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testMyListAtom() {
         let atom = MyListAtom()
         let context = AtomTestContext()
@@ -80,6 +82,7 @@ final class ExampleMovieDBTests: XCTestCase {
         XCTAssertEqual(context.watch(atom).movies, [.stub(id: 1)])
     }
 
+    @MainActor
     func testIsInMyListAtom() {
         let context = AtomTestContext()
 
@@ -89,6 +92,7 @@ final class ExampleMovieDBTests: XCTestCase {
         XCTAssertFalse(context.watch(IsInMyListAtom(movie: .stub(id: 1))))
     }
 
+    @MainActor
     func testCastsAtom() async {
         let apiClient = MockAPIClient()
         let atom = CastsAtom(movieID: 0)
@@ -113,6 +117,7 @@ final class ExampleMovieDBTests: XCTestCase {
         XCTAssertEqual(failurePhase.error as? URLError, error)
     }
 
+    @MainActor
     func testSearchMoviesAtom() async throws {
         let apiClient = MockAPIClient()
         let atom = SearchMoviesAtom()

--- a/Examples/Packages/iOS/Tests/ExampleTimeTravelTests/ExampleTimeTravelTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleTimeTravelTests/ExampleTimeTravelTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import ExampleTimeTravel
 
-@MainActor
 final class ExampleTimeTravelTests: XCTestCase {
+    @MainActor
     func testTextAtom() {
         let context = AtomTestContext()
         let atom = InputStateAtom()

--- a/Examples/Packages/iOS/Tests/ExampleVoiceMemoTests/ExampleVoiceMemoTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleVoiceMemoTests/ExampleVoiceMemoTests.swift
@@ -5,8 +5,8 @@ import XCTest
 
 @testable import ExampleVoiceMemo
 
-@MainActor
 final class ExampleVoiceMemoTests: XCTestCase {
+    @MainActor
     func testIsRecordingAtom() {
         let context = AtomTestContext()
         let atom = IsRecordingAtom()
@@ -18,6 +18,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
         XCTAssertTrue(context.read(atom))
     }
 
+    @MainActor
     func testRecordingDataAtom() {
         let context = AtomTestContext()
         let atom = RecordingDataAtom()
@@ -55,6 +56,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
         XCTAssertTrue(context.watch(IsRecordingFailedAtom()))
     }
 
+    @MainActor
     func testRecordingElapsedTimeAtom() async {
         let context = AtomTestContext()
         let atom = RecordingElapsedTimeAtom()
@@ -79,6 +81,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), .success(10))
     }
 
+    @MainActor
     func testToggleRecording() {
         let context = AtomTestContext()
         let actions = VoiceMemoActions(context: context)
@@ -125,6 +128,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
         XCTAssertNil(context.watch(RecordingDataAtom()))
     }
 
+    @MainActor
     func testDelete() {
         let context = AtomTestContext()
         let actions = VoiceMemoActions(context: context)
@@ -142,6 +146,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
         XCTAssertFalse(context.watch(IsPlayingAtom(voiceMemo: voiceMemo)))
     }
 
+    @MainActor
     func testIsPlayingAtom() {
         let context = AtomTestContext()
         let audioPlayer = MockAudioPlayer()
@@ -167,6 +172,7 @@ final class ExampleVoiceMemoTests: XCTestCase {
         XCTAssertTrue(context.watch(IsPlaybackFailedAtom()))
     }
 
+    @MainActor
     func testPlayingElapsedTimeAtom() async {
         let context = AtomTestContext()
         let voiceMemo = VoiceMemo.stub()

--- a/README.md
+++ b/README.md
@@ -1240,7 +1240,7 @@ In order to fully test your app, this library guarantees the following principle
 
 In the test case, you first create an `AtomTestContext` instance that behaves similarly to other context types. The context allows for flexible reproduction of expected scenarios for testing using the control functions described in the [Context](#context) section.  
 In addition, it's able to replace the atom value with test-friendly dependencies with `override` function. It helps you to write a reproducible & stable testing.  
-Since atom needs to be used from the main actor to guarantee thread-safety, `XCTestCase` class that tests atoms should have `@MainActor` attribute.
+Since atom needs to be used from the main actor to guarantee thread-safety, functions that tests atoms should have `@MainActor` attribute.
 
 <details><summary>Click to expand the classes to be tested</summary>
 
@@ -1293,8 +1293,8 @@ struct FetchBookAtom: ThrowingTaskAtom, Hashable {
 
 ```swift
 
-@MainActor
 class FetchBookTests: XCTestCase {
+    @MainActor
     func testFetch() async throws {
         let context = AtomTestContext()
         let api = MockAPIClient()

--- a/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AsyncSequenceAtomTests: XCTestCase {
+    @MainActor
     func testValue() async {
         let pipe = AsyncThrowingStreamPipe<Int>()
         let atom = TestAsyncSequenceAtom { pipe.stream }
@@ -67,6 +67,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testRefresh() async {
         let pipe = AsyncThrowingStreamPipe<Int>()
         let atom = TestAsyncSequenceAtom { pipe.stream }
@@ -130,6 +131,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testUpdated() async {
         let pipe = AsyncThrowingStreamPipe<Int>()
         var updatedValues = [Pair<Int?>]()

--- a/Tests/AtomsTests/Atom/ModifiedAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ModifiedAtomTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class ModifiedAtomTests: XCTestCase {
+    @MainActor
     func testKey() {
         let base = TestAtom(value: 0)
         let modifier = SelectModifier<Int, String>(keyPath: \.description)
@@ -17,6 +17,7 @@ final class ModifiedAtomTests: XCTestCase {
         XCTAssertNotEqual(AnyHashable(atom.key).hashValue, AnyHashable(base.key).hashValue)
     }
 
+    @MainActor
     func testValue() async {
         let base = TestStateAtom(defaultValue: "test")
         let modifier = SelectModifier<String, Int>(keyPath: \.count)

--- a/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
@@ -2,7 +2,6 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class ObservableObjectAtomTests: XCTestCase {
     @MainActor
     final class TestObject: ObservableObject {
@@ -30,6 +29,7 @@ final class ObservableObjectAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test() async {
         let atom = TestAtom()
         let context = AtomTestContext()
@@ -112,6 +112,7 @@ final class ObservableObjectAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testUpdated() async {
         var updatedObjects = [TestObject]()
         let atom = TestAtom { object, _ in

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class PublisherAtomTests: XCTestCase {
+    @MainActor
     func testValue() async {
         let subject = ResettableSubject<Int, URLError>()
         let atom = TestPublisherAtom { subject }
@@ -66,6 +66,7 @@ final class PublisherAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testRefresh() async {
         let subject = ResettableSubject<Int, URLError>()
         let atom = TestPublisherAtom { subject }
@@ -129,6 +130,7 @@ final class PublisherAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testUpdated() async {
         let subject = ResettableSubject<Int, URLError>()
         var updatedValues = [Pair<Int?>]()

--- a/Tests/AtomsTests/Atom/StateAtomTests.swift
+++ b/Tests/AtomsTests/Atom/StateAtomTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class StateAtomTests: XCTestCase {
+    @MainActor
     func testValue() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -22,6 +22,7 @@ final class StateAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSet() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -33,6 +34,7 @@ final class StateAtomTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), 100)
     }
 
+    @MainActor
     func testSetOverride() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -46,6 +48,7 @@ final class StateAtomTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), 100)
     }
 
+    @MainActor
     func testDependency() async {
         struct Dependency1Atom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -81,6 +84,7 @@ final class StateAtomTests: XCTestCase {
         XCTAssertEqual(value2, 0)
     }
 
+    @MainActor
     func testUpdated() {
         var updatedValues = [Pair<Int>]()
         let atom = TestStateAtom(defaultValue: 0) { new, old in

--- a/Tests/AtomsTests/Atom/TaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/TaskAtomTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class TaskAtomTests: XCTestCase {
+    @MainActor
     func testValue() async {
         let atom = TestTaskAtom(value: 0)
         let context = AtomTestContext()
@@ -41,6 +41,7 @@ final class TaskAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testRefresh() async {
         var value = 0
         let atom = TestTaskAtom<Int> { value }
@@ -108,6 +109,7 @@ final class TaskAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testReleaseDependencies() async {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -142,6 +144,7 @@ final class TaskAtomTests: XCTestCase {
         XCTAssertEqual(dependencyValue, 0)
     }
 
+    @MainActor
     func testUpdated() {
         var updatedTaskHashValues = [Int]()
         let atom = TestTaskAtom {

--- a/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class ThrowingTaskAtomTests: XCTestCase {
+    @MainActor
     func test() async throws {
         var result = Result<Int, Error>.success(0)
         let atom = TestThrowingTaskAtom { result }
@@ -56,6 +56,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testRefresh() async throws {
         var result = Result<Int, Error>.success(0)
         let atom = TestThrowingTaskAtom { result }
@@ -123,6 +124,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testReleaseDependencies() async throws {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -157,6 +159,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
         XCTAssertEqual(dependencyValue, 0)
     }
 
+    @MainActor
     func testUpdated() {
         var updatedTaskHashValues = [Int]()
         let atom = TestThrowingTaskAtom {

--- a/Tests/AtomsTests/Atom/ValueAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ValueAtomTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class ValueAtomTests: XCTestCase {
+    @MainActor
     func testValue() {
         let atom = TestValueAtom(value: 0)
         let context = AtomTestContext()
@@ -23,6 +23,7 @@ final class ValueAtomTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testUpdated() async {
         var updatedValues = [Pair<Int>]()
         let atom = TestValueAtom(value: 0) { new, old in

--- a/Tests/AtomsTests/Context/AtomContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomContextTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomContextTests: XCTestCase {
+    @MainActor
     func testSubscript() {
         let atom = TestStateAtom(defaultValue: 0)
         let context: AtomWatchableContext = AtomTestContext()
@@ -15,6 +15,7 @@ final class AtomContextTests: XCTestCase {
         XCTAssertEqual(context[atom], 100)
     }
 
+    @MainActor
     func testState() {
         let atom = TestStateAtom(defaultValue: 0)
         let context: AtomWatchableContext = AtomTestContext()

--- a/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomCurrentContextTests: XCTestCase {
+    @MainActor
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
@@ -13,6 +13,7 @@ final class AtomCurrentContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 100)
     }
 
+    @MainActor
     func testSet() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 100)
@@ -28,6 +29,7 @@ final class AtomCurrentContextTests: XCTestCase {
         XCTAssertEqual(storeContext.watch(dependency, in: transaction), 200)
     }
 
+    @MainActor
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let store = AtomStore()
@@ -37,6 +39,7 @@ final class AtomCurrentContextTests: XCTestCase {
         XCTAssertEqual(value, 100)
     }
 
+    @MainActor
     func testCustomRefresh() async {
         let atom = TestCustomRefreshableAtom {
             Just(100)
@@ -50,6 +53,7 @@ final class AtomCurrentContextTests: XCTestCase {
         XCTAssertEqual(value, 200)
     }
 
+    @MainActor
     func testReset() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 0)

--- a/Tests/AtomsTests/Context/AtomModifierContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomModifierContextTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomModifierContextTests: XCTestCase {
+    @MainActor
     func testUpdate() {
         let atom = TestValueAtom(value: 0)
         let transaction = Transaction(key: AtomKey(atom)) {}
@@ -17,6 +17,7 @@ final class AtomModifierContextTests: XCTestCase {
         XCTAssertEqual(updatedValue, 1)
     }
 
+    @MainActor
     func testAddTermination() {
         let atom = TestValueAtom(value: 0)
         let transaction = Transaction(key: AtomKey(atom)) {}

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomTestContextTests: XCTestCase {
+    @MainActor
     func testOnUpdate() {
         let atom = TestValueAtom(value: 100)
         let context = AtomTestContext()
@@ -32,6 +32,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertTrue(isCalled)
     }
 
+    @MainActor
     func testWaitForUpdate() async {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -51,6 +52,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertFalse(didUpdate1)
     }
 
+    @MainActor
     func testWaitFor() async {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -89,6 +91,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertFalse(didUpdate3)
     }
 
+    @MainActor
     func testOverride() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)
@@ -103,6 +106,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom1), 200)
     }
 
+    @MainActor
     func testOverrideWithType() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestValueAtom(value: 200)
@@ -117,6 +121,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom1), 300)
     }
 
+    @MainActor
     func testTerminate() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
@@ -137,6 +142,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(updateCount, 0)
     }
 
+    @MainActor
     func testSubscript() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
@@ -157,6 +163,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(updateCount, 1)
     }
 
+    @MainActor
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let context = AtomTestContext()
@@ -164,6 +171,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 100)
     }
 
+    @MainActor
     func testWatch() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
@@ -182,6 +190,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(updateCount, 1)
     }
 
+    @MainActor
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let context = AtomTestContext()
@@ -200,6 +209,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(updateCount, 1)
     }
 
+    @MainActor
     func testCustomRefresh() async {
         let atom = TestCustomRefreshableAtom {
             Just(100)
@@ -226,6 +236,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(updateCount, 2)
     }
 
+    @MainActor
     func testReset() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomTransactionContextTests: XCTestCase {
+    @MainActor
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
@@ -14,6 +14,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 100)
     }
 
+    @MainActor
     func testSet() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 100)
@@ -28,6 +29,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.watch(dependency), 200)
     }
 
+    @MainActor
     func testRefresh() async {
         let atom0 = TestValueAtom(value: 0)
         let atom1 = TestPublisherAtom { Just(100) }
@@ -43,6 +45,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom1).value, 100)
     }
 
+    @MainActor
     func testCustomRefresh() async {
         let atom0 = TestValueAtom(value: 0)
         let atom1 = TestCustomRefreshableAtom {
@@ -62,6 +65,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom1).value, 200)
     }
 
+    @MainActor
     func testReset() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 0)
@@ -80,6 +84,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.read(dependency), 0)
     }
 
+    @MainActor
     func testWatch() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomViewContextTests: XCTestCase {
+    @MainActor
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
@@ -18,6 +18,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 100)
     }
 
+    @MainActor
     func testSet() {
         let atom = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
@@ -35,6 +36,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), 200)
     }
 
+    @MainActor
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let store = AtomStore()
@@ -53,6 +55,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom).value, 100)
     }
 
+    @MainActor
     func testCustomRefresh() async {
         let atom = TestCustomRefreshableAtom {
             Just(100)
@@ -75,6 +78,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom).value, 200)
     }
 
+    @MainActor
     func testReset() {
         let atom = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
@@ -96,6 +100,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 0)
     }
 
+    @MainActor
     func testWatch() {
         let atom = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
@@ -113,6 +118,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), 200)
     }
 
+    @MainActor
     func testSnapshot() {
         let store = AtomStore()
         let container = SubscriptionContainer()
@@ -150,6 +156,7 @@ final class AtomViewContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testUnsubscription() {
         let atom = TestValueAtom(value: 100)
         let key = AtomKey(atom)

--- a/Tests/AtomsTests/Core/AtomCacheTests.swift
+++ b/Tests/AtomsTests/Core/AtomCacheTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomCacheTests: XCTestCase {
+    @MainActor
     func testDescription() {
         let atom = TestAtom(value: 0)
         let cache = AtomCache(atom: atom, value: 0)

--- a/Tests/AtomsTests/Core/EnvironmentTests.swift
+++ b/Tests/AtomsTests/Core/EnvironmentTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class EnvironmentTests: XCTestCase {
+    @MainActor
     func testStore() {
         let store = AtomStore()
         let atom = TestValueAtom(value: 0)

--- a/Tests/AtomsTests/Core/Loader/AtomLoaderContextTests.swift
+++ b/Tests/AtomsTests/Core/Loader/AtomLoaderContextTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class AtomLoaderContextTests: XCTestCase {
+    @MainActor
     func testUpdate() {
         let atom = TestValueAtom(value: 0)
         let transaction = Transaction(key: AtomKey(atom)) {}
@@ -22,6 +22,7 @@ final class AtomLoaderContextTests: XCTestCase {
         XCTAssertEqual(updatedValue, 1)
     }
 
+    @MainActor
     func testAddTermination() {
         let atom = TestValueAtom(value: 0)
         let transaction = Transaction(key: AtomKey(atom)) {}
@@ -42,6 +43,7 @@ final class AtomLoaderContextTests: XCTestCase {
         XCTAssertTrue(transaction.terminations.isEmpty)
     }
 
+    @MainActor
     func testTransaction() {
         let atom = TestValueAtom(value: 0)
         var isCommitted = false
@@ -59,6 +61,7 @@ final class AtomLoaderContextTests: XCTestCase {
         XCTAssertTrue(isCommitted)
     }
 
+    @MainActor
     func testAsyncTransaction() async {
         let atom = TestValueAtom(value: 0)
         var isCommitted = false

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class StoreContextTests: XCTestCase {
+    @MainActor
     func testScopedConstructor() {
         let store = AtomStore()
         let token = ScopeKey.Token()
@@ -37,6 +37,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testScoped() {
         let store = AtomStore()
         let container = SubscriptionContainer()
@@ -64,6 +65,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertFalse(snapshots1.isEmpty)
     }
 
+    @MainActor
     func testStoreDeinit() {
         let atom = TestAtom(value: 0)
         let container = SubscriptionContainer()
@@ -77,6 +79,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertNil(storeRef)
     }
 
+    @MainActor
     func testRead() {
         let store = AtomStore()
         let atom = TestAtom(value: 0)
@@ -111,6 +114,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertTrue(snapshots.isEmpty)
     }
 
+    @MainActor
     func testSet() {
         let store = AtomStore()
         let token = SubscriptionKey.Token()
@@ -157,6 +161,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testModify() {
         let store = AtomStore()
         let token = SubscriptionKey.Token()
@@ -203,6 +208,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testWatch() {
         let store = AtomStore()
         let atom = TestAtom(value: 0)
@@ -239,6 +245,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testWatchFromView() {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -293,6 +300,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testRefresh() async {
         let store = AtomStore()
         let container = SubscriptionContainer()
@@ -349,6 +357,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testCustomRefresh() async {
         let store = AtomStore()
         let container = SubscriptionContainer()
@@ -409,6 +418,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testReset() {
         let store = AtomStore()
         let container = SubscriptionContainer()
@@ -439,6 +449,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testUnwatch() {
         let store = AtomStore()
         let container = SubscriptionContainer()
@@ -456,6 +467,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testSnapshotAndRestore() {
         let store = AtomStore()
         let token = SubscriptionKey.Token()
@@ -489,6 +501,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testScopedOverride() async {
         struct TestDependency1Atom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -696,6 +709,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testCoordinator() {
         struct TestAtom: ValueAtom {
             final class Coordinator {}
@@ -749,6 +763,7 @@ final class StoreContextTests: XCTestCase {
         XCTAssertIdentical(newState?.coordinator, updatedCoordinator)
     }
 
+    @MainActor
     func testRelease() {
         struct KeepAliveAtom<T: Hashable>: ValueAtom, KeepAlive, Hashable {
             var value: T
@@ -807,6 +822,7 @@ final class StoreContextTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testObservers() {
         let container = SubscriptionContainer()
         let atom0 = TestAtom(value: 0)
@@ -972,6 +988,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testRestore() {
         let store = AtomStore()
         let context = StoreContext(store)
@@ -1048,6 +1065,7 @@ final class StoreContextTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testComplexDependencies() async {
         enum Phase {
             case first

--- a/Tests/AtomsTests/Core/SubscriptionContainerTests.swift
+++ b/Tests/AtomsTests/Core/SubscriptionContainerTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class SubscriptionContainerTests: XCTestCase {
+    @MainActor
     func testUnsubscribeOnDeinit() {
         var container: SubscriptionContainer? = SubscriptionContainer()
         var unsubscribedCount = 0
@@ -17,6 +17,7 @@ final class SubscriptionContainerTests: XCTestCase {
         XCTAssertEqual(unsubscribedCount, 1)
     }
 
+    @MainActor
     func testWrapper() {
         let location = SourceLocation()
         let container0 = SubscriptionContainer()

--- a/Tests/AtomsTests/Core/SubscriptionKeyTests.swift
+++ b/Tests/AtomsTests/Core/SubscriptionKeyTests.swift
@@ -2,7 +2,6 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class SubscriptionKeyTests: XCTestCase {
     func testKeyHashableForSameToken() {
         let token = SubscriptionKey.Token()

--- a/Tests/AtomsTests/Core/TransactionTests.swift
+++ b/Tests/AtomsTests/Core/TransactionTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class TransactionTests: XCTestCase {
+    @MainActor
     func testCommit() {
         let key = AtomKey(TestValueAtom(value: 0))
         var commitCount = 0
@@ -18,6 +18,7 @@ final class TransactionTests: XCTestCase {
         XCTAssertEqual(commitCount, 1)
     }
 
+    @MainActor
     func testAddTermination() {
         let key = AtomKey(TestValueAtom(value: 0))
         let transaction = Transaction(key: key) {}
@@ -29,6 +30,7 @@ final class TransactionTests: XCTestCase {
         XCTAssertEqual(transaction.terminations.count, 2)
     }
 
+    @MainActor
     func testTerminate() {
         let key = AtomKey(TestValueAtom(value: 0))
         var isCommitted = false

--- a/Tests/AtomsTests/Modifier/ChangesModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/ChangesModifierTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class ChangesModifierTests: XCTestCase {
+    @MainActor
     func testChanges() {
         let atom = TestStateAtom(defaultValue: "")
         let context = AtomTestContext()
@@ -27,6 +27,7 @@ final class ChangesModifierTests: XCTestCase {
         XCTAssertEqual(updatedCount, 1)
     }
 
+    @MainActor
     func testKey() {
         let modifier = ChangesModifier<Int>()
 
@@ -34,6 +35,7 @@ final class ChangesModifierTests: XCTestCase {
         XCTAssertEqual(modifier.key.hashValue, modifier.key.hashValue)
     }
 
+    @MainActor
     func testShouldUpdate() {
         let modifier = ChangesModifier<Int>()
 
@@ -41,6 +43,7 @@ final class ChangesModifierTests: XCTestCase {
         XCTAssertTrue(modifier.shouldUpdate(newValue: 100, oldValue: 200))
     }
 
+    @MainActor
     func testModify() {
         let atom = TestValueAtom(value: 0)
         let modifier = ChangesModifier<Int>()
@@ -51,6 +54,7 @@ final class ChangesModifierTests: XCTestCase {
         XCTAssertEqual(value, 100)
     }
 
+    @MainActor
     func testAssociateOverridden() {
         let atom = TestValueAtom(value: 0)
         let modifier = ChangesModifier<Int>()

--- a/Tests/AtomsTests/Modifier/SelectModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/SelectModifierTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class SelectModifierTests: XCTestCase {
+    @MainActor
     func testSelect() {
         let atom = TestStateAtom(defaultValue: "")
         let context = AtomTestContext()
@@ -36,6 +36,7 @@ final class SelectModifierTests: XCTestCase {
         XCTAssertNotEqual(modifier0.key.hashValue, modifier1.key.hashValue)
     }
 
+    @MainActor
     func testShouldUpdate() {
         let modifier = SelectModifier<String, Int>(keyPath: \.count)
 
@@ -43,6 +44,7 @@ final class SelectModifierTests: XCTestCase {
         XCTAssertTrue(modifier.shouldUpdate(newValue: 100, oldValue: 200))
     }
 
+    @MainActor
     func testModify() {
         let atom = TestValueAtom(value: 0)
         let modifier = SelectModifier<Int, String>(keyPath: \.description)
@@ -53,6 +55,7 @@ final class SelectModifierTests: XCTestCase {
         XCTAssertEqual(value, "100")
     }
 
+    @MainActor
     func testAssociateOverridden() {
         let atom = TestValueAtom(value: 0)
         let modifier = SelectModifier<Int, String>(keyPath: \.description)

--- a/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class TaskPhaseModifierTests: XCTestCase {
+    @MainActor
     func testPhase() async {
         let atom = TestTaskAtom(value: 0).phase
         let context = AtomTestContext()
@@ -23,6 +23,7 @@ final class TaskPhaseModifierTests: XCTestCase {
         XCTAssertEqual(modifier.key.hashValue, modifier.key.hashValue)
     }
 
+    @MainActor
     func testModify() {
         let atom = TestValueAtom(value: 0)
         let modifier = TaskPhaseModifier<Int, Never>()
@@ -43,6 +44,7 @@ final class TaskPhaseModifierTests: XCTestCase {
         XCTAssertEqual(phase, .success(100))
     }
 
+    @MainActor
     func testAssociateOverridden() {
         let atom = TestValueAtom(value: 0)
         let modifier = TaskPhaseModifier<Int, Never>()
@@ -53,6 +55,7 @@ final class TaskPhaseModifierTests: XCTestCase {
         XCTAssertEqual(phase, .success(100))
     }
 
+    @MainActor
     func testRefresh() async {
         let atom = TestTaskAtom(value: 0).phase
         let context = AtomTestContext()

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Atoms
 
-@MainActor
 final class SnapshotTests: XCTestCase {
+    @MainActor
     func testLookup() {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [x] Documentation update
- [ ] Chore

## Issue for this PR

Nothing

## Environment

```
xcodebuild -version 
Xcode 15.3
Build version 15E204a

swift --version
swift-driver version: 1.90.11.1 Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)
Target: arm64-apple-macosx14.0
```

## Description

I encountered below warning at main branch.

<img width="1138" alt="スクリーンショット 2024-04-02 1 48 18" src="https://github.com/ra1028/swiftui-atom-properties/assets/44288050/56fc95e4-536a-49e3-8e72-6a73f0cfaafd">

> Main actor-isolated class 'AtomViewContextTests' has different actor isolation from nonisolated superclass 'XCTestCase'; this is an error in Swift 6

## Motivation and Context

I'd like to suppress warning. (It will be error on Swift 6, we have to fix it.)

<details><summary>Detail Information</summary>
<p>

This swift specification might exist from Swift 5.5, According to the statement in [SE0316](https://github.com/apple/swift-evolution/blob/793091047ed4b70237949159797506ef63a543d9/proposals/0316-global-actors.md?plain=1#L272C1-L272C252).

> A class can only be annotated with a global actor if it has no superclass, the superclass is annotated with the same global actor, or the superclass is `NSObject`. A subclass of a global-actor-annotated class must be isolated to the same global actor.

However, above warning exist since swift 5.10.

</p>
</details> 

## What I did

- I moved `@MainActor` attribute from XCTestCase to its functions for all tests.
- Fix `README.md`.

## Impact on Existing Code

- Nothing for `Sources` code
- A little for `Tests` code (the isolation behavior on testing code might change?)

## Screenshot/Video/Gif
