### PR TITLE
Deprecate ResetContext & RefreshContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ struct FetchMoviesPhaseAtom: ValueAtom, Refreshable, Hashable {
         context.watch(FetchMoviesTaskAtom().phase)
     }
 
-    func refresh(context: RefreshContext) async -> AsyncPhase<[Movies], Error> {
+    func refresh(context: CurrentContext) async -> AsyncPhase<[Movies], Error> {
         await context.refresh(FetchMoviesTaskAtom().phase)
     }
 
@@ -838,7 +838,7 @@ struct RandomIntAtom: ValueAtom, Resettable, Hashable {
         return .random(in: 0..<100, using: &generator)
     }
 
-    func reset(context: ResetContext) {
+    func reset(context: CurrentContext) {
         context.reset(RandomNumberGeneratorAtom())
     }
 }

--- a/Sources/Atoms/Atom/Atom.swift
+++ b/Sources/Atoms/Atom/Atom.swift
@@ -21,6 +21,10 @@ public protocol Atom {
 
     /// A type of the context structure to read, set, and otherwise interact
     /// with other atoms.
+    typealias CurrentContext = AtomCurrentContext<Loader.Coordinator>
+
+    /// A type of the context structure to read, set, and otherwise interact
+    /// with other atoms.
     typealias UpdatedContext = AtomCurrentContext<Loader.Coordinator>
 
     /// A unique value used to identify the atom internally.

--- a/Sources/Atoms/Attribute/Refreshable.swift
+++ b/Sources/Atoms/Attribute/Refreshable.swift
@@ -9,7 +9,7 @@
 ///         context.watch(FetchUserAtom().phase)
 ///     }
 ///
-///     func refresh(context: RefreshContext) async -> AsyncPhase<User?, Never> {
+///     func refresh(context: CurrentContext) async -> AsyncPhase<User?, Never> {
 ///         await context.refresh(FetchUserAtom().phase)
 ///     }
 /// }
@@ -22,10 +22,6 @@
 /// ```
 ///
 public protocol Refreshable where Self: Atom {
-    /// A type of the context structure to read, set, and otherwise interact
-    /// with other atoms.
-    typealias RefreshContext = AtomCurrentContext<Loader.Coordinator>
-
     /// Refreshes and then return a result value.
     ///
     /// The value returned by this method will be cached as a new value when
@@ -36,5 +32,5 @@ public protocol Refreshable where Self: Atom {
     ///
     /// - Returns: A refreshed value.
     @MainActor
-    func refresh(context: RefreshContext) async -> Loader.Value
+    func refresh(context: CurrentContext) async -> Loader.Value
 }

--- a/Sources/Atoms/Attribute/Resettable.swift
+++ b/Sources/Atoms/Attribute/Resettable.swift
@@ -9,7 +9,7 @@
 ///         context.watch(FetchUserAtom().phase)
 ///     }
 ///
-///     func reset(context: ResetContext) {
+///     func reset(context: CurrentContext) {
 ///         context.reset(FetchUserAtom())
 ///     }
 /// }
@@ -22,10 +22,6 @@
 /// ```
 ///
 public protocol Resettable where Self: Atom {
-    /// A type of the context structure to read, set, and otherwise interact
-    /// with other atoms.
-    typealias ResetContext = AtomCurrentContext<Loader.Coordinator>
-
     /// Arbitrary reset method to be executed on atom reset.
     ///
     /// This is arbitrary custom reset method that replaces regular atom reset functionality.
@@ -33,5 +29,5 @@ public protocol Resettable where Self: Atom {
     /// - Parameter context: A context structure to read, set, and otherwise interact
     ///                      with other atoms.
     @MainActor
-    func reset(context: ResetContext)
+    func reset(context: CurrentContext)
 }

--- a/Sources/Atoms/Deprecated.swift
+++ b/Sources/Atoms/Deprecated.swift
@@ -9,6 +9,16 @@ public extension Atom {
     }
 }
 
+public extension Resettable {
+    @available(*, deprecated, renamed: "CurrentContext")
+    typealias ResetContext = AtomCurrentContext<Loader.Coordinator>
+}
+
+public extension Refreshable {
+    @available(*, deprecated, renamed: "CurrentContext")
+    typealias RefreshContext = AtomCurrentContext<Loader.Coordinator>
+}
+
 public extension AtomScope {
     @available(*, deprecated, renamed: "init(inheriting:content:)")
     init(

--- a/Tests/AtomsTests/Utilities/TestAtom.swift
+++ b/Tests/AtomsTests/Utilities/TestAtom.swift
@@ -88,14 +88,14 @@ struct TestCustomRefreshableAtom<Publisher: Combine.Publisher>: PublisherAtom, R
         makePublisher()
     }
 
-    func refresh(context: RefreshContext) async -> AsyncPhase<Publisher.Output, Publisher.Failure> {
+    func refresh(context: CurrentContext) async -> AsyncPhase<Publisher.Output, Publisher.Failure> {
         refresh()
     }
 }
 
 struct TestCustomResettableAtom<T>: StateAtom, Resettable {
     var defaultValue: (Context) -> T
-    var reset: (ResetContext) -> Void
+    var reset: (CurrentContext) -> Void
 
     var key: UniqueKey {
         UniqueKey()
@@ -105,7 +105,7 @@ struct TestCustomResettableAtom<T>: StateAtom, Resettable {
         defaultValue(context)
     }
 
-    func reset(context: ResetContext) {
+    func reset(context: CurrentContext) {
         reset(context)
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Multiple Attributes are available now and each of them has its own context type, so this PR unifies the context type into a single definition `CurrentContext` and deprecates existing ones.
`UpdateContext` was also a target of deprecation. However, I plan to deprecate `Atom.updated(newValue:oldValue:context:)` API and introduce a brand new way of handling side effects, `UpdateContext` itself will be deprecated along with it, not only for renaming. Since, protocol methods cannot be marked as deprecated, adding a deprecation message to `UpdateContext` would be helpful to make it noticeable.