### PR TITLE
Update the Resettable behavior when overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,23 +763,9 @@ struct FetchMasterDataAtom: ThrowingTaskAtom, KeepAlive, Hashable {
 
 <details><summary><code>📖 Expand to see example</code></summary>
 
-It gives custom refresh behavior to ValueAtom which is inherently unable to refresh.  
-
-```swift
-struct RandomIntAtom: ValueAtom, Refreshable, Hashable {
-    func value(context: Context) -> Int {
-        0
-    }
-
-    func refresh(context: RefreshContext) async -> Int {
-        try? await Task.sleep(nanoseconds: 3 * 1_000_000_000)
-        return .random(in: 0..<100)
-    }
-}
-```
-
-It's also useful when you want to expose a converted value of an atom as another atom with having refresh ability while keeping the original one private visibility.  
-In this example, `FetchMoviesPhaseAtom` transparently exposes the value of `FetchMoviesTaskAtom` as AsyncPhase so that the error can be handled easily inside the atom, and `Refreshable` gives refreshing ability to `FetchMoviesPhaseAtom` itself.  
+It adds custom refresh behavior to ValueAtom which is inherently unable to refresh.  
+It's useful when need to have arbitrary refresh behavior or implementing refresh when value depends on private atom.  
+In this example, `FetchMoviesPhaseAtom` transparently exposes the value of `FetchMoviesTaskAtom` as AsyncPhase so that the error can be handled easily inside the atom, and `Refreshable` gives refreshing behavior to `FetchMoviesPhaseAtom` itself.  
 
 ```swift
 private struct FetchMoviesTaskAtom: ThrowingTaskAtom, Hashable {
@@ -813,11 +799,9 @@ struct FetchMoviesPhaseAtom: ValueAtom, Refreshable, Hashable {
 
 <details><summary><code>📖 Expand to see example</code></summary>
 
-It adds custom reset behavior to an Atom that will be executed upon atom reset.
-
-It's useful when need to have arbitrary reset ability or implementing reset when value depends on private atom.
-  
-In following example, `RandomIntAtom` generates a random value using generated from private `RandomNumberGeneratorAtom`, and `Resettable` gives ability to replace exposed reset with  `RandomNumberGeneratorAtom` reset.
+It adds custom reset behavior to an atom that will be executed upon atom reset.  
+It's useful when need to have arbitrary reset behavior or implementing reset when value depends on private atom.  
+In following example, `RandomIntAtom` generates a random value using generated from private `RandomNumberGeneratorAtom`, and `Resettable` gives ability to replace exposed reset with  `RandomNumberGeneratorAtom` reset.  
 
 ```swift
 struct RandomIntAtom: ValueAtom, Resettable, Hashable {

--- a/README.md
+++ b/README.md
@@ -763,9 +763,9 @@ struct FetchMasterDataAtom: ThrowingTaskAtom, KeepAlive, Hashable {
 
 <details><summary><code>📖 Expand to see example</code></summary>
 
-It adds custom refresh behavior to ValueAtom which is inherently unable to refresh.  
+It adds custom refresh behavior to `ValueAtom` which is inherently unable to refresh.  
 It's useful when need to have arbitrary refresh behavior or implementing refresh when value depends on private atom.  
-In this example, `FetchMoviesPhaseAtom` transparently exposes the value of `FetchMoviesTaskAtom` as AsyncPhase so that the error can be handled easily inside the atom, and `Refreshable` gives refreshing behavior to `FetchMoviesPhaseAtom` itself.  
+In this example, `FetchMoviesPhaseAtom` transparently exposes the value of `FetchMoviesTaskAtom` as `AsyncPhase` so that the error can be handled easily inside the atom, and `Refreshable` gives refreshing behavior to `FetchMoviesPhaseAtom` itself.  
 
 ```swift
 private struct FetchMoviesTaskAtom: ThrowingTaskAtom, Hashable {

--- a/Sources/Atoms/Attribute/Refreshable.swift
+++ b/Sources/Atoms/Attribute/Refreshable.swift
@@ -1,16 +1,22 @@
-/// An attribute protocol allows an atom to have a custom refresh ability.
+/// An attribute protocol that allows an atom to have a custom refresh behavior.
 ///
-/// Note that the custom refresh ability is not triggered when the atom is overridden.
+/// It is useful when creating a wrapper atom and you want to transparently refresh the atom underneath.
+/// Note that the custom refresh will not be triggered when the atom is overridden.
 ///
 /// ```swift
-/// struct RandomIntAtom: ValueAtom, Refreshable, Hashable {
-///     func value(context: Context) -> Int {
-///         0
+/// struct UserAtom: ValueAtom, Refreshable, Hashable {
+///     func value(context: Context) -> AsyncPhase<User?, Never> {
+///         context.watch(FetchUserAtom().phase)
 ///     }
 ///
-///     func refresh(context: RefreshContext) async -> Int {
-///         try? await Task.sleep(nanoseconds: 3 * 1_000_000_000)
-///         return .random(in: 0..<100)
+///     func refresh(context: RefreshContext) async -> AsyncPhase<User?, Never> {
+///         await context.refresh(FetchUserAtom().phase)
+///     }
+/// }
+///
+/// private struct FetchUserAtom: TaskAtom, Hashable {
+///     func value(context: Context) async -> User? {
+///         await fetchUser()
 ///     }
 /// }
 /// ```

--- a/Sources/Atoms/Attribute/Resettable.swift
+++ b/Sources/Atoms/Attribute/Resettable.swift
@@ -1,21 +1,22 @@
-/// An attribute protocol allows an atom to have a custom reset override.
+/// An attribute protocol that allows an atom to have a custom reset behavior.
 ///
-/// Note that the custom reset will be triggered even when the atom is overridden.
+/// It is useful when creating a wrapper atom and you want to transparently reset the atom underneath.
+/// Note that the custom reset will not be triggered when the atom is overridden.
 ///
 /// ```swift
 /// struct UserAtom: ValueAtom, Resettable, Hashable {
-///     func value(context: Context) -> User? {
-///          context.watch(FetchUserAtom()).phase.value
+///     func value(context: Context) -> AsyncPhase<User?, Never> {
+///         context.watch(FetchUserAtom().phase)
 ///     }
 ///
 ///     func reset(context: ResetContext) {
-///          context.reset(FetchUserAtom())
+///         context.reset(FetchUserAtom())
 ///     }
 /// }
 ///
 /// private struct FetchUserAtom: TaskAtom, Hashable {
 ///     func value(context: Context) async -> User? {
-///          await fetchUser()
+///         await fetchUser()
 ///     }
 /// }
 /// ```

--- a/Sources/Atoms/Context/AtomContext.swift
+++ b/Sources/Atoms/Context/AtomContext.swift
@@ -83,6 +83,22 @@ public protocol AtomContext {
     @discardableResult
     func refresh<Node: Atom>(_ atom: Node) async -> Node.Loader.Value where Node.Loader: RefreshableAtomLoader
 
+    /// Refreshes and then returns the value associated with the given refreshable atom.
+    ///
+    /// This method only accepts atoms that conform to ``Refreshable`` protocol.
+    /// It refreshes the value with the custom refresh behavior, so the caller can await until
+    /// the atom completes the update.
+    /// Note that it can be used only in a context that supports concurrency.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// let value = await context.refresh(CustomRefreshableAtom())
+    /// print(value)
+    /// ```
+    ///
+    /// - Parameter atom: An atom to refresh.
+    ///
+    /// - Returns: The value after the refreshing associated with the given atom is completed.
     @discardableResult
     func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Loader.Value
 

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -268,15 +268,14 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom), 0)
         XCTAssertEqual(context.watch(resettableAtom), 0)
 
-        context.override(resettableAtom, with: { _ in 200 })
         context[atom] = 100
 
         XCTAssertEqual(context.watch(atom), 100)
-        XCTAssertEqual(context.watch(resettableAtom), 200)
+        XCTAssertEqual(context.watch(resettableAtom), 100)
 
         context.reset(resettableAtom)
 
         XCTAssertEqual(context.watch(atom), 300)
-        XCTAssertEqual(context.watch(resettableAtom), 200)
+        XCTAssertEqual(context.watch(resettableAtom), 300)
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation update
- [ ] Chore

## Description

This PR updates the `Resettable` attribute, which was introduced recently, when the atom is overridden.
Currently, it calls the user defined reset behavior no matter if it is overridden, but after this PR, the custom behavior will be ignored and reset to the overridden value.

## Impact on Existing Code

Changes the behavior when an existing Resettable atom is overridden.

