### PR TITLE
Bugfix: testWaitFor flakiness

### DIFF
--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -59,9 +59,9 @@ final class AtomTestContextTests: XCTestCase {
 
         context.watch(atom)
 
-        for i in 0..<3 {
+        for i in 1...3 {
             Task {
-                try? await Task.sleep(seconds: Double(i) / 10)
+                try? await Task.sleep(seconds: Double(i) / 100)
                 context[atom] += 1
             }
         }


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Fixing a [flaky](https://github.com/ra1028/swiftui-atom-properties/actions/runs/8565808658/job/23474466318?pr=99) test that was reproduced locally at `(Iteration 587 of 1000)`.  Current configuration seem to have no hard time limit, so it might be better to set time limit to decrease CI time in case of flaky tests that are stuck in `await`.

Main suspect of flakiness is Task with 0s sleep is executed before following await has started, meaning its value is greater than 0 already. Increasing first iteration sleep duration to any value above 0 would help to drastically decrease this flakiness. 

Also increased the divider from 10 to 100, because this test's average execution time is 0.3s already, and it would increase further with `1...3`. 

## Output
10000 iteration of tests didnt show degradation / flakiness, and average test execution duration is decreased to `0.1375` from `0.3`

