### PR TITLE
Isolate override closures on main actor

### DIFF
--- a/Sources/Atoms/AtomRoot.swift
+++ b/Sources/Atoms/AtomRoot.swift
@@ -128,7 +128,7 @@ public struct AtomRoot<Content: View>: View {
     ///   - value: A value to be used instead of the atom's value.
     ///
     /// - Returns: The self instance.
-    public func override<Node: Atom>(_ atom: Node, with value: @escaping @Sendable (Node) -> Node.Produced) -> Self {
+    public func override<Node: Atom>(_ atom: Node, with value: @escaping @MainActor @Sendable (Node) -> Node.Produced) -> Self {
         mutating(self) { $0.overrides[OverrideKey(atom)] = Override(isScoped: false, getValue: value) }
     }
 
@@ -144,7 +144,7 @@ public struct AtomRoot<Content: View>: View {
     ///   - value: A value to be used instead of the atom's value.
     ///
     /// - Returns: The self instance.
-    public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping @Sendable (Node) -> Node.Produced) -> Self {
+    public func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping @MainActor @Sendable (Node) -> Node.Produced) -> Self {
         mutating(self) { $0.overrides[OverrideKey(atomType)] = Override(isScoped: false, getValue: value) }
     }
 }

--- a/Sources/Atoms/AtomScope.swift
+++ b/Sources/Atoms/AtomScope.swift
@@ -129,7 +129,7 @@ public struct AtomScope<Content: View>: View {
     ///   - value: A value to be used instead of the atom's value.
     ///
     /// - Returns: The self instance.
-    public func scopedOverride<Node: Atom>(_ atom: Node, with value: @escaping @Sendable (Node) -> Node.Produced) -> Self {
+    public func scopedOverride<Node: Atom>(_ atom: Node, with value: @escaping @MainActor @Sendable (Node) -> Node.Produced) -> Self {
         mutating(self) { $0.overrides[OverrideKey(atom)] = Override(isScoped: true, getValue: value) }
     }
 
@@ -147,7 +147,7 @@ public struct AtomScope<Content: View>: View {
     ///   - value: A value to be used instead of the atom's value.
     ///
     /// - Returns: The self instance.
-    public func scopedOverride<Node: Atom>(_ atomType: Node.Type, with value: @escaping @Sendable (Node) -> Node.Produced) -> Self {
+    public func scopedOverride<Node: Atom>(_ atomType: Node.Type, with value: @escaping @MainActor @Sendable (Node) -> Node.Produced) -> Self {
         mutating(self) { $0.overrides[OverrideKey(atomType)] = Override(isScoped: true, getValue: value) }
     }
 }

--- a/Sources/Atoms/Core/Override.swift
+++ b/Sources/Atoms/Core/Override.swift
@@ -3,7 +3,7 @@ internal protocol OverrideProtocol: Sendable {
     associatedtype Node: Atom
 
     var isScoped: Bool { get }
-    var getValue: @Sendable (Node) -> Node.Produced { get }
+    var getValue: @MainActor @Sendable (Node) -> Node.Produced { get }
 }
 
 @usableFromInline
@@ -11,10 +11,10 @@ internal struct Override<Node: Atom>: OverrideProtocol {
     @usableFromInline
     let isScoped: Bool
     @usableFromInline
-    let getValue: @Sendable (Node) -> Node.Produced
+    let getValue: @MainActor @Sendable (Node) -> Node.Produced
 
     @usableFromInline
-    init(isScoped: Bool, getValue: @escaping @Sendable (Node) -> Node.Produced) {
+    init(isScoped: Bool, getValue: @escaping @MainActor @Sendable (Node) -> Node.Produced) {
         self.isScoped = isScoped
         self.getValue = getValue
     }

--- a/Sources/Atoms/Deprecated.swift
+++ b/Sources/Atoms/Deprecated.swift
@@ -59,12 +59,12 @@ public extension AtomScope {
     }
 
     @available(*, deprecated, renamed: "scopedOverride(_:with:)")
-    func override<Node: Atom>(_ atom: Node, with value: @escaping @Sendable (Node) -> Node.Produced) -> Self {
+    func override<Node: Atom>(_ atom: Node, with value: @escaping @MainActor @Sendable (Node) -> Node.Produced) -> Self {
         scopedOverride(atom, with: value)
     }
 
     @available(*, deprecated, renamed: "scopedOverride(_:with:)")
-    func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping @Sendable (Node) -> Node.Produced) -> Self {
+    func override<Node: Atom>(_ atomType: Node.Type, with value: @escaping @MainActor @Sendable (Node) -> Node.Produced) -> Self {
         scopedOverride(atomType, with: value)
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Recent change made the override closures Sendable, and it inhibited to create main actor isolated instances inside the closure.
Since the values created in the override closures are supposed to be used on main actor, it should be better to make them main actor isolated closures.

## Impact on Existing Code

- Creating an instance of custom actors synchronously in the override closures will be inhibited.
