### PR TITLE
AtomStore can now be hosted only in AtomRoot

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -42,9 +42,26 @@ import SwiftUI
 /// }
 /// ```
 ///
+/// Additionally, if for some reason you want to manage the store on your own,
+/// you can pass the instance to allow descendant views to store atom values
+/// in the given store.
+///
+/// ```swift
+/// let store = AtomStore()
+///
+/// struct Application: App {
+///     var body: some Scene {
+///         WindowGroup {
+///             AtomRoot(storesIn: store) {
+///                 RootView()
+///             }
+///         }
+///     }
+/// }
+/// ```
+///
 public struct AtomRoot<Content: View>: View {
-    @StateObject
-    private var state = State()
+    private var storeHost: StoreHost
     private var overrides = [OverrideKey: any AtomOverrideProtocol]()
     private var observers = [Observer]()
     private let content: Content
@@ -53,20 +70,42 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Parameter content: The content that uses atoms.
     public init(@ViewBuilder content: () -> Content) {
+        self.storeHost = .tree
+        self.content = content()
+    }
+
+    /// Creates a new scope with the specified content that will be allowed to use atoms by
+    /// passing a store object.
+    ///
+    /// - Parameters:
+    ///   - store: An object that stores the state of atoms.
+    ///   - content: The view content that inheriting from the parent.
+    public init(
+        storesIn store: AtomStore,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.storeHost = .unmanaged(store: store)
         self.content = content()
     }
 
     /// The content and behavior of the view.
     public var body: some View {
-        content.environment(
-            \.store,
-            StoreContext(
-                state.store,
-                scopeKey: ScopeKey(token: state.token),
-                observers: observers,
-                overrides: overrides
+        switch storeHost {
+        case .tree:
+            TreeHostedStore(
+                content: content,
+                overrides: overrides,
+                observers: observers
             )
-        )
+
+        case .unmanaged(let store):
+            UnmanagedStore(
+                content: content,
+                store: store,
+                overrides: overrides,
+                observers: observers
+            )
+        }
     }
 
     /// For debugging purposes, each time there is a change in the internal state,
@@ -112,10 +151,63 @@ public struct AtomRoot<Content: View>: View {
 }
 
 private extension AtomRoot {
-    @MainActor
-    final class State: ObservableObject {
-        let store = AtomStore()
-        let token = ScopeKey.Token()
+    enum StoreHost {
+        case tree
+        case unmanaged(store: AtomStore)
+    }
+
+    struct TreeHostedStore: View {
+        @MainActor
+        final class State: ObservableObject {
+            let store = AtomStore()
+            let token = ScopeKey.Token()
+        }
+
+        let content: Content
+        let overrides: [OverrideKey: any AtomOverrideProtocol]
+        let observers: [Observer]
+
+        @StateObject
+        private var state = State()
+
+        var body: some View {
+            content.environment(
+                \.store,
+                StoreContext(
+                    state.store,
+                    scopeKey: ScopeKey(token: state.token),
+                    observers: observers,
+                    overrides: overrides
+                )
+            )
+        }
+    }
+
+    struct UnmanagedStore: View {
+        @MainActor
+        final class State: ObservableObject {
+            let token = ScopeKey.Token()
+        }
+
+        let content: Content
+        let store: AtomStore
+        let overrides: [OverrideKey: any AtomOverrideProtocol]
+        let observers: [Observer]
+
+        @StateObject
+        private var state = State()
+
+        var body: some View {
+            content.environment(
+                \.store,
+                StoreContext(
+                    store,
+                    scopeKey: ScopeKey(token: state.token),
+                    observers: observers,
+                    overrides: overrides
+                )
+            )
+        }
     }
 
     func `mutating`(_ mutation: (inout Self) -> Void) -> Self {

--- a/Sources/Atoms/Deprecated.swift
+++ b/Sources/Atoms/Deprecated.swift
@@ -18,11 +18,13 @@ public extension AtomScope {
         self.init(inheriting: context, content: content)
     }
 
-    @available(*, deprecated, renamed: "init(storesIn:content:)")
-    init(
+    @available(*, deprecated, renamed: "AtomRoot.init(storesIn:content:)")
+    init<Root: View>(
         _ store: AtomStore,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.init(storesIn: store, content: content)
+        @ViewBuilder content: () -> Root
+    ) where Content == AtomRoot<Root> {
+        self.init {
+            AtomRoot(storesIn: store, content: content)
+        }
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

`AtomStore` managed outside the view tree could be used for atom's state management by passing it to `AtomScope`, but that functionality will be transferred to `AtomRoot`.

## Impact on Existing Code

`AtomScope(storesIn:content:)` have to be changed to `AtomRoot(storesIn:content:)`
