### PR TITLE
Internal refactoring

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -173,7 +173,7 @@ private extension AtomRoot {
             content.environment(
                 \.store,
                 StoreContext(
-                    state.store,
+                    store: state.store,
                     scopeKey: ScopeKey(token: state.token),
                     inheritedScopeKeys: [:],
                     observers: observers,
@@ -203,7 +203,7 @@ private extension AtomRoot {
             content.environment(
                 \.store,
                 StoreContext(
-                    store,
+                    store: store,
                     scopeKey: ScopeKey(token: state.token),
                     inheritedScopeKeys: [:],
                     observers: observers,

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -172,7 +172,7 @@ private extension AtomScope {
         var body: some View {
             content.environment(
                 \.store,
-                environmentStore.scoped(
+                environmentStore?.scoped(
                     scopeKey: ScopeKey(token: state.token),
                     scopeID: id,
                     observers: observers,

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -439,7 +439,7 @@ internal extension AtomTestContext {
     @usableFromInline
     var _store: StoreContext {
         StoreContext(
-            _state.store,
+            store: _state.store,
             scopeKey: ScopeKey(token: _state.token),
             inheritedScopeKeys: [:],
             observers: [],

--- a/Sources/Atoms/Core/Environment.swift
+++ b/Sources/Atoms/Core/Environment.swift
@@ -1,23 +1,14 @@
 import SwiftUI
 
 internal extension EnvironmentValues {
-    var store: StoreContext {
+    var store: StoreContext? {
         get { self[StoreEnvironmentKey.self] }
         set { self[StoreEnvironmentKey.self] = newValue }
     }
 }
 
 private struct StoreEnvironmentKey: EnvironmentKey {
-    static var defaultValue: StoreContext {
-        StoreContext(
-            nil,
-            scopeKey: ScopeKey(token: ScopeKey.Token()),
-            inheritedScopeKeys: [:],
-            observers: [],
-            scopedObservers: [],
-            overrides: [:],
-            scopedOverrides: [:],
-            enablesAssertion: true
-        )
+    static var defaultValue: StoreContext? {
+        nil
     }
 }

--- a/Sources/Atoms/PropertyWrapper/ViewContext.swift
+++ b/Sources/Atoms/PropertyWrapper/ViewContext.swift
@@ -39,11 +39,13 @@ public struct ViewContext: DynamicProperty {
     @Environment(\.store)
     private var _store
 
+    private let file: StaticString
     private let location: SourceLocation
 
     /// Creates a view context.
-    public init(fileID: String = #fileID, line: UInt = #line) {
-        location = SourceLocation(fileID: fileID, line: line)
+    public init(file: StaticString = #file, fileID: String = #fileID, line: UInt = #line) {
+        self.file = file
+        self.location = SourceLocation(fileID: fileID, line: line)
     }
 
     /// The underlying view context to interact with atoms.
@@ -53,7 +55,7 @@ public struct ViewContext: DynamicProperty {
     /// Instead, you use the property variable created with the `@ViewContext` attribute.
     public var wrappedValue: AtomViewContext {
         AtomViewContext(
-            store: _store,
+            store: store,
             subscriber: Subscriber(state.subscriberState, location: location),
             notifyUpdate: state.objectWillChange.send
         )
@@ -64,5 +66,75 @@ private extension ViewContext {
     @MainActor
     final class State: ObservableObject {
         let subscriberState = SubscriberState()
+    }
+
+    var store: StoreContext {
+        guard let _store else {
+            assertionFailure(
+                """
+                [Atoms]
+                There is no store provided on the current view tree.
+                Make sure that this application has an `AtomRoot` as a root ancestor of any view.
+
+                ```
+                struct ExampleApp: App {
+                    var body: some Scene {
+                        WindowGroup {
+                            AtomRoot {
+                                ExampleView()
+                            }
+                        }
+                    }
+                }
+                ```
+
+                If for some reason the view tree is formed that does not inherit from `EnvironmentValues`,
+                consider using `AtomScope` to pass it.
+                That happens when using SwiftUI view wrapped with `UIHostingController`.
+
+                ```
+                struct ExampleView: View {
+                    @ViewContext
+                    var context
+
+                    var body: some View {
+                        UIViewWrappingView {
+                            AtomScope(inheriting: context) {
+                                WrappedView()
+                            }
+                        }
+                    }
+                }
+                ```
+
+                The modal screen presented by the `.sheet` modifier or etc, inherits from the environment values,
+                but only in iOS14, there is a bug where the environment values will be dismantled during it is
+                dismissing. This also can be avoided by using `AtomScope` to explicitly inherit from it.
+
+                ```
+                .sheet(isPresented: ...) {
+                    AtomScope(inheriting: context) {
+                        ExampleView()
+                    }
+                }
+                ```
+                """,
+                file: file,
+                line: location.line
+            )
+
+            // Returns an ephemeral instance just to not crash in `-O` builds.
+            return StoreContext(
+                store: AtomStore(),
+                scopeKey: ScopeKey(token: ScopeKey.Token()),
+                inheritedScopeKeys: [:],
+                observers: [],
+                scopedObservers: [],
+                overrides: [:],
+                scopedOverrides: [:]
+            )
+        }
+
+        return _store
     }
 }

--- a/Tests/AtomsTests/Attribute/KeepAliveTests.swift
+++ b/Tests/AtomsTests/Attribute/KeepAliveTests.swift
@@ -23,7 +23,7 @@ final class KeepAliveTests: XCTestCase {
 
         XCTContext.runActivity(named: "Should not be released") { _ in
             let store = AtomStore()
-            let context = StoreContext(store)
+            let context = StoreContext(store: store)
             let atom = KeepAliveAtom(value: 0)
             let key = AtomKey(atom)
             let subscriberState = SubscriberState()
@@ -38,7 +38,7 @@ final class KeepAliveTests: XCTestCase {
 
         XCTContext.runActivity(named: "Should be released when overridden") { _ in
             let store = AtomStore()
-            let context = StoreContext(store)
+            let context = StoreContext(store: store)
             let atom = KeepAliveAtom(value: 0)
             let scopeToken = ScopeKey.Token()
             let scopeKey = ScopeKey(token: scopeToken)
@@ -63,7 +63,7 @@ final class KeepAliveTests: XCTestCase {
 
         XCTContext.runActivity(named: "Should be released when scoped") { _ in
             let store = AtomStore()
-            let context = StoreContext(store)
+            let context = StoreContext(store: store)
             let atom = ScopedKeepAliveAtom(value: 0)
             let scopeToken = ScopeKey.Token()
             let scopeKey = ScopeKey(token: scopeToken)

--- a/Tests/AtomsTests/Attribute/RefreshableTests.swift
+++ b/Tests/AtomsTests/Attribute/RefreshableTests.swift
@@ -17,7 +17,7 @@ final class RefreshableTests: XCTestCase {
         let key = AtomKey(atom)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         let phase0 = await context.refresh(atom)
         XCTAssertEqual(phase0.value, 1)

--- a/Tests/AtomsTests/Attribute/ResettableTests.swift
+++ b/Tests/AtomsTests/Attribute/ResettableTests.swift
@@ -29,7 +29,7 @@ final class ResettableTests: XCTestCase {
         let observer = Observer {
             snapshots.append($0)
         }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
         let value0 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
             counter.update += 1
         }

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -24,7 +24,7 @@ final class ScopedTests: XCTestCase {
 
         XCTContext.runActivity(named: "Should be scoped") { _ in
             let store = AtomStore()
-            let context = StoreContext(store)
+            let context = StoreContext(store: store)
             let scoped1Context = context.scoped(
                 scopeKey: scope1Key,
                 scopeID: ScopeID(DefaultScopeID()),
@@ -69,7 +69,7 @@ final class ScopedTests: XCTestCase {
 
         XCTContext.runActivity(named: "Should be scoped in particular scope") { _ in
             let store = AtomStore()
-            let context = StoreContext(store)
+            let context = StoreContext(store: store)
             let scopeID = "Scope 1"
             let scoped1Context = context.scoped(
                 scopeKey: scope1Key,

--- a/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
@@ -8,7 +8,7 @@ final class AtomCurrentContextTests: XCTestCase {
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
-        let context = AtomCurrentContext(store: StoreContext(store), coordinator: ())
+        let context = AtomCurrentContext(store: StoreContext(store: store), coordinator: ())
 
         XCTAssertEqual(context.read(atom), 100)
     }
@@ -19,7 +19,7 @@ final class AtomCurrentContextTests: XCTestCase {
         let dependency = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom)) {}
-        let storeContext = StoreContext(store)
+        let storeContext = StoreContext(store: store)
         let context = AtomCurrentContext(store: storeContext, coordinator: ())
 
         XCTAssertEqual(storeContext.watch(dependency, in: transaction), 100)
@@ -33,7 +33,7 @@ final class AtomCurrentContextTests: XCTestCase {
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let store = AtomStore()
-        let context = AtomCurrentContext(store: StoreContext(store), coordinator: ())
+        let context = AtomCurrentContext(store: StoreContext(store: store), coordinator: ())
         let value = await context.refresh(atom).value
 
         XCTAssertEqual(value, 100)
@@ -47,7 +47,7 @@ final class AtomCurrentContextTests: XCTestCase {
             .success(200)
         }
         let store = AtomStore()
-        let context = AtomCurrentContext(store: StoreContext(store), coordinator: ())
+        let context = AtomCurrentContext(store: StoreContext(store: store), coordinator: ())
         let value = await context.refresh(atom).value
 
         XCTAssertEqual(value, 200)
@@ -59,8 +59,8 @@ final class AtomCurrentContextTests: XCTestCase {
         let dependency = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom)) {}
-        let storeContext = StoreContext(store)
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let storeContext = StoreContext(store: store)
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertEqual(storeContext.watch(dependency, in: transaction), 0)
 
@@ -76,8 +76,8 @@ final class AtomCurrentContextTests: XCTestCase {
     @MainActor
     func testCustomReset() {
         let store = AtomStore()
-        let context = AtomCurrentContext(store: StoreContext(store), coordinator: ())
-        let storeContext = StoreContext(store)
+        let context = AtomCurrentContext(store: StoreContext(store: store), coordinator: ())
+        let storeContext = StoreContext(store: store)
         let transactionAtom = TestValueAtom(value: 0)
         let atom = TestStateAtom(defaultValue: 0)
         let transaction = Transaction(key: AtomKey(transactionAtom)) {}

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -9,7 +9,7 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertEqual(context.read(atom), 100)
     }
@@ -20,7 +20,7 @@ final class AtomTransactionContextTests: XCTestCase {
         let dependency = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertEqual(context.watch(dependency), 100)
 
@@ -35,7 +35,7 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom1 = TestPublisherAtom { Just(100) }
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom0)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertTrue(context.watch(atom1).isSuspending)
 
@@ -55,7 +55,7 @@ final class AtomTransactionContextTests: XCTestCase {
         }
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom0)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertTrue(context.watch(atom1).isSuspending)
 
@@ -71,7 +71,7 @@ final class AtomTransactionContextTests: XCTestCase {
         let dependency = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertEqual(context.watch(dependency), 0)
 
@@ -99,7 +99,7 @@ final class AtomTransactionContextTests: XCTestCase {
 
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(transactionAtom)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         XCTAssertEqual(context.watch(atom), 0)
         XCTAssertEqual(context.watch(resettableAtom), 0)
@@ -121,7 +121,7 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom1 = TestStateAtom(defaultValue: 200)
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom0)) {}
-        let context = AtomTransactionContext(store: StoreContext(store), transaction: transaction, coordinator: ())
+        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
         let value = context.watch(atom1)
 

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -10,7 +10,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -24,7 +24,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -42,7 +42,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -65,7 +65,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -84,7 +84,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -105,7 +105,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -140,7 +140,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -157,7 +157,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
             notifyUpdate: {}
         )
@@ -197,7 +197,7 @@ final class AtomViewContextTests: XCTestCase {
         let store = AtomStore()
         var subscriberState: SubscriberState? = SubscriberState()
         let context = AtomViewContext(
-            store: StoreContext(store),
+            store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState!),
             notifyUpdate: {}
         )

--- a/Tests/AtomsTests/Core/EnvironmentTests.swift
+++ b/Tests/AtomsTests/Core/EnvironmentTests.swift
@@ -11,8 +11,8 @@ final class EnvironmentTests: XCTestCase {
         var environment = EnvironmentValues()
 
         store.state.caches = [AtomKey(atom): AtomCache(atom: atom, value: 100)]
-        environment.store = StoreContext(store)
+        environment.store = StoreContext(store: store)
 
-        XCTAssertEqual(environment.store.read(atom), 100)
+        XCTAssertEqual(environment.store?.read(atom), 100)
     }
 }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -13,7 +13,7 @@ final class StoreContextTests: XCTestCase {
         let scopeToken = ScopeKey.Token()
         let scopeKey = ScopeKey(token: scopeToken)
         let context = StoreContext(
-            store,
+            store: store,
             scopeKey: scopeKey,
             inheritedScopeKeys: [:],
             observers: [],
@@ -46,7 +46,7 @@ final class StoreContextTests: XCTestCase {
         var snapshots0 = [Snapshot]()
         var snapshots1 = [Snapshot]()
         let context = StoreContext(
-            store,
+            store: store,
             scopeKey: scopeKey,
             observers: [
                 Observer { snapshots0.append($0) }
@@ -85,7 +85,7 @@ final class StoreContextTests: XCTestCase {
         var snapshots0 = [Snapshot]()
         var snapshots1 = [Snapshot]()
         let context = StoreContext(
-            store,
+            store: store,
             observers: [
                 Observer { snapshots0.append($0) }
             ]
@@ -115,28 +115,13 @@ final class StoreContextTests: XCTestCase {
     }
 
     @MainActor
-    func testStoreDeinit() {
-        let atom = TestAtom(value: 0)
-        let subscriberState = SubscriberState()
-        let subscriber = Subscriber(subscriberState)
-        var store: AtomStore? = AtomStore()
-        weak var storeRef = store
-        let context = StoreContext(store!)
-
-        XCTAssertEqual(context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}, 0)
-        XCTAssertNotNil(storeRef)
-        store = nil
-        XCTAssertNil(storeRef)
-    }
-
-    @MainActor
     func testRead() {
         let store = AtomStore()
         let atom = TestAtom(value: 0)
         let key = AtomKey(atom)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         XCTAssertEqual(context.read(atom), 0)
         XCTAssertNil(store.state.caches[key])
@@ -174,7 +159,7 @@ final class StoreContextTests: XCTestCase {
         var updateCount = 0
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         context.set(1, for: atom)
         XCTAssertEqual(updateCount, 0)
@@ -221,7 +206,7 @@ final class StoreContextTests: XCTestCase {
         let key = AtomKey(atom)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         context.modify(atom) { $0 = 1 }
         XCTAssertEqual(updateCount, 0)
@@ -270,7 +255,7 @@ final class StoreContextTests: XCTestCase {
         let transaction = Transaction(key: key) {}
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         XCTAssertEqual(context.watch(dependency0, in: transaction), 0)
         XCTAssertEqual(store.graph.dependencies, [key: [dependency0Key]])
@@ -318,7 +303,7 @@ final class StoreContextTests: XCTestCase {
         let dependencyKey = AtomKey(dependency)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
         var updateCount = 0
         let initialValue = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
             updateCount += 1
@@ -360,7 +345,7 @@ final class StoreContextTests: XCTestCase {
         let key = AtomKey(atom)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         let phase0 = await context.refresh(atom)
         XCTAssertEqual(phase0.value, 0)
@@ -419,7 +404,7 @@ final class StoreContextTests: XCTestCase {
         let key = AtomKey(atom)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
         var updateCount = 0
 
         _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
@@ -450,7 +435,7 @@ final class StoreContextTests: XCTestCase {
         let atom = TestStateAtom(defaultValue: 0)
         var snapshots = [Snapshot]()
         let observer = Observer { snapshots.append($0) }
-        let context = StoreContext(store, observers: [observer])
+        let context = StoreContext(store: store, observers: [observer])
 
         _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
         snapshots.removeAll()
@@ -466,7 +451,7 @@ final class StoreContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberToken = SubscriberKey.Token()
         let subscriberKey = SubscriberKey(token: subscriberToken)
-        let context = StoreContext(store)
+        let context = StoreContext(store: store)
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
         let key0 = AtomKey(atom0)
@@ -509,7 +494,7 @@ final class StoreContextTests: XCTestCase {
         let scope2Token = ScopeKey.Token()
         let scope2Key = ScopeKey(token: scope2Token)
         let context = StoreContext(
-            store,
+            store: store,
             scopeKey: rootScopeKey,
             overrides: [
                 // Should override atoms used in any scopes.
@@ -605,7 +590,7 @@ final class StoreContextTests: XCTestCase {
         let scope2Token = ScopeKey.Token()
         let scope1Key = ScopeKey(token: scope1Token)
         let scope2Key = ScopeKey(token: scope2Token)
-        let context = StoreContext(store)
+        let context = StoreContext(store: store)
         let scoped1Context = context.scoped(
             scopeKey: scope1Key,
             scopeID: ScopeID(DefaultScopeID()),
@@ -807,7 +792,7 @@ final class StoreContextTests: XCTestCase {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let subscriber = Subscriber(subscriberState)
-        let context = StoreContext(store)
+        let context = StoreContext(store: store)
         var valueCoordinator: TestAtom.Coordinator?
         var updatedCoordinator: TestAtom.Coordinator?
         let atom = TestAtom(
@@ -836,7 +821,7 @@ final class StoreContextTests: XCTestCase {
     @MainActor
     func testRelease() {
         let store = AtomStore()
-        let context = StoreContext(store)
+        let context = StoreContext(store: store)
 
         let atom = TestAtom(value: 0)
         let key = AtomKey(atom)
@@ -871,7 +856,7 @@ final class StoreContextTests: XCTestCase {
         var snapshots = [Snapshot]()
         var scopedSnapshots = [Snapshot]()
         let context = StoreContext(
-            store,
+            store: store,
             observers: [Observer { snapshots.append($0) }]
         )
         let scoped1Context = context.scoped(
@@ -1022,7 +1007,7 @@ final class StoreContextTests: XCTestCase {
     @MainActor
     func testRestore() {
         let store = AtomStore()
-        let context = StoreContext(store)
+        let context = StoreContext(store: store)
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
         let atom2 = TestAtom(value: 2)
@@ -1182,7 +1167,7 @@ final class StoreContextTests: XCTestCase {
         }
 
         let store = AtomStore()
-        let atomStore = StoreContext(store)
+        let atomStore = StoreContext(store: store)
         var subscriberState: SubscriberState? = SubscriberState()
         let subscriber = Subscriber(subscriberState!)
         let pipe = AsyncThrowingStreamPipe<Void>()

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -59,13 +59,13 @@ final class ResettableSubject<Output, Failure: Error>: Publisher, Subject {
 
 extension StoreContext {
     init(
-        _ store: AtomStore? = nil,
+        store: AtomStore = AtomStore(),
         scopeKey: ScopeKey = ScopeKey(token: ScopeKey.Token()),
         observers: [Observer] = [],
         overrides: [OverrideKey: any AtomOverrideProtocol] = [:]
     ) {
         self.init(
-            store,
+            store: store,
             scopeKey: scopeKey,
             inheritedScopeKeys: [:],
             observers: observers,


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

- Do not provide a dummy instance of StoreContext in environment values, and provide nil by default.
- Retain `AtomStore` in `StoreContext`.

## Impact on Existing Code

It's possible that some project with doing something tricky around swapping AtomStore instance in runtime because the store is no longer be released immediately, but it's not something we should support.