### PR TITLE
AtomScope no longer inherits overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1221,26 +1221,29 @@ struct NewsView: View {
 
 #### Override
 
-Values and states defined by atoms can be overridden in root or in any scope.  
-If you override an atom in [AtomRoot](#atomroot), it will override the values throughout the app, which is useful for dependency injection. In case you want to override an atom only in a limited scope, you might like to use [AtomScope](#atomscope) instead to override as it substitutes the atom value only in that scope, which can be useful for injecting dependencies that are needed only for the scope or overriding state in certain views.
+Overriding an atom in [AtomRoot](#atomroot) or [AtomScope](#atomscope) overwrites its value when used in the descendant views, which is useful for dependency injection or swapping state in a particular view.  
 
 ```swift
-AtomRoot {
-    VStack {
-        CountStepper()
-
-        AtomScope {
-            CountDisplay()
-        }
-        .override(CounterAtom()) { _ in
-            // Overrides the count to be 456 only for the display content.
-            456
-        }
-    }
+AtomScope {
+    CountDisplay()
 }
 .override(CounterAtom()) { _ in
-    // Overrides the count to be 123 throughout the app.
-    123
+    456  // Overrides the count to be `456` only for this scope.
+}
+```
+
+Note that when multiple `AtomScope`s are nested, it doesn't inherit the overrides of its ancestor scopes.  
+In this case, you can explicitly inherit overrides from the parent scope by passing a `@ViewContext` context that has gotten in the parent scope.  
+
+```swift
+@ViewContext
+var context
+
+var body: some {
+    // Inherites the nearest ancester scope's overrides.
+    AtomScope(inheriting: context) {
+        CountDisplay()
+    }
 }
 ```
 
@@ -1592,7 +1595,7 @@ struct RootView: View {
             Text("Example View")
         }
         .sheet(isPresented: $isPresented) {
-            AtomScope(context) {
+            AtomScope(inheriting: context) {
                 MailView()
             }
         }

--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -60,9 +60,9 @@ public struct AtomRoot<Content: View>: View {
     public var body: some View {
         content.environment(
             \.store,
-            .scoped(
-                key: ScopeKey(token: state.token),
-                store: state.store,
+            StoreContext(
+                state.store,
+                scopeKey: ScopeKey(token: state.token),
                 observers: observers,
                 overrides: overrides
             )

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -439,9 +439,9 @@ internal extension AtomTestContext {
 
     @usableFromInline
     var _store: StoreContext {
-        .scoped(
-            key: ScopeKey(token: _state.token),
-            store: _state.store,
+        StoreContext(
+            _state.store,
+            scopeKey: ScopeKey(token: _state.token),
             observers: [],
             overrides: _state.overrides
         )

--- a/Sources/Atoms/Core/AtomKey.swift
+++ b/Sources/Atoms/Core/AtomKey.swift
@@ -1,36 +1,38 @@
 internal struct AtomKey: Hashable {
     private let key: AnyHashable
     private let type: ObjectIdentifier
-    private let overrideScopeKey: ScopeKey?
-    private let getName: () -> String
-
-    var isOverridden: Bool {
-        overrideScopeKey != nil
-    }
+    private let scopeKey: ScopeKey?
+    private let anyAtomType: Any.Type
 
     var debugLabel: String {
-        if let overrideScopeKey {
-            return getName() + "-override:\(overrideScopeKey.debugLabel)"
+        let atomLabel = String(describing: anyAtomType)
+
+        if let scopeKey {
+            return atomLabel + "-scoped:\(scopeKey.debugLabel)"
         }
         else {
-            return getName()
+            return atomLabel
         }
     }
 
-    init<Node: Atom>(_ atom: Node, overrideScopeKey: ScopeKey?) {
+    var isScoped: Bool {
+        scopeKey != nil
+    }
+
+    init<Node: Atom>(_ atom: Node, scopeKey: ScopeKey?) {
         self.key = AnyHashable(atom.key)
         self.type = ObjectIdentifier(Node.self)
-        self.overrideScopeKey = overrideScopeKey
-        self.getName = { String(describing: Node.self) }
+        self.scopeKey = scopeKey
+        self.anyAtomType = Node.self
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(key)
         hasher.combine(type)
-        hasher.combine(overrideScopeKey)
+        hasher.combine(scopeKey)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.key == rhs.key && lhs.type == rhs.type && lhs.overrideScopeKey == rhs.overrideScopeKey
+        lhs.key == rhs.key && lhs.type == rhs.type && lhs.scopeKey == rhs.scopeKey
     }
 }

--- a/Sources/Atoms/Core/AtomOverride.swift
+++ b/Sources/Atoms/Core/AtomOverride.swift
@@ -3,8 +3,6 @@ internal protocol AtomOverrideProtocol {
     associatedtype Node: Atom
 
     var value: (Node) -> Node.Loader.Value { get }
-
-    func scoped(key: ScopeKey) -> any AtomScopedOverrideProtocol
 }
 
 @usableFromInline
@@ -16,25 +14,4 @@ internal struct AtomOverride<Node: Atom>: AtomOverrideProtocol {
     init(value: @escaping (Node) -> Node.Loader.Value) {
         self.value = value
     }
-
-    @usableFromInline
-    func scoped(key: ScopeKey) -> any AtomScopedOverrideProtocol {
-        AtomScopedOverride<Node>(scopeKey: key, value: value)
-    }
-}
-
-// As a workaround to the problem of not getting ScopeKey synchronously
-// when the AtomRoot or AtomScope's override modifier is called, those modifiers
-// temporarily register AtomOverride and convert them to AtomScopedOverride when
-// their View body is evaluated. This is not ideal from a performance standpoint,
-// so it will be improved as soon as an alternative way to grant per-scope keys
-// independent of the SwiftUI lifecycle is came up.
-@usableFromInline
-internal protocol AtomScopedOverrideProtocol {
-    var scopeKey: ScopeKey { get }
-}
-
-internal struct AtomScopedOverride<Node: Atom>: AtomScopedOverrideProtocol {
-    let scopeKey: ScopeKey
-    let value: (Node) -> Node.Loader.Value
 }

--- a/Sources/Atoms/Core/Environment.swift
+++ b/Sources/Atoms/Core/Environment.swift
@@ -9,6 +9,12 @@ internal extension EnvironmentValues {
 
 private struct StoreEnvironmentKey: EnvironmentKey {
     static var defaultValue: StoreContext {
-        StoreContext(enablesAssertion: true)
+        StoreContext(
+            nil,
+            scopeKey: ScopeKey(token: ScopeKey.Token()),
+            observers: [],
+            overrides: [:],
+            enablesAssertion: true
+        )
     }
 }

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -582,7 +582,7 @@ private extension StoreContext {
                 Detected an illegal override.
                 There might be duplicate keys or logic failure.
                 Detected: \(type(of: baseOverride))
-                Expected: AtomScopedOverride<\(Node.self)>
+                Expected: AtomOverride<\(Node.self)>
                 """
             )
 
@@ -639,7 +639,7 @@ private extension StoreContext {
 
                 var body: some View {
                     UIViewWrappingView {
-                        AtomScope(context) {
+                        AtomScope(inheriting: context) {
                             WrappedView()
                         }
                     }
@@ -653,7 +653,7 @@ private extension StoreContext {
 
             ```
             .sheet(isPresented: ...) {
-                AtomScope(context) {
+                AtomScope(inheriting: context) {
                     ExampleView()
                 }
             }

--- a/Sources/Atoms/Deprecated.swift
+++ b/Sources/Atoms/Deprecated.swift
@@ -1,8 +1,28 @@
+import SwiftUI
+
 public extension Atom {
     @available(*, deprecated, renamed: "changes(of:)")
     func select<Selected: Equatable>(
         _ keyPath: KeyPath<Loader.Value, Selected>
     ) -> ModifiedAtom<Self, ChangesOfModifier<Loader.Value, Selected>> {
         changes(of: keyPath)
+    }
+}
+
+public extension AtomScope {
+    @available(*, deprecated, renamed: "init(inheriting:content:)")
+    init(
+        _ context: AtomViewContext,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.init(inheriting: context, content: content)
+    }
+
+    @available(*, deprecated, renamed: "init(storesIn:content:)")
+    init(
+        _ store: AtomStore,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.init(storesIn: store, content: content)
     }
 }

--- a/Sources/Atoms/Snapshot.swift
+++ b/Sources/Atoms/Snapshot.swift
@@ -32,7 +32,7 @@ public struct Snapshot: CustomStringConvertible {
     /// - Returns: The captured value associated with the given atom if it exists.
     @MainActor
     public func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
-        let key = AtomKey(atom, overrideScopeKey: nil)
+        let key = AtomKey(atom, scopeKey: nil)
         let cache = caches[key] as? AtomCache<Node>
         return cache?.value
     }

--- a/Tests/AtomsTests/Core/AtomKeyTests.swift
+++ b/Tests/AtomsTests/Core/AtomKeyTests.swift
@@ -44,9 +44,9 @@ final class AtomKeyTests: XCTestCase {
         let token = ScopeKey.Token()
         let scopeKey = ScopeKey(token: token)
         let key0 = AtomKey(atom)
-        let key1 = AtomKey(atom, overrideScopeKey: scopeKey)
+        let key1 = AtomKey(atom, scopeKey: scopeKey)
 
         XCTAssertEqual(key0.debugLabel, "TestAtom<Int>")
-        XCTAssertEqual(key1.debugLabel, "TestAtom<Int>-override:\(scopeKey.debugLabel)")
+        XCTAssertEqual(key1.debugLabel, "TestAtom<Int>-scoped:\(scopeKey.debugLabel)")
     }
 }

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -48,7 +48,7 @@ final class SnapshotTests: XCTestCase {
         let key1 = AtomKey(atom1)
         let key2 = AtomKey(atom2)
         let key3 = AtomKey(atom3)
-        let key4 = AtomKey(atom4, overrideScopeKey: scopeKey)
+        let key4 = AtomKey(atom4, scopeKey: scopeKey)
         let location = SourceLocation(fileID: "Module/View.swift", line: 10)
         let subscriberToken = SubscriberKey.Token()
         let subscriberKey = SubscriberKey(token: subscriberToken)
@@ -99,8 +99,8 @@ final class SnapshotTests: XCTestCase {
               "TestAtom<Value2>" -> "TestAtom<Value3>"
               "TestAtom<Value3>"
               "TestAtom<Value3>" -> "Module/View.swift" [label="line:10"]
-              "TestAtom<Value4>-override:\(scopeKey.debugLabel)"
-              "TestAtom<Value4>-override:\(scopeKey.debugLabel)" -> "Module/View.swift" [label="line:10"]
+              "TestAtom<Value4>-scoped:\(scopeKey.debugLabel)"
+              "TestAtom<Value4>-scoped:\(scopeKey.debugLabel)" -> "Module/View.swift" [label="line:10"]
             }
             """
         )

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -57,9 +57,24 @@ final class ResettableSubject<Output, Failure: Error>: Publisher, Subject {
     }
 }
 
+extension StoreContext {
+    init(
+        _ store: AtomStore? = nil,
+        observers: [Observer] = [],
+        overrides: [OverrideKey: any AtomOverrideProtocol] = [:]
+    ) {
+        self.init(
+            store,
+            scopeKey: ScopeKey(token: ScopeKey.Token()),
+            observers: observers,
+            overrides: overrides
+        )
+    }
+}
+
 extension AtomKey {
     init(_ atom: some Atom) {
-        self.init(atom, overrideScopeKey: nil)
+        self.init(atom, scopeKey: nil)
     }
 }
 


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Nested AtomScopes no longer inherit overrides from the ancestor scopes for the sake of performance and consistency with the Scoped atoms feature which is soon to be added.
This also solves the existing problem that, once an atom is overritten in a certain AtomScope, then it never be a shared state in the descendant views.

## Impact on Existing Code

- `AtomScope` no longer inherits overrides from ancestor scopes.
- `AtomScope.init(_: AtomContext, content: () -> Content)` is deprecated, and renamed to `AtomScope.init(inheriting: AtomContext, content: () -> Content)`.
- `AtomScope.init(_: AtomStore, content: () -> Content)` is deprecated, and renamed to `AtomScope.init(storesIn: AtomStore, content: () -> Content)`.
