### PR TITLE
Do not override custom Resettable & Refreshable behavior

### DIFF
--- a/Tests/AtomsTests/Attribute/RefreshableTests.swift
+++ b/Tests/AtomsTests/Attribute/RefreshableTests.swift
@@ -19,51 +19,70 @@ final class RefreshableTests: XCTestCase {
         let observer = Observer { snapshots.append($0) }
         let context = StoreContext(store: store, observers: [observer])
 
-        let phase0 = await context.refresh(atom)
-        XCTAssertEqual(phase0.value, 1)
-        XCTAssertNil(store.state.caches[key])
-        XCTAssertNil(store.state.states[key])
-        XCTAssertTrue(snapshots.isEmpty)
+        do {
+            // Should call custom refresh behavior
 
-        var updateCount = 0
-        let phase1 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-            updateCount += 1
+            let phase0 = await context.refresh(atom)
+            XCTAssertEqual(phase0.value, 1)
+            XCTAssertNil(store.state.caches[key])
+            XCTAssertNil(store.state.states[key])
+            XCTAssertTrue(snapshots.isEmpty)
+
+            var updateCount = 0
+            let phase1 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
+                updateCount += 1
+            }
+
+            XCTAssertTrue(phase1.isSuspending)
+
+            snapshots.removeAll()
+
+            let phase2 = await context.refresh(atom)
+            XCTAssertEqual(phase2.value, 1)
+            XCTAssertNotNil(store.state.states[key])
+            XCTAssertEqual((store.state.caches[key] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value, .success(1))
+            XCTAssertEqual(updateCount, 1)
+            XCTAssertEqual(
+                snapshots.map { $0.caches.mapValues { $0.value as? AsyncPhase<Int, Never> } },
+                [[key: .success(1)]]
+            )
+
+            context.unwatch(atom, subscriber: subscriber)
         }
 
-        XCTAssertTrue(phase1.isSuspending)
+        do {
+            // Custom refresh behavior should not be overridden
 
-        snapshots.removeAll()
+            let scopeKey = ScopeKey(token: ScopeKey.Token())
+            let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
+            let scopedContext = context.scoped(
+                scopeKey: scopeKey,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [
+                    OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>>(isScoped: true) { _ in .success(2) }
+                ]
+            )
 
-        let phase2 = await context.refresh(atom)
-        XCTAssertEqual(phase2.value, 1)
-        XCTAssertNotNil(store.state.states[key])
-        XCTAssertEqual((store.state.caches[key] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value, .success(1))
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? AsyncPhase<Int, Never> } },
-            [[key: .success(1)]]
-        )
+            let phase0 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            XCTAssertEqual(phase0.value, 2)
 
-        let scopeKey = ScopeKey(token: ScopeKey.Token())
-        let overrideAtomKey = AtomKey(atom, scopeKey: scopeKey)
-        let scopedContext = context.scoped(
-            scopeKey: scopeKey,
-            scopeID: ScopeID(DefaultScopeID()),
-            observers: [],
-            overrides: [
-                OverrideKey(atom): AtomOverride<TestCustomRefreshableAtom<Just<Int>>>(isScoped: true) { _ in .success(2) }
-            ]
-        )
+            let phase1 = await scopedContext.refresh(atom)
+            XCTAssertEqual(phase1.value, 1)
+            XCTAssertNotNil(store.state.states[overrideAtomKey])
+            XCTAssertEqual(
+                (store.state.caches[overrideAtomKey] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value,
+                .success(1)
+            )
+        }
 
-        let phase3 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
-        XCTAssertEqual(phase3.value, 2)
+        do {
+            // Should not make new state and cache
 
-        let phase4 = await scopedContext.refresh(atom)
-        XCTAssertEqual(phase4.value, 2)
-        XCTAssertNotNil(store.state.states[overrideAtomKey])
-        XCTAssertEqual(
-            (store.state.caches[overrideAtomKey] as? AtomCache<TestCustomRefreshableAtom<Just<Int>>>)?.value,
-            .success(2)
-        )
+            let value = await context.refresh(atom)
+
+            XCTAssertNil(store.state.states[key])
+            XCTAssertNil(store.state.caches[key])
+        }
     }
 }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -424,6 +424,11 @@ final class StoreContextTests: XCTestCase {
         let context = StoreContext(store: store, observers: [observer])
         var updateCount = 0
 
+        context.reset(atom)
+        XCTAssertNil(store.state.caches[key])
+        XCTAssertNil(store.state.states[key])
+        XCTAssertTrue(snapshots.isEmpty)
+
         _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
             updateCount += 1
         }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

We've chosen to override the custom reset & refresh when the atom value is overridden to avoid the complexity of testing the atom. But changed my mind that as it is really implicit behavior and also would make some test scenarios impossible.
Thus, this PR makes it not override the custom reset & refresh behavior and simply calls it even if it is overridden.
It also includes some internal refactoring around ephemeral state that can be created when calling custom reset or while refreshing atoms.