### PR TITLE
Animation Modifier

### DIFF
--- a/Sources/Atoms/Atoms.docc/Atoms.md
+++ b/Sources/Atoms/Atoms.docc/Atoms.md
@@ -30,6 +30,7 @@ Building state by compositing atoms automatically optimizes rendering based on i
 - ``Atom/changes``
 - ``Atom/changes(of:)``
 - ``Atom/phase``
+- ``Atom/animation(_:)``
 
 ### Attributes
 
@@ -75,6 +76,7 @@ Building state by compositing atoms automatically optimizes rendering based on i
 - ``ChangesModifier``
 - ``ChangesOfModifier``
 - ``TaskPhaseModifier``
+- ``AnimationModifier``
 - ``AtomLoader``
 - ``RefreshableAtomLoader``
 - ``AsyncAtomLoader``

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -321,9 +321,11 @@ public struct AtomTestContext: AtomWatchableContext {
     @inlinable
     @discardableResult
     public func watch<Node: Atom>(_ atom: Node) -> Node.Loader.Value {
-        _store.watch(atom, subscriber: _subscriber, requiresObjectUpdate: true) { [weak _state] in
-            _state?.notifyUpdate()
-        }
+        _store.watch(
+            atom,
+            subscriber: _subscriber,
+            subscription: _subscription
+        )
     }
 
     /// Returns the already cached value associated with a given atom without side effects.
@@ -430,7 +432,7 @@ internal extension AtomTestContext {
         }
 
         @usableFromInline
-        func notifyUpdate() {
+        func update() {
             onUpdate?()
             notifier.send()
         }
@@ -451,6 +453,13 @@ internal extension AtomTestContext {
 
     @usableFromInline
     var _subscriber: Subscriber {
-        Subscriber(_state.subscriberState, location: location)
+        Subscriber(_state.subscriberState)
+    }
+
+    @usableFromInline
+    var _subscription: Subscription {
+        Subscription(location: location) { [weak _state] in
+            _state?.update()
+        }
     }
 }

--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -9,16 +9,16 @@ public struct AtomViewContext: AtomWatchableContext {
     @usableFromInline
     internal let _subscriber: Subscriber
     @usableFromInline
-    internal let _notifyUpdate: () -> Void
+    internal let _subscription: Subscription
 
     internal init(
         store: StoreContext,
         subscriber: Subscriber,
-        notifyUpdate: @escaping () -> Void
+        subscription: Subscription
     ) {
         _store = store
         _subscriber = subscriber
-        _notifyUpdate = notifyUpdate
+        _subscription = subscription
     }
 
     /// Accesses the value associated with the given atom without watching it.
@@ -198,8 +198,7 @@ public struct AtomViewContext: AtomWatchableContext {
         _store.watch(
             atom,
             subscriber: _subscriber,
-            requiresObjectUpdate: false,
-            notifyUpdate: _notifyUpdate
+            subscription: _subscription
         )
     }
 

--- a/Sources/Atoms/Core/Loader/AtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/AtomLoader.swift
@@ -19,11 +19,18 @@ public protocol AtomLoader {
     /// Returns a boolean value indicating whether it should notify updates downstream
     /// by checking the equivalence of the given old value and new value.
     func shouldUpdate(newValue: Value, oldValue: Value) -> Bool
+
+    /// Performs atom update.
+    func performUpdate(_ body: () -> Void)
 }
 
 public extension AtomLoader {
     func shouldUpdate(newValue: Value, oldValue: Value) -> Bool {
         true
+    }
+
+    func performUpdate(_ body: () -> Void) {
+        body()
     }
 }
 

--- a/Sources/Atoms/Core/Loader/AtomLoaderContext.swift
+++ b/Sources/Atoms/Core/Loader/AtomLoaderContext.swift
@@ -1,10 +1,10 @@
 /// The context structure to interact with an atom store.
 @MainActor
 public struct AtomLoaderContext<Value, Coordinator> {
-    internal let store: StoreContext
-    internal let transaction: Transaction
-    internal let coordinator: Coordinator
-    internal let update: @MainActor (Value) -> Void
+    private let store: StoreContext
+    private let transaction: Transaction
+    private let coordinator: Coordinator
+    private let update: @MainActor (Value) -> Void
 
     internal init(
         store: StoreContext,
@@ -16,6 +16,10 @@ public struct AtomLoaderContext<Value, Coordinator> {
         self.transaction = transaction
         self.coordinator = coordinator
         self.update = update
+    }
+
+    internal var isTerminated: Bool {
+        transaction.isTerminated
     }
 
     internal var modifierContext: AtomModifierContext<Value> {

--- a/Sources/Atoms/Core/Loader/AtomLoaderContext.swift
+++ b/Sources/Atoms/Core/Loader/AtomLoaderContext.swift
@@ -4,13 +4,13 @@ public struct AtomLoaderContext<Value, Coordinator> {
     internal let store: StoreContext
     internal let transaction: Transaction
     internal let coordinator: Coordinator
-    internal let update: @MainActor (Value, UpdateOrder) -> Void
+    internal let update: @MainActor (Value) -> Void
 
     internal init(
         store: StoreContext,
         transaction: Transaction,
         coordinator: Coordinator,
-        update: @escaping @MainActor (Value, UpdateOrder) -> Void
+        update: @escaping @MainActor (Value) -> Void
     ) {
         self.store = store
         self.transaction = transaction
@@ -24,8 +24,8 @@ public struct AtomLoaderContext<Value, Coordinator> {
         }
     }
 
-    internal func update(with value: Value, order: UpdateOrder = .newValue) {
-        update(value, order)
+    internal func update(with value: Value) {
+        update(value)
     }
 
     internal func addTermination(_ termination: @MainActor @escaping () -> Void) {

--- a/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ModifiedAtomLoader.swift
@@ -30,6 +30,11 @@ public struct ModifiedAtomLoader<Node: Atom, Modifier: AtomModifier>: AtomLoader
     public func shouldUpdate(newValue: Value, oldValue: Value) -> Bool {
         modifier.shouldUpdate(newValue: newValue, oldValue: oldValue)
     }
+
+    /// Performs atom update.
+    public func performUpdate(_ body: () -> Void) {
+        modifier.performUpdate(body)
+    }
 }
 
 extension ModifiedAtomLoader: RefreshableAtomLoader where Node.Loader: RefreshableAtomLoader, Modifier: RefreshableAtomModifier {

--- a/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
@@ -25,11 +25,11 @@ public struct ObservableObjectAtomLoader<Node: ObservableObjectAtom>: AtomLoader
     public func manageOverridden(value: Value, context: Context) -> Value {
         let cancellable = value
             .objectWillChange
-            .sink { _ in
+            .sink { [weak value] _ in
                 // Wait until the object's property is set, because `objectWillChange`
                 // emits an event before the property is updated.
                 RunLoop.main.perform(inModes: [.common]) {
-                    if !context.isTerminated {
+                    if !context.isTerminated, let value {
                         context.update(with: value)
                     }
                 }

--- a/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
@@ -29,7 +29,9 @@ public struct ObservableObjectAtomLoader<Node: ObservableObjectAtom>: AtomLoader
                 // Wait until the object's property is set, because `objectWillChange`
                 // emits an event before the property is updated.
                 RunLoop.main.perform(inModes: [.common]) {
-                    context.update(with: value)
+                    if !context.isTerminated {
+                        context.update(with: value)
+                    }
                 }
             }
 

--- a/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
+++ b/Sources/Atoms/Core/Loader/ObservableObjectAtomLoader.swift
@@ -23,13 +23,15 @@ public struct ObservableObjectAtomLoader<Node: ObservableObjectAtom>: AtomLoader
 
     /// Manage given overridden value updates and cancellations.
     public func manageOverridden(value: Value, context: Context) -> Value {
-        let cancellable = value.objectWillChange.sink { [weak value] _ in
-            guard let value else {
-                return
+        let cancellable = value
+            .objectWillChange
+            .sink { _ in
+                // Wait until the object's property is set, because `objectWillChange`
+                // emits an event before the property is updated.
+                RunLoop.main.perform(inModes: [.common]) {
+                    context.update(with: value)
+                }
             }
-
-            context.update(with: value, order: .objectWillChange)
-        }
 
         context.addTermination(cancellable.cancel)
 

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -168,7 +168,7 @@ internal struct StoreContext {
         }
 
         // Notify update unless it's cancelled or terminated by other operations.
-        if !Task.isCancelled && !context.transaction.isTerminated {
+        if !Task.isCancelled && !context.isTerminated {
             update(atom: atom, for: key, newValue: value, cache: cache)
         }
 

--- a/Sources/Atoms/Core/Subscriber.swift
+++ b/Sources/Atoms/Core/Subscriber.swift
@@ -4,12 +4,10 @@ internal struct Subscriber {
     private weak var state: SubscriberState?
 
     let key: SubscriberKey
-    let location: SourceLocation
 
-    init(_ state: SubscriberState, location: SourceLocation) {
+    init(_ state: SubscriberState) {
         self.state = state
         self.key = SubscriberKey(token: state.token)
-        self.location = location
     }
 
     var subscribingKeys: Set<AtomKey> {

--- a/Sources/Atoms/Core/Subscription.swift
+++ b/Sources/Atoms/Core/Subscription.swift
@@ -1,6 +1,6 @@
+@usableFromInline
 @MainActor
 internal struct Subscription {
     let location: SourceLocation
-    let requiresObjectUpdate: Bool
-    let notifyUpdate: () -> Void
+    let update: () -> Void
 }

--- a/Sources/Atoms/Core/UpdateOrder.swift
+++ b/Sources/Atoms/Core/UpdateOrder.swift
@@ -1,4 +1,0 @@
-internal enum UpdateOrder {
-    case newValue
-    case objectWillChange
-}

--- a/Sources/Atoms/Modifier/AnimationModifier.swift
+++ b/Sources/Atoms/Modifier/AnimationModifier.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+public extension Atom {
+    /// Animates the view watching the atom when the value updates.
+    ///
+    /// Note that this modifier does nothing when being watched by other atoms.
+    ///
+    /// ```swift
+    /// struct TextAtom: ValueAtom, Hashable {
+    ///     func value(context: Context) -> String {
+    ///         ""
+    ///     }
+    /// }
+    ///
+    /// struct ExampleView: View {
+    ///     @Watch(TextAtom().animation())
+    ///     var text
+    ///
+    ///     var body: some View {
+    ///         Text(text)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter animation: The animation to apply to the value.
+    ///
+    /// - Returns: An atom that animates the view watching the atom when the value updates.
+    func animation(_ animation: Animation? = .default) -> ModifiedAtom<Self, AnimationModifier<Loader.Value>> {
+        modifier(AnimationModifier(animation: animation))
+    }
+}
+
+/// A modifier that animates the view watching the atom when the value updates.
+///
+/// Use ``Atom/animation(_:)`` instead of using this modifier directly.
+public struct AnimationModifier<T>: AtomModifier {
+    /// A type of base value to be modified.
+    public typealias BaseValue = T
+
+    /// A type of modified value to provide.
+    public typealias Value = T
+
+    /// A type representing the stable identity of this atom associated with an instance.
+    public struct Key: Hashable {
+        private let animation: Animation?
+
+        fileprivate init(animation: Animation?) {
+            self.animation = animation
+        }
+    }
+
+    private let animation: Animation?
+
+    internal init(animation: Animation?) {
+        self.animation = animation
+    }
+
+    /// A unique value used to identify the modifier internally.
+    public var key: Key {
+        Key(animation: animation)
+    }
+
+    /// Returns a new value for the corresponding atom.
+    public func modify(value: BaseValue, context: Context) -> Value {
+        value
+    }
+
+    /// Manage given overridden value updates and cancellations.
+    public func manageOverridden(value: Value, context: Context) -> Value {
+        value
+    }
+
+    /// Performs atom update.
+    public func performUpdate(_ body: () -> Void) {
+        withAnimation(animation, body)
+    }
+}

--- a/Sources/Atoms/Modifier/AtomModifier.swift
+++ b/Sources/Atoms/Modifier/AtomModifier.swift
@@ -37,11 +37,19 @@ public protocol AtomModifier {
     /// by checking the equivalence of the given old value and new value.
     @MainActor
     func shouldUpdate(newValue: Value, oldValue: Value) -> Bool
+
+    /// Performs atom update.
+    @MainActor
+    func performUpdate(_ body: () -> Void)
 }
 
 public extension AtomModifier {
     func shouldUpdate(newValue: Value, oldValue: Value) -> Bool {
         true
+    }
+
+    func performUpdate(_ body: () -> Void) {
+        body()
     }
 }
 

--- a/Sources/Atoms/PropertyWrapper/ViewContext.swift
+++ b/Sources/Atoms/PropertyWrapper/ViewContext.swift
@@ -56,8 +56,11 @@ public struct ViewContext: DynamicProperty {
     public var wrappedValue: AtomViewContext {
         AtomViewContext(
             store: store,
-            subscriber: Subscriber(state.subscriberState, location: location),
-            notifyUpdate: state.objectWillChange.send
+            subscriber: Subscriber(state.subscriberState),
+            subscription: Subscription(
+                location: location,
+                update: state.objectWillChange.send
+            )
         )
     }
 }

--- a/Tests/AtomsTests/Attribute/KeepAliveTests.swift
+++ b/Tests/AtomsTests/Attribute/KeepAliveTests.swift
@@ -29,7 +29,7 @@ final class KeepAliveTests: XCTestCase {
             let subscriberState = SubscriberState()
             let subscriber = Subscriber(subscriberState)
 
-            _ = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
             XCTAssertNotNil(store.state.caches[key])
 
             context.unwatch(atom, subscriber: subscriber)
@@ -54,7 +54,7 @@ final class KeepAliveTests: XCTestCase {
             let subscriberState = SubscriberState()
             let subscriber = Subscriber(subscriberState)
 
-            _ = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
             XCTAssertNotNil(store.state.caches[key])
 
             scopedContext.unwatch(atom, subscriber: subscriber)
@@ -77,7 +77,7 @@ final class KeepAliveTests: XCTestCase {
             let subscriberState = SubscriberState()
             let subscriber = Subscriber(subscriberState)
 
-            _ = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
             XCTAssertNotNil(store.state.caches[key])
 
             scopedContext.unwatch(atom, subscriber: subscriber)

--- a/Tests/AtomsTests/Attribute/RefreshableTests.swift
+++ b/Tests/AtomsTests/Attribute/RefreshableTests.swift
@@ -29,9 +29,13 @@ final class RefreshableTests: XCTestCase {
             XCTAssertTrue(snapshots.isEmpty)
 
             var updateCount = 0
-            let phase1 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-                updateCount += 1
-            }
+            let phase1 = context.watch(
+                atom,
+                subscriber: subscriber,
+                subscription: Subscription {
+                    updateCount += 1
+                }
+            )
 
             XCTAssertTrue(phase1.isSuspending)
 
@@ -64,7 +68,7 @@ final class RefreshableTests: XCTestCase {
                 ]
             )
 
-            let phase0 = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {}
+            let phase0 = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
             XCTAssertEqual(phase0.value, 2)
 
             let phase1 = await scopedContext.refresh(atom)
@@ -79,8 +83,9 @@ final class RefreshableTests: XCTestCase {
         do {
             // Should not make new state and cache
 
-            let value = await context.refresh(atom)
+            let phase = await context.refresh(atom)
 
+            XCTAssertEqual(phase.value, 1)
             XCTAssertNil(store.state.states[key])
             XCTAssertNil(store.state.caches[key])
         }

--- a/Tests/AtomsTests/Attribute/ResettableTests.swift
+++ b/Tests/AtomsTests/Attribute/ResettableTests.swift
@@ -32,9 +32,13 @@ final class ResettableTests: XCTestCase {
         let context = StoreContext(store: store, observers: [observer])
 
         XCTContext.runActivity(named: "Should call custom reset behavior") { _ in
-            let value0 = context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-                counter.update += 1
-            }
+            let value0 = context.watch(
+                atom,
+                subscriber: subscriber,
+                subscription: Subscription {
+                    counter.update += 1
+                }
+            )
 
             snapshots.removeAll()
             context.set(1, for: atom)
@@ -69,9 +73,13 @@ final class ResettableTests: XCTestCase {
                     }
                 ]
             )
-            let value = scopedContext.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {
-                counter.update += 1
-            }
+            let value = scopedContext.watch(
+                atom,
+                subscriber: subscriber,
+                subscription: Subscription {
+                    counter.update += 1
+                }
+            )
 
             XCTAssertEqual(value, 2)
             XCTAssertEqual(counter, Counter(value: 0, update: 0, reset: 0))

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -42,7 +42,7 @@ final class ScopedTests: XCTestCase {
             let atomScope2Key = AtomKey(atom, scopeKey: scope2Key)
 
             XCTAssertEqual(
-                scoped1Context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {},
+                scoped1Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
             XCTAssertEqual(
@@ -55,7 +55,7 @@ final class ScopedTests: XCTestCase {
             XCTAssertNil(store.state.caches[atomScope1Key])
 
             XCTAssertEqual(
-                scoped2Context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {},
+                scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
             XCTAssertEqual(
@@ -88,7 +88,7 @@ final class ScopedTests: XCTestCase {
             let atomScope2Key = AtomKey(atom, scopeKey: scope2Key)
 
             XCTAssertEqual(
-                scoped2Context.watch(atom, subscriber: subscriber, requiresObjectUpdate: false) {},
+                scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
             XCTAssertEqual(

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -12,7 +12,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         XCTAssertEqual(context.read(atom), 100)
@@ -26,7 +26,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         XCTAssertEqual(context.watch(atom), 100)
@@ -44,7 +44,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         XCTAssertTrue(context.watch(atom).isSuspending)
@@ -67,7 +67,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         XCTAssertTrue(context.watch(atom).isSuspending)
@@ -86,7 +86,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         XCTAssertEqual(context.watch(atom), 0)
@@ -107,7 +107,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         let atom = TestStateAtom(defaultValue: 0)
@@ -142,7 +142,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         XCTAssertEqual(context.watch(atom), 100)
@@ -159,7 +159,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
@@ -199,7 +199,7 @@ final class AtomViewContextTests: XCTestCase {
         let context = AtomViewContext(
             store: StoreContext(store: store),
             subscriber: Atoms.Subscriber(subscriberState!),
-            notifyUpdate: {}
+            subscription: Subscription()
         )
 
         context.watch(atom)

--- a/Tests/AtomsTests/Core/Loader/AtomLoaderContextTests.swift
+++ b/Tests/AtomsTests/Core/Loader/AtomLoaderContextTests.swift
@@ -13,7 +13,7 @@ final class AtomLoaderContextTests: XCTestCase {
             store: StoreContext(),
             transaction: transaction,
             coordinator: ()
-        ) { value, _ in
+        ) { value in
             updatedValue = value
         }
 
@@ -30,7 +30,7 @@ final class AtomLoaderContextTests: XCTestCase {
             store: StoreContext(),
             transaction: transaction,
             coordinator: ()
-        ) { _, _ in }
+        ) { _ in }
 
         context.addTermination {}
         context.addTermination {}
@@ -54,7 +54,7 @@ final class AtomLoaderContextTests: XCTestCase {
             store: StoreContext(),
             transaction: transaction,
             coordinator: ()
-        ) { _, _ in }
+        ) { _ in }
 
         context.transaction { _ in }
 
@@ -72,7 +72,7 @@ final class AtomLoaderContextTests: XCTestCase {
             store: StoreContext(),
             transaction: transaction,
             coordinator: ()
-        ) { _, _ in }
+        ) { _ in }
 
         await context.transaction { _ in
             try? await Task.sleep(seconds: 0)

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -30,6 +30,7 @@ final class SnapshotTests: XCTestCase {
         XCTAssertEqual(snapshot.graphDescription(), "digraph {}")
     }
 
+    @MainActor
     func testGraphDescription() {
         struct Value0: Hashable {}
         struct Value1: Hashable {}
@@ -54,8 +55,7 @@ final class SnapshotTests: XCTestCase {
         let subscriberKey = SubscriberKey(token: subscriberToken)
         let subscription = Subscription(
             location: location,
-            requiresObjectUpdate: false,
-            notifyUpdate: {}
+            update: {}
         )
         let snapshot = Snapshot(
             graph: Graph(

--- a/Tests/AtomsTests/Utilities/Util.swift
+++ b/Tests/AtomsTests/Utilities/Util.swift
@@ -82,10 +82,10 @@ extension AtomKey {
     }
 }
 
-extension Atoms.Subscriber {
-    init(_ state: SubscriberState) {
+extension Atoms.Subscription {
+    init(update: @escaping () -> Void = {}) {
         let location = SourceLocation()
-        self.init(state, location: location)
+        self.init(location: location, update: update)
     }
 }
 


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

There is an existing problem that when a selector atom that has ObservableObjectAtom as a dependency is being watched from a view, a view animation is not applied when the ObservableObject's properties are updated.
This is because when `objectWillChange` emits the event, it delays updating the view until the next execution of the run loop so that atoms can handle the changed values.
For the ObservableObjectAtom being watched directly from the view, we had included a workaround so that the animation was valid, but it was not possible for the cases via another selector atom.

To make a little more stable countermeasure for this problem, this PR removes the internal workaround for enabling animation of ObservableObjectAtom in any case, in other words, it makes it completely not animateable by default, and instead implements `.animation(_:)` modifier that allows arbitrary animation to be given to updates.

## Impact on Existing Code

- `ObservableObjectAtom` no longer animates the view when updated.
