### PR TITLE
Scoped Override

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -17,15 +17,15 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// Optionally, this component allows you to override a value of arbitrary atoms, that's useful
+/// This view allows you to override a value of arbitrary atoms, which is useful
 /// for dependency injection in testing.
 ///
 /// ```swift
 /// AtomRoot {
-///     MyView()
+///     RootView()
 /// }
-/// .override(RepositoryAtom()) {
-///     FakeRepository()
+/// .override(APIClientAtom()) {
+///     StubAPIClient()
 /// }
 /// ```
 ///
@@ -118,10 +118,10 @@ public struct AtomRoot<Content: View>: View {
         mutating(self) { $0.observers.append(Observer(onUpdate: onUpdate)) }
     }
 
-    /// Overrides the atom value with the given value.
+    /// Overrides the atoms with the given value.
     ///
-    /// When accessing the overridden atom, this context will create and return the given value
-    /// instead of the atom value.
+    /// It will create and return the given value instead of the actual atom value when accessing
+    /// the overridden atom in any scopes.
     ///
     /// - Parameters:
     ///   - atom: An atom to be overridden.
@@ -129,15 +129,15 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating(self) { $0.overrides[OverrideKey(atom)] = AtomOverride(value: value) }
+        mutating(self) { $0.overrides[OverrideKey(atom)] = AtomOverride(isScoped: false, value: value) }
     }
 
-    /// Overrides the atom value with the given value.
+    /// Overrides the atoms with the given value.
     ///
-    /// Instead of overriding the particular instance of atom, this method overrides any atom that
-    /// has the same metatype.
-    /// When accessing the overridden atom, this context will create and return the given value
-    /// instead of the atom value.
+    /// It will create and return the given value instead of the actual atom value when accessing
+    /// the overridden atom in any scopes.
+    /// This method overrides any atoms that has the same metatype, instead of overriding
+    /// the particular instance of atom.
     ///
     /// - Parameters:
     ///   - atomType: An atom type to be overridden.
@@ -145,7 +145,7 @@ public struct AtomRoot<Content: View>: View {
     ///
     /// - Returns: The self instance.
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
-        mutating(self) { $0.overrides[OverrideKey(atomType)] = AtomOverride(value: value) }
+        mutating(self) { $0.overrides[OverrideKey(atomType)] = AtomOverride(isScoped: false, value: value) }
     }
 }
 
@@ -178,7 +178,8 @@ private extension AtomRoot {
                     inheritedScopeKeys: [:],
                     observers: observers,
                     scopedObservers: [],
-                    overrides: overrides
+                    overrides: overrides,
+                    scopedOverrides: [:]
                 )
             )
         }
@@ -207,7 +208,8 @@ private extension AtomRoot {
                     inheritedScopeKeys: [:],
                     observers: observers,
                     scopedObservers: [],
-                    overrides: overrides
+                    overrides: overrides,
+                    scopedOverrides: [:]
                 )
             )
         }

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -366,7 +366,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///   - value: A value to be used instead of the atom's value.
     @inlinable
     public func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) {
-        _state.overrides[OverrideKey(atom)] = AtomOverride(value: value)
+        _state.overrides[OverrideKey(atom)] = AtomOverride(isScoped: false, value: value)
     }
 
     /// Overrides the atom value with the given value.
@@ -381,7 +381,7 @@ public struct AtomTestContext: AtomWatchableContext {
     ///   - value: A value to be used instead of the atom's value.
     @inlinable
     public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) {
-        _state.overrides[OverrideKey(atomType)] = AtomOverride(value: value)
+        _state.overrides[OverrideKey(atomType)] = AtomOverride(isScoped: false, value: value)
     }
 }
 
@@ -444,7 +444,8 @@ internal extension AtomTestContext {
             inheritedScopeKeys: [:],
             observers: [],
             scopedObservers: [],
-            overrides: _state.overrides
+            overrides: _state.overrides,
+            scopedOverrides: [:]
         )
     }
 

