### PR TITLE
Deprecate context.state(_:) and rename it to context.binding(_:)

### DIFF
--- a/Examples/Packages/iOS/Sources/ExampleVoiceMemo/VoiceMemoRow.swift
+++ b/Examples/Packages/iOS/Sources/ExampleVoiceMemo/VoiceMemoRow.swift
@@ -9,7 +9,7 @@ struct VoiceMemoRow: View {
     var context
 
     var isPlaying: Binding<Bool> {
-        context.state(IsPlayingAtom(voiceMemo: voiceMemo))
+        context.binding(IsPlayingAtom(voiceMemo: voiceMemo))
     }
 
     var elapsedTime: TimeInterval {

--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ A context available through the `@ViewContext` property wrapper when using atoms
 
 |API|Use|
 |:--|:--|
-|[binding](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomwatchablecontext/binding(_:))|Gets a binding to the atom state.|
+|[binding](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomviewcontext/binding(_:))|Gets a binding to the atom state.|
 |[snapshot()](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomviewcontext/snapshot())|For debugging, takes a snapshot that captures specific set of values of atoms.|
 
 <details><summary><code>📖 Example</code></summary>

--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,6 @@ Context is a structure for using and interacting with atom values from views or 
 |[set](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/set(_:for:))|Sets a new value to the atom.|
 |[modify](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/modify(_:body:))|Modifies the cached atom value.|
 |[subscript[]](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/subscript(_:))|Read-write access for applying mutating methods.|
-|[state](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomwatchablecontext/state(_:))|Gets a binding to the atom state.|
 |[refresh](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/refresh(_:)-1gb3a)|Produce a new value of the atom after waiting until asynchronous operation is complete.|
 |[reset](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomcontext/reset(_:))|Reset an atom to the default value or a first output.|
 
@@ -1038,6 +1037,7 @@ A context available through the `@ViewContext` property wrapper when using atoms
 
 |API|Use|
 |:--|:--|
+|[binding](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomwatchablecontext/binding(_:))|Gets a binding to the atom state.|
 |[snapshot()](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomviewcontext/snapshot())|For debugging, takes a snapshot that captures specific set of values of atoms.|
 
 <details><summary><code>📖 Example</code></summary>
@@ -1063,8 +1063,8 @@ struct BooksView: View {
     var body: some View {
         // watch
         let booksTask = context.watch(FetchBooksAtom())     // Task<[Book], Error>
-        // state
-        let searchQuery = context.state(SearchQueryAtom())  // Binding<String>
+        // binding
+        let searchQuery = context.binding(SearchQueryAtom())  // Binding<String>
 
         List {
             Suspense(booksTask) { books in

--- a/Sources/Atoms/Context/AtomContext.swift
+++ b/Sources/Atoms/Context/AtomContext.swift
@@ -190,33 +190,3 @@ public protocol AtomWatchableContext: AtomContext {
     @discardableResult
     func watch<Node: Atom>(_ atom: Node) -> Node.Loader.Value
 }
-
-public extension AtomWatchableContext {
-    /// Creates a `Binding` that accesses the value associated with the given read-write atom.
-    ///
-    /// This method only accepts read-write atoms such as types conforming to ``StateAtom``,
-    /// and returns a binding that accesses the value or assigns a new value for the atom.
-    /// When you set a new value to the `wrappedValue` property of the binding, it assigns the value
-    /// to the atom, and immediately notifies downstream atoms and views.
-    /// Note that the binding initiates watching the given atom when the value is accessed through the
-    /// `wrappedValue` property.
-    ///
-    /// ```swift
-    /// let context = ...
-    /// let binding = context.state(TextAtom())
-    /// binding.wrappedValue = "New text"
-    /// binding.wrappedValue.append(" is mutated!")
-    /// print(binding.wrappedValue) // Prints "New text is mutated!"
-    /// ```
-    ///
-    /// - Parameter atom: An atom to create binding for.
-    ///
-    /// - Returns: The value associated with the given atom.
-    @inlinable
-    func state<Node: StateAtom>(_ atom: Node) -> Binding<Node.Loader.Value> {
-        Binding(
-            get: { watch(atom) },
-            set: { self[atom] = $0 }
-        )
-    }
-}

--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -1,3 +1,5 @@
+import SwiftUI
+
 /// A context structure to read, watch, and otherwise interact with atoms.
 ///
 /// When an atom is watched through this context, and that atom is updated,
@@ -199,6 +201,34 @@ public struct AtomViewContext: AtomWatchableContext {
             atom,
             subscriber: _subscriber,
             subscription: _subscription
+        )
+    }
+
+    /// Creates a `Binding` that accesses the value of the given read-write atom.
+    ///
+    /// This method only accepts read-write atoms such as ones conforming to ``StateAtom``,
+    /// and returns a binding that accesses the value or set a new value for the atom.
+    /// When you set a new value to the `wrappedValue` of the returned binding, it assigns the value
+    /// to the atom, and immediately notifies downstream atoms and views.
+    /// Note that the binding initiates watching the given atom when the value is accessed through the
+    /// `wrappedValue`.
+    ///
+    /// ```swift
+    /// let context = ...
+    /// let binding = context.binding(TextAtom())
+    /// binding.wrappedValue = "New text"
+    /// binding.wrappedValue.append(" is mutated!")
+    /// print(binding.wrappedValue) // Prints "New text is mutated!"
+    /// ```
+    ///
+    /// - Parameter atom: An atom to create binding to.
+    ///
+    /// - Returns: A binding to the atom value.
+    @inlinable
+    public func binding<Node: StateAtom>(_ atom: Node) -> Binding<Node.Loader.Value> {
+        Binding(
+            get: { watch(atom) },
+            set: { set($0, for: atom) }
         )
     }
 

--- a/Sources/Atoms/Deprecated.swift
+++ b/Sources/Atoms/Deprecated.swift
@@ -9,6 +9,16 @@ public extension Atom {
     }
 }
 
+public extension AtomWatchableContext {
+    @available(*, deprecated, renamed: "AtomViewContext.binding(_:)")
+    func state<Node: StateAtom>(_ atom: Node) -> Binding<Node.Loader.Value> {
+        Binding(
+            get: { watch(atom) },
+            set: { set($0, for: atom) }
+        )
+    }
+}
+
 public extension Resettable {
     @available(*, deprecated, renamed: "CurrentContext")
     typealias ResetContext = AtomCurrentContext<Loader.Coordinator>

--- a/Sources/Atoms/PropertyWrapper/WatchState.swift
+++ b/Sources/Atoms/PropertyWrapper/WatchState.swift
@@ -62,6 +62,6 @@ public struct WatchState<Node: StateAtom>: DynamicProperty {
     /// Accessing this property itself does not start watching the atom, but does when
     /// the view accesses to the getter of the binding.
     public var projectedValue: Binding<Node.Loader.Value> {
-        context.state(atom)
+        context.binding(atom)
     }
 }

--- a/Tests/AtomsTests/Context/AtomContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomContextTests.swift
@@ -14,18 +14,4 @@ final class AtomContextTests: XCTestCase {
 
         XCTAssertEqual(context[atom], 100)
     }
-
-    @MainActor
-    func testState() {
-        let atom = TestStateAtom(defaultValue: 0)
-        let context: AtomWatchableContext = AtomTestContext()
-        let state = context.state(atom)
-
-        XCTAssertEqual(context.read(atom), 0)
-
-        state.wrappedValue = 100
-
-        XCTAssertEqual(state.wrappedValue, 100)
-        XCTAssertEqual(context.read(atom), 100)
-    }
 }

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -11,7 +11,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -25,7 +25,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -43,7 +43,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -66,7 +66,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -85,7 +85,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -106,7 +106,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -141,7 +141,7 @@ final class AtomViewContextTests: XCTestCase {
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
 
@@ -153,12 +153,33 @@ final class AtomViewContextTests: XCTestCase {
     }
 
     @MainActor
+    func testBinding() {
+        let atom = TestStateAtom(defaultValue: 0)
+        let store = AtomStore()
+        let subscriberState = SubscriberState()
+        let context = AtomViewContext(
+            store: StoreContext(store: store),
+            subscriber: Subscriber(subscriberState),
+            subscription: Subscription()
+        )
+
+        let binding = context.binding(atom)
+
+        XCTAssertEqual(context.read(atom), 0)
+
+        binding.wrappedValue = 100
+
+        XCTAssertEqual(binding.wrappedValue, 100)
+        XCTAssertEqual(context.read(atom), 100)
+    }
+
+    @MainActor
     func testSnapshot() {
         let store = AtomStore()
         let subscriberState = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState),
+            subscriber: Subscriber(subscriberState),
             subscription: Subscription()
         )
         let atom0 = TestAtom(value: 0)
@@ -198,7 +219,7 @@ final class AtomViewContextTests: XCTestCase {
         var subscriberState: SubscriberState? = SubscriberState()
         let context = AtomViewContext(
             store: StoreContext(store: store),
-            subscriber: Atoms.Subscriber(subscriberState!),
+            subscriber: Subscriber(subscriberState!),
             subscription: Subscription()
         )
 


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

The naming `context.state(_:)` doesn't well imply that it returns a `Binding`, and its existence often goes unnoticed, so it's renamed `context.binding(_:)` that implies directly that it returns a `Binding` to the atom state.
Also, now that only `AtomViewContext` has `context.binding(:_)` because it was not needed to allow it to be used on selector atoms.

## Impact on Existing Code

- `AtomWatchableContext.state(_:)` is deprecated.
- `AtomViewContext.binding(_:)` is added.

