### PR TITLE
Detach atom dependencies while executing custom refresh

### DIFF
--- a/Tests/AtomsTests/Attribute/ResettableTests.swift
+++ b/Tests/AtomsTests/Attribute/ResettableTests.swift
@@ -99,4 +99,28 @@ final class ResettableTests: XCTestCase {
             XCTAssertNil(store.state.caches[key])
         }
     }
+
+    @MainActor
+    func testTransitiveReset() {
+        let parentAtom = TestValueAtom(value: 0)
+        let atom = TestCustomResettableAtom { context in
+            context.watch(parentAtom)
+        } reset: { context in
+            context.reset(parentAtom)
+        }
+        let context = AtomTestContext()
+
+        var updateCount = 0
+        context.onUpdate = {
+            updateCount += 1
+        }
+
+        XCTAssertEqual(context.watch(atom), 0)
+        XCTAssertEqual(updateCount, 0)
+
+        context.reset(atom)
+
+        XCTAssertEqual(context.watch(atom), 0)
+        XCTAssertEqual(updateCount, 1)
+    }
 }

--- a/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
@@ -41,15 +41,15 @@ final class AtomCurrentContextTests: XCTestCase {
 
     @MainActor
     func testCustomRefresh() async {
-        let atom = TestCustomRefreshableAtom {
-            Just(100)
-        } refresh: {
-            .success(200)
+        let atom = TestCustomRefreshableAtom { _ in
+            100
+        } refresh: { _ in
+            200
         }
         let store = AtomStore()
         let context = AtomCurrentContext(store: StoreContext(store: store), coordinator: ())
-        let value = await context.refresh(atom).value
 
+        let value = await context.refresh(atom)
         XCTAssertEqual(value, 200)
     }
 

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -211,10 +211,10 @@ final class AtomTestContextTests: XCTestCase {
 
     @MainActor
     func testCustomRefresh() async {
-        let atom = TestCustomRefreshableAtom {
-            Just(100)
-        } refresh: {
-            .success(200)
+        let atom = TestCustomRefreshableAtom { _ in
+            100
+        } refresh: { _ in
+            200
         }
         let context = AtomTestContext()
         var updateCount = 0
@@ -223,17 +223,13 @@ final class AtomTestContextTests: XCTestCase {
             updateCount += 1
         }
 
-        XCTAssertTrue(context.watch(atom).isSuspending)
+        XCTAssertEqual(context.watch(atom), 100)
 
-        await context.waitForUpdate()
-
-        XCTAssertEqual(context.watch(atom).value, 100)
-
-        let value = await context.refresh(atom).value
+        let value = await context.refresh(atom)
 
         XCTAssertEqual(value, 200)
-        XCTAssertEqual(context.watch(atom).value, 200)
-        XCTAssertEqual(updateCount, 2)
+        XCTAssertEqual(context.watch(atom), 200)
+        XCTAssertEqual(updateCount, 1)
     }
 
     @MainActor

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -48,21 +48,20 @@ final class AtomTransactionContextTests: XCTestCase {
     @MainActor
     func testCustomRefresh() async {
         let atom0 = TestValueAtom(value: 0)
-        let atom1 = TestCustomRefreshableAtom {
-            Just(100)
-        } refresh: {
-            .success(200)
+        let atom1 = TestCustomRefreshableAtom { _ in
+            100
+        } refresh: { _ in
+            200
         }
         let store = AtomStore()
         let transaction = Transaction(key: AtomKey(atom0))
         let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction, coordinator: ())
 
-        XCTAssertTrue(context.watch(atom1).isSuspending)
+        XCTAssertEqual(context.watch(atom1), 100)
 
-        let value = await context.refresh(atom1).value
-
+        let value = await context.refresh(atom1)
         XCTAssertEqual(value, 200)
-        XCTAssertEqual(context.watch(atom1).value, 200)
+        XCTAssertEqual(context.watch(atom1), 200)
     }
 
     @MainActor

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -57,10 +57,10 @@ final class AtomViewContextTests: XCTestCase {
 
     @MainActor
     func testCustomRefresh() async {
-        let atom = TestCustomRefreshableAtom {
-            Just(100)
-        } refresh: {
-            .success(200)
+        let atom = TestCustomRefreshableAtom { _ in
+            100
+        } refresh: { _ in
+            200
         }
         let store = AtomStore()
         let subscriberState = SubscriberState()
@@ -70,12 +70,11 @@ final class AtomViewContextTests: XCTestCase {
             subscription: Subscription()
         )
 
-        XCTAssertTrue(context.watch(atom).isSuspending)
+        XCTAssertEqual(context.watch(atom), 100)
 
-        let value = await context.refresh(atom).value
-
+        let value = await context.refresh(atom)
         XCTAssertEqual(value, 200)
-        XCTAssertEqual(context.watch(atom).value, 200)
+        XCTAssertEqual(context.watch(atom), 200)
     }
 
     @MainActor

--- a/Tests/AtomsTests/Utilities/TestAtom.swift
+++ b/Tests/AtomsTests/Utilities/TestAtom.swift
@@ -78,20 +78,20 @@ struct TestThrowingTaskAtom<Success: Sendable>: ThrowingTaskAtom {
     }
 }
 
-struct TestCustomRefreshableAtom<Publisher: Combine.Publisher>: PublisherAtom, Refreshable {
-    var makePublisher: () -> Publisher
-    var refresh: () -> AsyncPhase<Publisher.Output, Publisher.Failure>
+struct TestCustomRefreshableAtom<T>: ValueAtom, Refreshable {
+    var getValue: (Context) -> T
+    var refresh: (CurrentContext) async -> T
 
     var key: UniqueKey {
         UniqueKey()
     }
 
-    func publisher(context: Context) -> Publisher {
-        makePublisher()
+    func value(context: Context) -> T {
+        getValue(context)
     }
 
-    func refresh(context: CurrentContext) async -> AsyncPhase<Publisher.Output, Publisher.Failure> {
-        refresh()
+    func refresh(context: CurrentContext) async -> T {
+        await refresh(context)
     }
 }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore


## Description

Transitive refresh of dependent atoms in a custom refresh was found to cause multiple updates to be notified downstream due to updates of the parent atoms plus the update of self.
As a countermeasure, dependencies are temporarily detached during refresh to prevent update notifications and restored after refresh.