--- a/Sources/Atoms/Core/AtomOverride.swift
+++ b/Sources/Atoms/Core/AtomOverride.swift
@@ -2,16 +2,20 @@
 internal protocol AtomOverrideProtocol {
     associatedtype Node: Atom
 
+    var isScoped: Bool { get }
     var value: (Node) -> Node.Loader.Value { get }
 }
 
 @usableFromInline
 internal struct AtomOverride<Node: Atom>: AtomOverrideProtocol {
     @usableFromInline
+    let isScoped: Bool
+    @usableFromInline
     let value: (Node) -> Node.Loader.Value
 
     @usableFromInline
-    init(value: @escaping (Node) -> Node.Loader.Value) {
+    init(isScoped: Bool, value: @escaping (Node) -> Node.Loader.Value) {
+        self.isScoped = isScoped
         self.value = value
     }
 }

--- a/Sources/Atoms/Core/Environment.swift
+++ b/Sources/Atoms/Core/Environment.swift
@@ -16,6 +16,7 @@ private struct StoreEnvironmentKey: EnvironmentKey {
             observers: [],
             scopedObservers: [],
             overrides: [:],
+            scopedOverrides: [:],
             enablesAssertion: true
         )
     }

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -585,8 +585,10 @@ private extension StoreContext {
     }
 
     func lookupOverride<Node: Atom>(of atom: Node) -> AtomOverride<Node>? {
-        let overrideKey = OverrideKey(atom)
-        let typeOverrideKey = OverrideKey(Node.self)
+        lazy var overrideKey = OverrideKey(atom)
+        lazy var typeOverrideKey = OverrideKey(Node.self)
+
+        // OPTIMIZE: Desirable to reduce the number of dictionary lookups which is currently 4 times.
         let baseScopedOverride = scopedOverrides[overrideKey] ?? scopedOverrides[typeOverrideKey]
         let baseOverride = baseScopedOverride ?? overrides[overrideKey] ?? overrides[typeOverrideKey]
 

--- a/Sources/Atoms/Deprecated.swift
+++ b/Sources/Atoms/Deprecated.swift
@@ -32,4 +32,14 @@ public extension AtomScope {
     func observe(_ onUpdate: @escaping @MainActor (Snapshot) -> Void) -> Self {
         scopedObserve(onUpdate)
     }
+
+    @available(*, deprecated, renamed: "scopedOverride(_:with:)")
+    func override<Node: Atom>(_ atom: Node, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
+        scopedOverride(atom, with: value)
+    }
+
+    @available(*, deprecated, renamed: "scopedOverride(_:with:)")
+    func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping (Node) -> Node.Loader.Value) -> Self {
+        scopedOverride(atomType, with: value)
+    }
 }

--- a/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
@@ -122,6 +122,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             context.override(atom) { _ in .success(200) }
             pipe.reset()
 
+            context.unwatch(atom)
             XCTAssertEqual(context.watch(atom).value, 200)
 
             let phase = await context.refresh(atom)

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -121,6 +121,7 @@ final class PublisherAtomTests: XCTestCase {
             context.override(atom) { _ in .success(200) }
             subject.reset()
 
+            context.unwatch(atom)
             XCTAssertEqual(context.watch(atom).value, 200)
 
             let phase = await context.refresh(atom)

--- a/Tests/AtomsTests/Attribute/KeepAliveTests.swift
+++ b/Tests/AtomsTests/Attribute/KeepAliveTests.swift
@@ -48,7 +48,7 @@ final class KeepAliveTests: XCTestCase {
                 scopeID: ScopeID(DefaultScopeID()),
                 observers: [],
                 overrides: [
-                    OverrideKey(atom): AtomOverride<KeepAliveAtom<Int>> { _ in 10 }
+                    OverrideKey(atom): AtomOverride<KeepAliveAtom<Int>>(isScoped: true) { _ in 10 }
                 ]
             )
             let subscriberState = SubscriberState()

--- a/Tests/AtomsTests/Attribute/RefreshableTests.swift
+++ b/Tests/AtomsTests/Attribute/RefreshableTests.swift
@@ -51,7 +51,7 @@ final class RefreshableTests: XCTestCase {
             scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: [
-                OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>> { _ in .success(2) }
+                OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>>(isScoped: true) { _ in .success(2) }
             ]
         )
 

--- a/Tests/AtomsTests/Attribute/ResettableTests.swift
+++ b/Tests/AtomsTests/Attribute/ResettableTests.swift
@@ -60,7 +60,7 @@ final class ResettableTests: XCTestCase {
             scopeID: ScopeID(DefaultScopeID()),
             observers: [],
             overrides: [
-                OverrideKey(atom): AtomOverride<TestCustomResettableAtom<Int>> { _ in 2 }
+                OverrideKey(atom): AtomOverride<TestCustomResettableAtom<Int>>(isScoped: true) { _ in 2 }
             ]
         )
         let value1 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -60,16 +60,18 @@ final class ResettableSubject<Output, Failure: Error>: Publisher, Subject {
 extension StoreContext {
     init(
         _ store: AtomStore? = nil,
+        scopeKey: ScopeKey = ScopeKey(token: ScopeKey.Token()),
         observers: [Observer] = [],
         overrides: [OverrideKey: any AtomOverrideProtocol] = [:]
     ) {
         self.init(
             store,
-            scopeKey: ScopeKey(token: ScopeKey.Token()),
+            scopeKey: scopeKey,
             inheritedScopeKeys: [:],
             observers: observers,
             scopedObservers: [],
-            overrides: overrides
+            overrides: overrides,
+            scopedOverrides: [:]
         )
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

This PR adds a rather *non* scoped override way and changes the current behavior to a more explicit interface.
With the recent changes, nested AtomScopes is no longer inherits overrides from both AtomRoot, which made dependency injection for the entire app difficult.
This PR changes AtomRoot `override` to be inherited by all scopes.

## Impact on Existing Code

- `AtomScope.override(_:)` is deprecated and renamed to `AtomScope.scopedOverride(_:)`.
- Overriding in `AtomRoot` is now inherited by any scopes.
