### PR TITLE
Scoped Atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ The attributes allow control over how the atoms essentially work, for example, c
 
 #### [Scoped](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/scoped)
 
-`Scoped` preserves the atom state in the nearest scope in the ancestor of where it is used and prevent it from being shared outside of the scope.
+`Scoped` preserves the atom state in the scope nearest to the ancestor of where it is used and prevents it from being shared out of scope.
 
 <details><summary><code>📖 Example</code></summary>
 
@@ -1250,7 +1250,7 @@ struct NewsView: View {
 #### Scoped Atoms
 
 This library is designed with the shared state as a single source of truth first principle, but also the state can be scoped depending on the intended use.  
-Scoped atoms preserve their state in the nearest [AtomScope](#atomscope) in the ancestor of the view in which the atom is used, and they are not shared outside the scope. `Scoped` is the attribute for that feature.  
+Scoped atoms preserves the atom state in the [AtomScope](#atomscope) nearest to the ancestor of where it is used and prevents it from being shared out of scope. `Scoped` is the attribute for that feature.  
 
 ```swift
 struct TextInputAtom: StateAtom, Scoped Hashable {
@@ -1302,12 +1302,12 @@ AtomScope(id: TextScopeID()) {
 }
 ```
 
-This is also useful when multiple identical screens are stacked and each has isolated states such as user inputs.  
-Note that other atoms that depend on the scoped atom will be in a shared state and must be given `Scoped` attribute as well in order to scope them as well.  
+This is also useful when multiple identical screens are stacked and each screen needs isolated states such as user inputs.  
+Note that other atoms that depend on scoped atoms will be in a shared state and must be given `Scoped` attribute as well in order to scope them as well.  
 
 #### Override Atoms
 
-Overriding an atom in [AtomRoot](#atomroot) or [AtomScope](#atomscope) overwrites its value when used in the descendant views, which is useful for dependency injection or swapping state in a particular view.  
+Overriding an atom in [AtomRoot](#atomroot) or [AtomScope](#atomscope) overwrites its state when used in the descendant views, which is useful for dependency injection or swapping state in a particular view.  
 
 ```swift
 AtomScope {

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ In order to provide the best interface and effective data-binding for the type o
 |Output     |`T`|
 |Use Case   |Computed property, Derived data, Dependency injection|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct LocaleAtom: ValueAtom, Hashable {
@@ -425,7 +425,7 @@ struct LocaleView: View {
 |Output     |`T`|
 |Use Case   |Mutable data, Derived data|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct CounterAtom: StateAtom, Hashable {
@@ -454,7 +454,7 @@ struct CounterView: View {
 |Output     |`Task<T, Never>`|
 |Use Case   |Non-throwing asynchronous operation e.g. Expensive calculation|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct FetchUserAtom: TaskAtom, Hashable {
@@ -485,7 +485,7 @@ struct UserView: View {
 |Output     |`Task<T, Error>`|
 |Use Case   |Throwing asynchronous operation e.g. API call|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct FetchMoviesAtom: ThrowingTaskAtom, Hashable {
@@ -522,7 +522,7 @@ struct MoviesView: View {
 |Output     |`AsyncPhase<T, Error>`|
 |Use Case   |Handle multiple asynchronous values e.g. web-sockets|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct NotificationAtom: AsyncSequenceAtom, Hashable {
@@ -559,7 +559,7 @@ struct NotificationView: View {
 |Output       |`AsyncPhase<T, E: Error>`|
 |Use Case     |Handle single or multiple asynchronous value(s) e.g. API call|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct TimerAtom: PublisherAtom, Hashable {
@@ -592,7 +592,7 @@ struct TimerView: View {
 |Output     |`T: ObservableObject`|
 |Use Case   |Mutable complex state object|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 class Contact: ObservableObject {
@@ -643,7 +643,7 @@ Modifiers can be applied to an atom to produce a different versions of the origi
 |Compatible     |All atoms types. The derived property must be `Equatable` compliant.|
 |Use Case       |Performance optimization, Property scope restriction|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct CountAtom: StateAtom, Hashable {
@@ -673,7 +673,7 @@ struct CountDisplayView: View {
 |Compatible     |All atom types that produce `Equatable` compliant value.|
 |Use Case       |Performance optimization|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct CountAtom: StateAtom, Hashable {
@@ -703,7 +703,7 @@ struct CountDisplayView: View {
 |Compatible     |`TaskAtom`, `ThrowingTaskAtom`|
 |Use Case       |Consume asynchronous result as `AsyncPhase`|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct FetchWeatherAtom: ThrowingTaskAtom, Hashable {
@@ -739,11 +739,39 @@ struct WeatherReportView: View {
 
 The attributes allow control over how the atoms essentially work, for example, cache control of the state.
 
+#### [Scoped](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/scoped)
+
+`Scoped` preserves the atom state in the nearest scope in the ancestor of where it is used and prevent it from being shared outside of the scope.
+
+<details><summary><code>📖 Example</code></summary>
+
+In the example case below, each `SearchPane` uses the `SearchQueryAtom` state isolated for each scope.
+
+```swift
+struct SearchQueryAtom: StateAtom, Scoped, Hashable {
+    func defaultValue(context: Context) -> String {
+         ""
+    }
+}
+
+VStack {
+    AtomScope {
+        SearchPane()
+    }
+
+    AtomScope {
+        SearchPane()
+    }
+}
+```
+
+</details>
+
 #### [KeepAlive](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/keepalive)
 
 `KeepAlive` allows the atom to preserve its data even if it's no longer watched from anywhere.  
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 In the example case below, once master data is obtained from the server, it can be cached in memory until the app process terminates.
 
@@ -761,7 +789,7 @@ struct FetchMasterDataAtom: ThrowingTaskAtom, KeepAlive, Hashable {
 
 `Refreshable` allows you to implement a custom refreshable behavior to an atom.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 It adds custom refresh behavior to `ValueAtom` which is inherently unable to refresh.  
 It's useful when need to have arbitrary refresh behavior or implementing refresh when value depends on private atom.  
@@ -797,7 +825,7 @@ struct FetchMoviesPhaseAtom: ValueAtom, Refreshable, Hashable {
 
 `Resettable` allows you to implement a custom reset behavior to an atom.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 It adds custom reset behavior to an atom that will be executed upon atom reset.  
 It's useful when need to have arbitrary reset behavior or implementing reset when value depends on private atom.  
@@ -838,7 +866,7 @@ By retrieving the atom through these property wrappers, the internal system mark
 |Summary        |This property wrapper is similar to `@State` or `@Environment`, but is always read-only. It recomputes the view with value changes.|
 |Compatible     |All atom types|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct UserNameAtom: StateAtom, Hashable {
@@ -866,7 +894,7 @@ struct UserNameDisplayView: View {
 |Summary        |This property wrapper is read-write as the same interface as `@State`. It recomputes the view with data changes. You can get a `Binding` to the value using `$` prefix.|
 |Compatible     |`StateAtom`|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct UserNameAtom: StateAtom, Hashable {
@@ -899,7 +927,7 @@ struct UserNameInputView: View {
 |Summary        |This property wrapper has the same interface as `@StateObject` and `@ObservedObject`. It recomputes the view when the observable object updates. You can get a `Binding` to one of the observable object's properties using `$` prefix.|
 |Compatible     |`ObservableObjectAtom`|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 class Counter: ObservableObject {
@@ -953,7 +981,7 @@ context.reset(CounterAtom())
 
 The context also provides a flexible solution for passing dynamic parameters to atom's initializer. See [Context](#context) section for more detail.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct FetchBookAtom: ThrowingTaskAtom, Hashable {
@@ -1012,7 +1040,7 @@ A context available through the `@ViewContext` property wrapper when using atoms
 |:--|:--|
 |[snapshot()](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomviewcontext/snapshot())|For debugging, takes a snapshot that captures specific set of values of atoms.|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct SearchQueryAtom: StateAtom, Hashable {
@@ -1093,7 +1121,7 @@ This context type has a `coordinator` property that preserves an instance from t
 |:--|:--|
 |[coordinator](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtransactioncontext/coordinator)|The atom’s associated coordinator that preservess a state until the atom will no longer be used.|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct LocationManagerAtom: ValueAtom, Hashable {
@@ -1132,7 +1160,7 @@ A context that can simulate any scenarios in which atoms are used from a view or
 |[wait(for:timeout:until:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/wait(for:timeout:until:))|Waits for the given atom until it will be a certain state.|
 |[onUpdate](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/onupdate)|Sets a closure that notifies there has been an update to one of the atoms.|
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 protocol APIClientProtocol {
@@ -1180,7 +1208,7 @@ class FetchMusicsTests: XCTestCase {
 #### [AtomScope](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomscope)
 
 `AtomScope` allows you to monitor changes or override atoms used in descendant views. Unlike `AtomRoot`, they affect only those in scope.  
-See the [Override](#override) and [Debugging](#debugging) sections for specific uses.  
+See the [Override Atoms](#override-atoms) and [Debugging](#debugging) sections for specific uses.  
 
 ```swift
 AtomScope {
@@ -1219,7 +1247,65 @@ struct NewsView: View {
 
 ### Techniques
 
-#### Override
+#### Scoped Atoms
+
+This library is designed with the shared state as a single source of truth first principle, but also the state can be scoped depending on the intended use.  
+Scoped atoms preserve their state in the nearest [AtomScope](#atomscope) in the ancestor of the view in which the atom is used, and they are not shared outside the scope. `Scoped` is the attribute for that feature.  
+
+```swift
+struct TextInputAtom: StateAtom, Scoped Hashable {
+    func defaultValue(context: Context) -> String {
+        ""
+    }
+}
+
+struct TextInputView: View {
+    @Watch(TextInputAtom())
+    ...
+}
+
+VStack {
+    // The following two TextInputView don't share TextInputAtom state.
+
+    AtomScope {
+        TextInputView()
+    }
+
+    AtomScope {
+        TextInputView()
+    }
+}
+```
+
+When multiple `AtomScope`s are nested, and you want to store and share an atom state in the particular scope, it is able to define a scope ID which is to find a matching scope.  
+
+```swift
+struct TextScopeID: Hashable {}
+
+struct TextInputAtom: StateAtom, Scoped Hashable {
+    var scopeID: TextScopeID {
+        TextScopeID()
+    }
+
+    func defaultValue(context: Context) -> String {
+        ""
+    }
+}
+
+AtomScope(id: TextScopeID()) {
+    TextInputView()
+
+    AtomScope {
+        // Shares TextInputAtom state with the TextInputView placed in the parent scope.
+        TextInputView()
+    }
+}
+```
+
+This is also useful when multiple identical screens are stacked and each has isolated states such as user inputs.  
+Note that other atoms that depend on the scoped atom will be in a shared state and must be given `Scoped` attribute as well in order to scope them as well.  
+
+#### Override Atoms
 
 Overriding an atom in [AtomRoot](#atomroot) or [AtomScope](#atomscope) overwrites its value when used in the descendant views, which is useful for dependency injection or swapping state in a particular view.  
 
@@ -1247,7 +1333,9 @@ var body: some {
 }
 ```
 
-See [Testing](#testing) section for details on dependency injection on unit tests.
+Note also that overridden atoms will automatically be scoped to the `AtomScope`, but other atoms that depend on them will be in a shared state and must be given `Scoped` attribute (See also: [Scoped Atoms](#scoped-atoms)) in order to scope them as well.  
+
+See [Testing](#testing) section for details on dependency injection on unit tests.  
 
 #### Testing
 
@@ -1436,7 +1524,7 @@ struct NewsList_Preview: PreviewProvider {
 
 The `read(_:)` function is a way to get the data of an atom without having watch to and receiving future updates of it. It's commonly used inside functions triggered by call-to-actions.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct TextAtom: StateAtom, Hashable {
@@ -1463,7 +1551,7 @@ struct TextCopyView: View {
 
 Each atom must have a unique `key` to be uniquely associated with its value. As described in the [Atoms](#atoms) section, it is automatically synthesized by conforming to `Hashable`, but with explicitly specifying a `key` allowing you to pass arbitrary external parameters to the atom. It is commonly used, for example, to retrieve user information associated with a dynamically specified ID from a server.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct FetchUserAtom: ThrowingTaskAtom {
@@ -1505,7 +1593,7 @@ struct UserView: View {
 
 You can pass a context to your object and interact with other atoms at any asynchronous timing. However, in that case, when the `watch` is called, it end up with the object instance itself will be re-created with fresh data. Therefore, you can explicitly prevent the use of the `watch` by passing it as `AtomContext` type.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct MessageLoaderAtom: ObservableObjectAtom, Hashable {
@@ -1553,7 +1641,7 @@ class MessageLoader: ObservableObject {
 All atom types can optionally implement [`updated(newValue:oldValue:context:)`](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atom/updated(newvalue:oldvalue:context:)-98n6k) method to manage arbitrary side-effects of value updates, such as state persistence, state synchronization, logging, and etc.  
 In the above example, the initial state of the atom is retrieved from UserDefaults, and when the user updates the state, the value is reflected into UserDefaults as a side effect.
 
-<details><summary><code>📖 Expand to see example</code></summary>
+<details><summary><code>📖 Example</code></summary>
 
 ```swift
 struct PersistentCounterAtom: StateAtom, Hashable {

--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -116,7 +116,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func observe(_ onUpdate: @escaping @MainActor (Snapshot) -> Void) -> Self {
-        mutating { $0.observers.append(Observer(onUpdate: onUpdate)) }
+        mutating(self) { $0.observers.append(Observer(onUpdate: onUpdate)) }
     }
 
     /// Overrides the atom value with the given value.
@@ -130,7 +130,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
+        mutating(self) { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
     }
 
     /// Overrides the atom value with the given value.
@@ -146,7 +146,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
+        mutating(self) { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
     }
 }
 
@@ -176,6 +176,7 @@ private extension AtomRoot {
                 StoreContext(
                     state.store,
                     scopeKey: ScopeKey(token: state.token),
+                    inheritedScopeKeys: [:],
                     observers: observers,
                     overrides: overrides
                 )
@@ -203,16 +204,11 @@ private extension AtomRoot {
                 StoreContext(
                     store,
                     scopeKey: ScopeKey(token: state.token),
+                    inheritedScopeKeys: [:],
                     observers: observers,
                     overrides: overrides
                 )
             )
         }
-    }
-
-    func `mutating`(_ mutation: (inout Self) -> Void) -> Self {
-        var view = self
-        mutation(&view)
-        return view
     }
 }

--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -68,7 +68,7 @@ public struct AtomRoot<Content: View>: View {
 
     /// Creates an atom root with the specified content that will be allowed to use atoms.
     ///
-    /// - Parameter content: The content that uses atoms.
+    /// - Parameter content: The descendant view content that provides context for atoms.
     public init(@ViewBuilder content: () -> Content) {
         self.storeHost = .tree
         self.content = content()
@@ -79,7 +79,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Parameters:
     ///   - store: An object that stores the state of atoms.
-    ///   - content: The view content that inheriting from the parent.
+    ///   - content: The descendant view content that provides context for atoms.
     public init(
         storesIn store: AtomStore,
         @ViewBuilder content: () -> Content

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -44,8 +44,8 @@ public struct AtomScope<Content: View>: View {
     /// Creates a new scope with the specified content.
     ///
     /// - Parameters:
-    ///   - id: An identifier represents this scope used for matching scoped atoms.
-    ///   - content: The view content that inheriting from the parent.
+    ///   - id: An identifier represents this scope used for matching with scoped atoms.
+    ///   - content: The descendant view content that provides scoped context for atoms.
     public init<ID: Hashable>(id: ID = DefaultScopeID(), @ViewBuilder content: () -> Content) {
         let id = ScopeID(id)
         self.inheritance = .environment(id: id)
@@ -57,7 +57,7 @@ public struct AtomScope<Content: View>: View {
     ///
     /// - Parameters:
     ///   - context: The parent view context that for inheriting store explicitly.
-    ///   - content: The view content that inheriting from the parent.
+    ///   - content: The descendant view content that provides scoped context for atoms.
     public init(
         inheriting context: AtomViewContext,
         @ViewBuilder content: () -> Content

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -43,9 +43,12 @@ public struct AtomScope<Content: View>: View {
 
     /// Creates a new scope with the specified content.
     ///
-    /// - Parameter content: The view content that inheriting from the parent.
-    public init(@ViewBuilder content: () -> Content) {
-        self.inheritance = .environment
+    /// - Parameters:
+    ///   - id: An identifier represents this scope used for matching scoped atoms.
+    ///   - content: The view content that inheriting from the parent.
+    public init<ID: Hashable>(id: ID = DefaultScopeID(), @ViewBuilder content: () -> Content) {
+        let id = ScopeID(id)
+        self.inheritance = .environment(id: id)
         self.content = content()
     }
 
@@ -66,8 +69,9 @@ public struct AtomScope<Content: View>: View {
     /// The content and behavior of the view.
     public var body: some View {
         switch inheritance {
-        case .environment:
+        case .environment(let id):
             InheritedEnvironment(
+                id: id,
                 content: content,
                 overrides: overrides,
                 observers: observers
@@ -94,7 +98,7 @@ public struct AtomScope<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func observe(_ onUpdate: @escaping @MainActor (Snapshot) -> Void) -> Self {
-        mutating { $0.observers.append(Observer(onUpdate: onUpdate)) }
+        mutating(self) { $0.observers.append(Observer(onUpdate: onUpdate)) }
     }
 
     /// Override the atom value used in this scope with the given value.
@@ -110,7 +114,7 @@ public struct AtomScope<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
+        mutating(self) { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
     }
 
     /// Override the atom value used in this scope with the given value.
@@ -128,13 +132,13 @@ public struct AtomScope<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
+        mutating(self) { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
     }
 }
 
 private extension AtomScope {
     enum Inheritance {
-        case environment
+        case environment(id: ScopeID)
         case context(AtomViewContext)
     }
 
@@ -144,6 +148,7 @@ private extension AtomScope {
             let token = ScopeKey.Token()
         }
 
+        let id: ScopeID
         let content: Content
         let overrides: [OverrideKey: any AtomOverrideProtocol]
         let observers: [Observer]
@@ -158,6 +163,7 @@ private extension AtomScope {
                 \.store,
                 environmentStore.scoped(
                     scopeKey: ScopeKey(token: state.token),
+                    scopeID: id,
                     observers: observers,
                     overrides: overrides
                 )
@@ -180,11 +186,5 @@ private extension AtomScope {
                 )
             )
         }
-    }
-
-    func `mutating`(_ mutation: (inout Self) -> Void) -> Self {
-        var view = self
-        mutation(&view)
-        return view
     }
 }

--- a/Sources/Atoms/Atoms.docc/Atoms.md
+++ b/Sources/Atoms/Atoms.docc/Atoms.md
@@ -33,6 +33,7 @@ Building state by compositing atoms automatically optimizes rendering based on i
 
 ### Attributes
 
+- ``Scoped``
 - ``KeepAlive``
 - ``Refreshable``
 - ``Resettable``
@@ -85,3 +86,4 @@ Building state by compositing atoms automatically optimizes rendering based on i
 - ``ObservableObjectAtomLoader``
 - ``ModifiedAtomLoader``
 - ``AtomLoaderContext``
+- ``DefaultScopeID``

--- a/Sources/Atoms/Attribute/KeepAlive.swift
+++ b/Sources/Atoms/Attribute/KeepAlive.swift
@@ -1,7 +1,7 @@
 /// An attribute protocol to allow the value of an atom to continue being retained
 /// even after they are no longer watched.
 ///
-/// Note that overridden atoms are not retained even with this attribute.
+/// Note that overridden or scoped atoms are not retained even with this attribute.
 ///
 /// ## Example
 ///

--- a/Sources/Atoms/Attribute/Scoped.swift
+++ b/Sources/Atoms/Attribute/Scoped.swift
@@ -1,5 +1,5 @@
-/// An attribute protocol to preserve the atom state in the nearest scope in the ancestor of
-/// where it is used and prevent it from being shared outside of the scope.
+/// An attribute protocol to preserve the atom state in the scope nearest to the ancestor
+/// of where it is used and prevents it from being shared out of scope.
 ///
 /// If multiple scopes are nested, you can define an arbitrary `scopeID` to ensure that
 /// values are stored in a particular scope.

--- a/Sources/Atoms/Attribute/Scoped.swift
+++ b/Sources/Atoms/Attribute/Scoped.swift
@@ -1,5 +1,5 @@
-/// An attribute protocol to scope the atom in descendant views, and prevent it from
-/// being shared outside of the scope.
+/// An attribute protocol to preserve the atom state in the nearest scope in the ancestor of
+/// where it is used and prevent it from being shared outside of the scope.
 ///
 /// If multiple scopes are nested, you can define an arbitrary `scopeID` to ensure that
 /// values are stored in a particular scope.

--- a/Sources/Atoms/Attribute/Scoped.swift
+++ b/Sources/Atoms/Attribute/Scoped.swift
@@ -1,0 +1,15 @@
+public protocol Scoped where Self: Atom {
+    associatedtype ScopeID: Hashable = DefaultScopeID
+
+    var scopeID: ScopeID { get }
+}
+
+public extension Scoped where ScopeID == DefaultScopeID {
+    var scopeID: ScopeID {
+        DefaultScopeID()
+    }
+}
+
+public struct DefaultScopeID: Hashable {
+    public init() {}
+}

--- a/Sources/Atoms/Attribute/Scoped.swift
+++ b/Sources/Atoms/Attribute/Scoped.swift
@@ -1,15 +1,51 @@
+/// An attribute protocol to scope the atom in descendant views, and prevent it from
+/// being shared outside of the scope.
+///
+/// If multiple scopes are nested, you can define an arbitrary `scopeID` to ensure that
+/// values are stored in a particular scope.
+/// The atom with `scopeID` searches for the nearest ``AtomScope`` with the matching ID in
+/// ancestor views, and if not found, the state is shared within the app.
+///
+/// Note that other atoms that depend on the scoped atom will be in a shared state and must be
+/// given this attribute as well in order to scope them as well.
+///
+/// ## Example
+///
+/// ```swift
+/// struct SearchScopeID: Hashable {}
+///
+/// struct SearchQueryAtom: StateAtom, Scoped, Hashable {
+///     var scopeID: SearchScopeID {
+///         SearchScopeID()
+///     }
+///
+///     func defaultValue(context: Context) -> String {
+///          ""
+///     }
+/// }
+///
+/// AtomScope(id: SearchScopeID()) {
+///     SearchPane()
+/// }
+/// ```
+///
 public protocol Scoped where Self: Atom {
+    /// A type of the scope ID which is to find a matching scope.
     associatedtype ScopeID: Hashable = DefaultScopeID
 
+    /// A scope ID which is to find a matching scope.
     var scopeID: ScopeID { get }
 }
 
 public extension Scoped where ScopeID == DefaultScopeID {
+    /// A scope ID which is to find a matching scope.
     var scopeID: ScopeID {
         DefaultScopeID()
     }
 }
 
+/// A default scope ID to find a matching scope inbetween scoped atoms and ``AtomScope``.
 public struct DefaultScopeID: Hashable {
+    /// Creates a new default scope ID which is always indentical.
     public init() {}
 }

--- a/Sources/Atoms/Context/AtomCurrentContext.swift
+++ b/Sources/Atoms/Context/AtomCurrentContext.swift
@@ -40,7 +40,7 @@ public struct AtomCurrentContext<Coordinator>: AtomContext {
     /// and assigns a new value for the atom.
     /// When you assign a new value, it immediately notifies downstream atoms and views.
     ///
-    /// - SeeAlso: ``AtomViewContext/subscript(_:)``
+    /// - SeeAlso: ``AtomContext/subscript(_:)``
     ///
     /// ```swift
     /// let context = ...

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -442,6 +442,7 @@ internal extension AtomTestContext {
         StoreContext(
             _state.store,
             scopeKey: ScopeKey(token: _state.token),
+            inheritedScopeKeys: [:],
             observers: [],
             overrides: _state.overrides
         )

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -173,7 +173,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// and assigns a new value for the atom.
     /// When you assign a new value, it immediately notifies downstream atoms and views.
     ///
-    /// - SeeAlso: ``AtomTestContext/subscript(_:)``
+    /// - SeeAlso: ``AtomContext/subscript(_:)``
     ///
     /// ```swift
     /// let context = AtomTestContext()

--- a/Sources/Atoms/Context/AtomTransactionContext.swift
+++ b/Sources/Atoms/Context/AtomTransactionContext.swift
@@ -47,7 +47,7 @@ public struct AtomTransactionContext<Coordinator>: AtomWatchableContext {
     /// and assigns a new value for the atom.
     /// When you assign a new value, it immediately notifies downstream atoms and views.
     ///
-    /// - SeeAlso: ``AtomTransactionContext/subscript(_:)``
+    /// - SeeAlso: ``AtomContext/subscript(_:)``
     ///
     /// ```swift
     /// let context = ...

--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -46,7 +46,7 @@ public struct AtomViewContext: AtomWatchableContext {
     /// and assigns a new value for the atom.
     /// When you assign a new value, it immediately notifies downstream atoms and views.
     ///
-    /// - SeeAlso: ``AtomViewContext/subscript(_:)``
+    /// - SeeAlso: ``AtomContext/subscript(_:)``
     ///
     /// ```swift
     /// let context = ...

--- a/Sources/Atoms/Core/Environment.swift
+++ b/Sources/Atoms/Core/Environment.swift
@@ -12,6 +12,7 @@ private struct StoreEnvironmentKey: EnvironmentKey {
         StoreContext(
             nil,
             scopeKey: ScopeKey(token: ScopeKey.Token()),
+            inheritedScopeKeys: [:],
             observers: [],
             overrides: [:],
             enablesAssertion: true

--- a/Sources/Atoms/Core/ScopeID.swift
+++ b/Sources/Atoms/Core/ScopeID.swift
@@ -1,0 +1,7 @@
+internal struct ScopeID: Hashable {
+    private let id: AnyHashable
+
+    init(_ id: any Hashable) {
+        self.id = AnyHashable(id)
+    }
+}

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -217,7 +217,7 @@ internal struct StoreContext {
     @_disfavoredOverload
     func reset<Node: Atom>(_ atom: Node) {
         let override = lookupOverride(of: atom)
-        let scopeKey = override != nil ? scopeKey : nil
+        let scopeKey = lookupScopeKey(of: atom, isOverridden: override != nil)
         let key = AtomKey(atom, scopeKey: scopeKey)
 
         if let cache = lookupCache(of: atom, for: key) {
@@ -229,7 +229,7 @@ internal struct StoreContext {
     @usableFromInline
     func reset<Node: Resettable>(_ atom: Node) {
         let override = lookupOverride(of: atom)
-        let scopeKey = override != nil ? scopeKey : nil
+        let scopeKey = lookupScopeKey(of: atom, isOverridden: override != nil)
         let key = AtomKey(atom, scopeKey: scopeKey)
 
         guard let override else {
@@ -247,7 +247,7 @@ internal struct StoreContext {
     @usableFromInline
     func lookup<Node: Atom>(_ atom: Node) -> Node.Loader.Value? {
         let override = lookupOverride(of: atom)
-        let scopeKey = override != nil ? scopeKey : nil
+        let scopeKey = lookupScopeKey(of: atom, isOverridden: override != nil)
         let key = AtomKey(atom, scopeKey: scopeKey)
         let cache = lookupCache(of: atom, for: key)
 
@@ -257,7 +257,7 @@ internal struct StoreContext {
     @usableFromInline
     func unwatch(_ atom: some Atom, subscriber: Subscriber) {
         let override = lookupOverride(of: atom)
-        let scopeKey = override != nil ? scopeKey : nil
+        let scopeKey = lookupScopeKey(of: atom, isOverridden: override != nil)
         let key = AtomKey(atom, scopeKey: scopeKey)
 
         subscriber.subscribingKeys.remove(key)

--- a/Sources/Atoms/Core/Utilities.swift
+++ b/Sources/Atoms/Core/Utilities.swift
@@ -1,3 +1,9 @@
+func `mutating`<T>(_ value: T, _ mutation: (inout T) -> Void) -> T {
+    var value = value
+    mutation(&value)
+    return value
+}
+
 internal extension Task where Success == Never, Failure == Never {
     @inlinable
     static func sleep(seconds duration: Double) async throws {

--- a/Tests/AtomsTests/Attribute/KeepAliveTests.swift
+++ b/Tests/AtomsTests/Attribute/KeepAliveTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import Atoms
+
+final class KeepAliveTests: XCTestCase {
+    @MainActor
+    func testKeepAliveAtoms() {
+        struct KeepAliveAtom<T: Hashable>: ValueAtom, KeepAlive, Hashable {
+            let value: T
+
+            func value(context: Context) -> T {
+                value
+            }
+        }
+
+        struct ScopedKeepAliveAtom<T: Hashable>: ValueAtom, KeepAlive, Scoped, Hashable {
+            let value: T
+
+            func value(context: Context) -> T {
+                value
+            }
+        }
+
+        XCTContext.runActivity(named: "Should not be released") { _ in
+            let store = AtomStore()
+            let context = StoreContext(store)
+            let atom = KeepAliveAtom(value: 0)
+            let key = AtomKey(atom)
+            let subscriberState = SubscriberState()
+            let subscriber = Subscriber(subscriberState)
+
+            _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            XCTAssertNotNil(store.state.caches[key])
+
+            context.unwatch(atom, subscriber: subscriber)
+            XCTAssertNotNil(store.state.caches[key])
+        }
+
+        XCTContext.runActivity(named: "Should be released when overridden") { _ in
+            let store = AtomStore()
+            let context = StoreContext(store)
+            let atom = KeepAliveAtom(value: 0)
+            let scopeToken = ScopeKey.Token()
+            let scopeKey = ScopeKey(token: scopeToken)
+            let key = AtomKey(atom, scopeKey: scopeKey)
+            let scopedContext = context.scoped(
+                scopeKey: scopeKey,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [
+                    OverrideKey(atom): AtomOverride<KeepAliveAtom<Int>> { _ in 10 }
+                ]
+            )
+            let subscriberState = SubscriberState()
+            let subscriber = Subscriber(subscriberState)
+
+            _ = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            XCTAssertNotNil(store.state.caches[key])
+
+            scopedContext.unwatch(atom, subscriber: subscriber)
+            XCTAssertNil(store.state.caches[key])
+        }
+
+        XCTContext.runActivity(named: "Should be released when scoped") { _ in
+            let store = AtomStore()
+            let context = StoreContext(store)
+            let atom = ScopedKeepAliveAtom(value: 0)
+            let scopeToken = ScopeKey.Token()
+            let scopeKey = ScopeKey(token: scopeToken)
+            let key = AtomKey(atom, scopeKey: scopeKey)
+            let scopedContext = context.scoped(
+                scopeKey: scopeKey,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [:]
+            )
+            let subscriberState = SubscriberState()
+            let subscriber = Subscriber(subscriberState)
+
+            _ = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            XCTAssertNotNil(store.state.caches[key])
+
+            scopedContext.unwatch(atom, subscriber: subscriber)
+            XCTAssertNil(store.state.caches[key])
+        }
+    }
+}

--- a/Tests/AtomsTests/Attribute/RefreshableTests.swift
+++ b/Tests/AtomsTests/Attribute/RefreshableTests.swift
@@ -1,0 +1,69 @@
+import Combine
+import XCTest
+
+@testable import Atoms
+
+final class RefreshableTests: XCTestCase {
+    @MainActor
+    func testCustomRefresh() async {
+        let store = AtomStore()
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
+        let atom = TestCustomRefreshableAtom {
+            Just(0)
+        } refresh: {
+            .success(1)
+        }
+        let key = AtomKey(atom)
+        var snapshots = [Snapshot]()
+        let observer = Observer { snapshots.append($0) }
+        let context = StoreContext(store, observers: [observer])
+
+        let phase0 = await context.refresh(atom)
+        XCTAssertEqual(phase0.value, 1)
+        XCTAssertNil(store.state.caches[key])
+        XCTAssertNil(store.state.states[key])
+        XCTAssertTrue(snapshots.isEmpty)
+
+        var updateCount = 0
+        let phase1 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
+            updateCount += 1
+        }
+
+        XCTAssertTrue(phase1.isSuspending)
+
+        snapshots.removeAll()
+
+        let phase2 = await context.refresh(atom)
+        XCTAssertEqual(phase2.value, 1)
+        XCTAssertNotNil(store.state.states[key])
+        XCTAssertEqual((store.state.caches[key] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value, .success(1))
+        XCTAssertEqual(updateCount, 1)
+        XCTAssertEqual(
+            snapshots.map { $0.caches.mapValues { $0.value as? AsyncPhase<Int, Never> } },
+            [[key: .success(1)]]
+        )
+
+        let scopeKey = ScopeKey(token: ScopeKey.Token())
+        let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
+        let scopedContext = context.scoped(
+            scopeKey: scopeKey,
+            scopeID: ScopeID(DefaultScopeID()),
+            observers: [],
+            overrides: [
+                OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>> { _ in .success(2) }
+            ]
+        )
+
+        let phase3 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+        XCTAssertEqual(phase3.value, 2)
+
+        let phase4 = await scopedContext.refresh(atom)
+        XCTAssertEqual(phase4.value, 2)
+        XCTAssertNotNil(store.state.states[overrideAtomKey])
+        XCTAssertEqual(
+            (store.state.caches[overrideAtomKey] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value,
+            .success(2)
+        )
+    }
+}

--- a/Tests/AtomsTests/Attribute/ResettableTests.swift
+++ b/Tests/AtomsTests/Attribute/ResettableTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+@testable import Atoms
+
+final class ResettableTests: XCTestCase {
+    @MainActor
+    func testCustomReset() {
+        struct Counter: Equatable {
+            var value = 0
+            var update = 0
+            var reset = 0
+        }
+
+        let store = AtomStore()
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
+        var counter = Counter()
+        let atom = TestCustomResettableAtom(
+            defaultValue: { _ in
+                counter.value += 1
+                return 0
+            },
+            reset: { _ in
+                counter.reset += 1
+            }
+        )
+        let key = AtomKey(atom)
+        var snapshots = [Snapshot]()
+        let observer = Observer {
+            snapshots.append($0)
+        }
+        let context = StoreContext(store, observers: [observer])
+        let value0 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
+            counter.update += 1
+        }
+
+        snapshots.removeAll()
+        context.set(1, for: atom)
+
+        XCTAssertEqual(value0, 0)
+        XCTAssertEqual(counter, Counter(value: 1, update: 1, reset: 0))
+        XCTAssertEqual(
+            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
+            [[key: 1]]
+        )
+
+        snapshots.removeAll()
+        context.reset(atom)
+
+        XCTAssertEqual(counter, Counter(value: 1, update: 1, reset: 1))
+        XCTAssertTrue(snapshots.isEmpty)
+
+        context.unwatch(atom, subscriber: subscriber)
+        counter = Counter()
+
+        let scopeKey = ScopeKey(token: ScopeKey.Token())
+        let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
+        let scopedContext = context.scoped(
+            scopeKey: scopeKey,
+            scopeID: ScopeID(DefaultScopeID()),
+            observers: [],
+            overrides: [
+                OverrideKey(atom): AtomOverride<TestCustomResettableAtom<Int>> { _ in 2 }
+            ]
+        )
+        let value1 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
+            counter.update += 1
+        }
+
+        XCTAssertEqual(value1, 2)
+        XCTAssertEqual(counter, Counter(value: 0, update: 0, reset: 0))
+
+        scopedContext.reset(atom)
+
+        XCTAssertEqual(scopedContext.read(atom), 2)
+        XCTAssertEqual(counter, Counter(value: 0, update: 1, reset: 0))
+        XCTAssertNotNil(store.state.states[overrideAtomKey])
+        XCTAssertEqual((store.state.caches[overrideAtomKey] as? AtomCache<TestCustomResettableAtom<Int>>)?.value, 2)
+    }
+}

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -15,15 +15,16 @@ final class ScopedTests: XCTestCase {
             }
         }
 
+        let scope1Token = ScopeKey.Token()
+        let scope1Key = ScopeKey(token: scope1Token)
+        let scope2Token = ScopeKey.Token()
+        let scope2Key = ScopeKey(token: scope2Token)
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
+
         XCTContext.runActivity(named: "Should be scoped") { _ in
             let store = AtomStore()
             let context = StoreContext(store)
-            let scope1Token = ScopeKey.Token()
-            let scope1Key = ScopeKey(token: scope1Token)
-            let scope2Token = ScopeKey.Token()
-            let scope2Key = ScopeKey(token: scope2Token)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
             let scoped1Context = context.scoped(
                 scopeKey: scope1Key,
                 scopeID: ScopeID(DefaultScopeID()),
@@ -69,12 +70,6 @@ final class ScopedTests: XCTestCase {
         XCTContext.runActivity(named: "Should be scoped in particular scope") { _ in
             let store = AtomStore()
             let context = StoreContext(store)
-            let scope1Token = ScopeKey.Token()
-            let scope1Key = ScopeKey(token: scope1Token)
-            let scope2Token = ScopeKey.Token()
-            let scope2Key = ScopeKey(token: scope2Token)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
             let scopeID = "Scope 1"
             let scoped1Context = context.scoped(
                 scopeKey: scope1Key,

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+@testable import Atoms
+
+final class ScopedTests: XCTestCase {
+    @MainActor
+    func testScopedAtoms() {
+        struct ScopedAtom<ID: Hashable, T: Hashable>: ValueAtom, Scoped, Equatable {
+            let key = UniqueKey()
+            let scopeID: ID
+            let value: T
+
+            func value(context: Context) -> T {
+                value
+            }
+        }
+
+        XCTContext.runActivity(named: "Should be scoped") { _ in
+            let store = AtomStore()
+            let context = StoreContext(store)
+            let scope1Token = ScopeKey.Token()
+            let scope1Key = ScopeKey(token: scope1Token)
+            let scope2Token = ScopeKey.Token()
+            let scope2Key = ScopeKey(token: scope2Token)
+            let subscriberState = SubscriberState()
+            let subscriber = Subscriber(subscriberState)
+            let scoped1Context = context.scoped(
+                scopeKey: scope1Key,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [:]
+            )
+            let scoped2Context = scoped1Context.scoped(
+                scopeKey: scope2Key,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [:]
+            )
+            let atom = ScopedAtom(scopeID: DefaultScopeID(), value: 0)
+            let atomScope1Key = AtomKey(atom, scopeKey: scope1Key)
+            let atomScope2Key = AtomKey(atom, scopeKey: scope2Key)
+
+            XCTAssertEqual(
+                scoped1Context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {},
+                0
+            )
+            XCTAssertEqual(
+                store.state.caches[atomScope1Key] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
+                AtomCache(atom: atom, value: 0)
+            )
+            XCTAssertNil(store.state.caches[atomScope2Key])
+
+            scoped1Context.unwatch(atom, subscriber: subscriber)
+            XCTAssertNil(store.state.caches[atomScope1Key])
+
+            XCTAssertEqual(
+                scoped2Context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {},
+                0
+            )
+            XCTAssertEqual(
+                store.state.caches[atomScope2Key] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
+                AtomCache(atom: atom, value: 0)
+            )
+
+            scoped2Context.unwatch(atom, subscriber: subscriber)
+            XCTAssertNil(store.state.caches[atomScope2Key])
+        }
+
+        XCTContext.runActivity(named: "Should be scoped in particular scope") { _ in
+            let store = AtomStore()
+            let context = StoreContext(store)
+            let scope1Token = ScopeKey.Token()
+            let scope1Key = ScopeKey(token: scope1Token)
+            let scope2Token = ScopeKey.Token()
+            let scope2Key = ScopeKey(token: scope2Token)
+            let subscriberState = SubscriberState()
+            let subscriber = Subscriber(subscriberState)
+            let scopeID = "Scope 1"
+            let scoped1Context = context.scoped(
+                scopeKey: scope1Key,
+                scopeID: ScopeID(scopeID),
+                observers: [],
+                overrides: [:]
+            )
+            let scoped2Context = scoped1Context.scoped(
+                scopeKey: scope2Key,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [:]
+            )
+            let atom = ScopedAtom(scopeID: scopeID, value: 0)
+            let atomScope1Key = AtomKey(atom, scopeKey: scope1Key)
+            let atomScope2Key = AtomKey(atom, scopeKey: scope2Key)
+
+            XCTAssertEqual(
+                scoped2Context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {},
+                0
+            )
+            XCTAssertEqual(
+                store.state.caches[atomScope1Key] as? AtomCache<ScopedAtom<String, Int>>,
+                AtomCache(atom: atom, value: 0)
+            )
+            XCTAssertNil(store.state.caches[atomScope2Key])
+
+            scoped2Context.unwatch(atom, subscriber: subscriber)
+            XCTAssertNil(store.state.caches[atomScope1Key])
+        }
+    }
+}

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -365,69 +365,6 @@ final class StoreContextTests: XCTestCase {
     }
 
     @MainActor
-    func testCustomRefresh() async {
-        let store = AtomStore()
-        let subscriberState = SubscriberState()
-        let subscriber = Subscriber(subscriberState)
-        let atom = TestCustomRefreshableAtom {
-            Just(0)
-        } refresh: {
-            .success(1)
-        }
-        let key = AtomKey(atom)
-        var snapshots = [Snapshot]()
-        let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
-
-        let phase0 = await context.refresh(atom)
-        XCTAssertEqual(phase0.value, 1)
-        XCTAssertNil(store.state.caches[key])
-        XCTAssertNil(store.state.states[key])
-        XCTAssertTrue(snapshots.isEmpty)
-
-        var updateCount = 0
-        let phase1 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-            updateCount += 1
-        }
-
-        XCTAssertTrue(phase1.isSuspending)
-
-        snapshots.removeAll()
-
-        let phase2 = await context.refresh(atom)
-        XCTAssertEqual(phase2.value, 1)
-        XCTAssertNotNil(store.state.states[key])
-        XCTAssertEqual((store.state.caches[key] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value, .success(1))
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? AsyncPhase<Int, Never> } },
-            [[key: .success(1)]]
-        )
-
-        let scopeKey = ScopeKey(token: ScopeKey.Token())
-        let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
-        let scopedContext = context.scoped(
-            scopeKey: scopeKey,
-            scopeID: ScopeID(DefaultScopeID()),
-            observers: [],
-            overrides: [
-                OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>> { _ in .success(2) }
-            ]
-        )
-
-        let phase3 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
-        XCTAssertEqual(phase3.value, 2)
-
-        let phase4 = await scopedContext.refresh(atom)
-        XCTAssertEqual(phase4.value, 2)
-        XCTAssertNotNil(store.state.states[overrideAtomKey])
-        XCTAssertEqual(
-            (store.state.caches[overrideAtomKey] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value,
-            .success(2)
-        )
-    }
-
-    @MainActor
     func testReset() {
         let store = AtomStore()
         let subscriberState = SubscriberState()
@@ -457,81 +394,6 @@ final class StoreContextTests: XCTestCase {
             snapshots.map { $0.caches.mapValues { $0.value as? Int } },
             [[key: 0]]
         )
-    }
-
-    @MainActor
-    func testCustomReset() {
-        struct Counter: Equatable {
-            var value = 0
-            var update = 0
-            var reset = 0
-        }
-
-        let store = AtomStore()
-        let subscriberState = SubscriberState()
-        let subscriber = Subscriber(subscriberState)
-        var counter = Counter()
-        let atom = TestCustomResettableAtom(
-            defaultValue: { _ in
-                counter.value += 1
-                return 0
-            },
-            reset: { _ in
-                counter.reset += 1
-            }
-        )
-        let key = AtomKey(atom)
-        var snapshots = [Snapshot]()
-        let observer = Observer {
-            snapshots.append($0)
-        }
-        let context = StoreContext(store, observers: [observer])
-        let value0 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-            counter.update += 1
-        }
-
-        snapshots.removeAll()
-        context.set(1, for: atom)
-
-        XCTAssertEqual(value0, 0)
-        XCTAssertEqual(counter, Counter(value: 1, update: 1, reset: 0))
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 1]]
-        )
-
-        snapshots.removeAll()
-        context.reset(atom)
-
-        XCTAssertEqual(counter, Counter(value: 1, update: 1, reset: 1))
-        XCTAssertTrue(snapshots.isEmpty)
-
-        context.unwatch(atom, subscriber: subscriber)
-        counter = Counter()
-
-        let scopeKey = ScopeKey(token: ScopeKey.Token())
-        let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
-        let scopedContext = context.scoped(
-            scopeKey: scopeKey,
-            scopeID: ScopeID(DefaultScopeID()),
-            observers: [],
-            overrides: [
-                OverrideKey(atom): AtomOverride<TestCustomResettableAtom<Int>> { _ in 2 }
-            ]
-        )
-        let value1 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-            counter.update += 1
-        }
-
-        XCTAssertEqual(value1, 2)
-        XCTAssertEqual(counter, Counter(value: 0, update: 0, reset: 0))
-
-        scopedContext.reset(atom)
-
-        XCTAssertEqual(scopedContext.read(atom), 2)
-        XCTAssertEqual(counter, Counter(value: 0, update: 1, reset: 0))
-        XCTAssertNotNil(store.state.states[overrideAtomKey])
-        XCTAssertEqual((store.state.caches[overrideAtomKey] as? AtomCache<TestCustomResettableAtom<Int>>)?.value, 2)
     }
 
     @MainActor
@@ -869,65 +731,19 @@ final class StoreContextTests: XCTestCase {
 
     @MainActor
     func testRelease() {
-        struct KeepAliveAtom<T: Hashable>: ValueAtom, KeepAlive, Hashable {
-            var value: T
-
-            func value(context: Context) -> T {
-                value
-            }
-        }
-
         let store = AtomStore()
         let context = StoreContext(store)
 
-        XCTContext.runActivity(named: "Normal atoms should be released.") { _ in
-            let atom = TestAtom(value: 0)
-            let key = AtomKey(atom)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
+        let atom = TestAtom(value: 0)
+        let key = AtomKey(atom)
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
 
-            _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
-            XCTAssertNotNil(store.state.caches[key])
+        _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+        XCTAssertNotNil(store.state.caches[key])
 
-            context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.state.caches[key])
-        }
-
-        XCTContext.runActivity(named: "KeepAlive atoms should not be released.") { _ in
-            let atom = KeepAliveAtom(value: 0)
-            let key = AtomKey(atom)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
-
-            _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
-            XCTAssertNotNil(store.state.caches[key])
-
-            context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNotNil(store.state.caches[key])
-        }
-
-        XCTContext.runActivity(named: "Overridden KeepAlive atoms should be released.") { _ in
-            let atom = KeepAliveAtom(value: 0)
-            let token = ScopeKey.Token()
-            let scopeKey = ScopeKey(token: token)
-            let key = AtomKey(atom, scopeKey: scopeKey)
-            let context = context.scoped(
-                scopeKey: scopeKey,
-                scopeID: ScopeID(DefaultScopeID()),
-                observers: [],
-                overrides: [
-                    OverrideKey(atom): AtomOverride<KeepAliveAtom<Int>> { _ in 10 }
-                ]
-            )
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
-
-            _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
-            XCTAssertNotNil(store.state.caches[key])
-
-            context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.state.caches[key])
-        }
+        context.unwatch(atom, subscriber: subscriber)
+        XCTAssertNil(store.state.caches[key])
     }
 
     @MainActor

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -14,6 +14,7 @@ final class StoreContextTests: XCTestCase {
         let context = StoreContext(
             store,
             scopeKey: scopeKey,
+            inheritedScopeKeys: [:],
             observers: [],
             overrides: [
                 OverrideKey(atom): AtomOverride<TestAtom<Int>> { _ in
@@ -53,6 +54,7 @@ final class StoreContextTests: XCTestCase {
         )
         let scopedContext = context.scoped(
             scopeKey: ScopeKey(token: ScopeKey.Token()),
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [observer1],
             overrides: [
                 OverrideKey(atom): AtomOverride<TestValueAtom<Int>> { _ in
@@ -343,6 +345,7 @@ final class StoreContextTests: XCTestCase {
         let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
         let scopedContext = context.scoped(
             scopeKey: scopeKey,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: [
                 OverrideKey(atom): AtomOverride<TestPublisherAtom<Just<Int>>> { _ in .success(1) }
@@ -405,6 +408,7 @@ final class StoreContextTests: XCTestCase {
         let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
         let scopedContext = context.scoped(
             scopeKey: scopeKey,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: [
                 OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>> { _ in .success(2) }
@@ -509,6 +513,7 @@ final class StoreContextTests: XCTestCase {
         let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
         let scopedContext = context.scoped(
             scopeKey: scopeKey,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: [
                 OverrideKey(atom): AtomOverride<TestCustomResettableAtom<Int>> { _ in 2 }
@@ -645,11 +650,13 @@ final class StoreContextTests: XCTestCase {
         let context = StoreContext(store)
         let scoped1Context = context.scoped(
             scopeKey: scope1Key,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: scoped1Overrides
         )
         let scoped2Context = scoped1Context.scoped(
             scopeKey: scope2Key,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: scoped2Overrides
         )
@@ -906,6 +913,7 @@ final class StoreContextTests: XCTestCase {
             let key = AtomKey(atom, scopeKey: scopeKey)
             let context = context.scoped(
                 scopeKey: scopeKey,
+                scopeID: ScopeID(DefaultScopeID()),
                 observers: [],
                 overrides: [
                     OverrideKey(atom): AtomOverride<KeepAliveAtom<Int>> { _ in 10 }
@@ -948,11 +956,13 @@ final class StoreContextTests: XCTestCase {
         )
         let scoped1Context = context.scoped(
             scopeKey: scope1Key,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: [:]
         )
         let scoped2Context = scoped1Context.scoped(
             scopeKey: scope2Key,
+            scopeID: ScopeID(DefaultScopeID()),
             observers: [Observer { scopedSnapshots.append($0) }],
             overrides: scopedOverride
         )

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -66,6 +66,7 @@ extension StoreContext {
         self.init(
             store,
             scopeKey: ScopeKey(token: ScopeKey.Token()),
+            inheritedScopeKeys: [:],
             observers: observers,
             overrides: overrides
         )


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Introduces a new feature called `Scoped Atoms` that is to allow atoms to be scoped in a particular scope instead of always being shared within the app.
A scope can be defined with `AtomScope`.
The state of an atom with the newly introduced `Scoped` attribute is scoped to the nearest scope in the ancestor of where it is used.
If the atom needs to be scoped to a particular scope, it can define an arbitrary `scopeID` to find a matching scope from the ancestor.

## Impact on Existing Code

- Adds a new initializer parameter to `AtomScope`.
