### PR TITLE
Remove @discardableResult of AtomViewContext.snapshot()

### DIFF
--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -210,7 +210,6 @@ public struct AtomViewContext: AtomWatchableContext {
     /// or rollback to a specific state.
     ///
     /// - Returns: A snapshot that contains values of atoms.
-    @discardableResult
     @inlinable
     public func snapshot() -> Snapshot {
         _store.snapshot()


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Removes `@discardableResult` of `AtomViewContext.snapshot()`.
I guess this is accidentally introduced.

## Impact on Existing Code

It always needs to handle the return value now, but practically no impact because the snapshot function has no usage as a side effect of just calling the function.
