### PR TITLE
Mark ModifiedAtom Scoped if the base atom is Scoped

### DIFF
--- a/Sources/Atoms/Core/Atom/ModifiedAtom.swift
+++ b/Sources/Atoms/Core/Atom/ModifiedAtom.swift
@@ -58,3 +58,10 @@ extension ModifiedAtom: AsyncAtom where Node: AsyncAtom, Modifier: AsyncAtomModi
         modifier.refreshProducer(atom: atom)
     }
 }
+
+extension ModifiedAtom: Scoped where Node: Scoped {
+    /// A scope ID which is to find a matching scope.
+    public var scopeID: Node.ScopeID {
+        atom.scopeID
+    }
+}

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -38,33 +38,33 @@ final class ScopedTests: XCTestCase {
                 overrides: [:]
             )
             let atom = ScopedAtom(scopeID: DefaultScopeID(), value: 0)
-            let atomScope1Key = AtomKey(atom, scopeKey: scope1Key)
-            let atomScope2Key = AtomKey(atom, scopeKey: scope2Key)
+            let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Key)
+            let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Key)
 
             XCTAssertEqual(
                 scoped1Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
             XCTAssertEqual(
-                store.state.caches[atomScope1Key] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
+                store.state.caches[scoped1AtomKey] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
                 AtomCache(atom: atom, value: 0)
             )
-            XCTAssertNil(store.state.caches[atomScope2Key])
+            XCTAssertNil(store.state.caches[scoped2AtomKey])
 
             scoped1Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.state.caches[atomScope1Key])
+            XCTAssertNil(store.state.caches[scoped1AtomKey])
 
             XCTAssertEqual(
                 scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
             XCTAssertEqual(
-                store.state.caches[atomScope2Key] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
+                store.state.caches[scoped2AtomKey] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
                 AtomCache(atom: atom, value: 0)
             )
 
             scoped2Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.state.caches[atomScope2Key])
+            XCTAssertNil(store.state.caches[scoped2AtomKey])
         }
 
         XCTContext.runActivity(named: "Should be scoped in particular scope") { _ in
@@ -84,21 +84,62 @@ final class ScopedTests: XCTestCase {
                 overrides: [:]
             )
             let atom = ScopedAtom(scopeID: scopeID, value: 0)
-            let atomScope1Key = AtomKey(atom, scopeKey: scope1Key)
-            let atomScope2Key = AtomKey(atom, scopeKey: scope2Key)
+            let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Key)
+            let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Key)
 
             XCTAssertEqual(
                 scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
             XCTAssertEqual(
-                store.state.caches[atomScope1Key] as? AtomCache<ScopedAtom<String, Int>>,
+                store.state.caches[scoped1AtomKey] as? AtomCache<ScopedAtom<String, Int>>,
                 AtomCache(atom: atom, value: 0)
             )
-            XCTAssertNil(store.state.caches[atomScope2Key])
+            XCTAssertNil(store.state.caches[scoped2AtomKey])
 
             scoped2Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.state.caches[atomScope1Key])
+            XCTAssertNil(store.state.caches[scoped1AtomKey])
+        }
+
+        XCTContext.runActivity(named: "Modified atoms should also be scoped") { _ in
+            let store = AtomStore()
+            let context = StoreContext(store: store)
+            let scopeID = "Scope 1"
+            let scoped1Context = context.scoped(
+                scopeKey: scope1Key,
+                scopeID: ScopeID(scopeID),
+                observers: [],
+                overrides: [:]
+            )
+            let scoped2Context = scoped1Context.scoped(
+                scopeKey: scope2Key,
+                scopeID: ScopeID(DefaultScopeID()),
+                observers: [],
+                overrides: [:]
+            )
+            let baseAtom = ScopedAtom(scopeID: scopeID, value: 0)
+            let atom = baseAtom.changes
+            let baseAtomKey = AtomKey(baseAtom, scopeKey: nil)
+            let atomKey = AtomKey(atom, scopeKey: nil)
+            let scoped1BaseAtomKey = AtomKey(baseAtom, scopeKey: scope1Key)
+            let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Key)
+            let scoped2BaseAtomKey = AtomKey(baseAtom, scopeKey: scope2Key)
+            let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Key)
+
+            XCTAssertEqual(
+                scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
+                0
+            )
+            XCTAssertEqual(store.state.caches[scoped1BaseAtomKey]?.value as? Int, 0)
+            XCTAssertEqual(store.state.caches[scoped1AtomKey]?.value as? Int, 0)
+            XCTAssertNil(store.state.caches[scoped2BaseAtomKey])
+            XCTAssertNil(store.state.caches[scoped2AtomKey])
+            XCTAssertNil(store.state.caches[baseAtomKey])
+            XCTAssertNil(store.state.caches[atomKey])
+
+            scoped2Context.unwatch(atom, subscriber: subscriber)
+            XCTAssertNil(store.state.caches[scoped1BaseAtomKey])
+            XCTAssertNil(store.state.caches[scoped1AtomKey])
         }
     }
 }

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -130,8 +130,14 @@ final class ScopedTests: XCTestCase {
                 scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
                 0
             )
-            XCTAssertEqual(store.state.caches[scoped1BaseAtomKey]?.value as? Int, 0)
-            XCTAssertEqual(store.state.caches[scoped1AtomKey]?.value as? Int, 0)
+            XCTAssertEqual(
+                (store.state.caches[scoped1BaseAtomKey] as? AtomCache<ScopedAtom<String, Int>>)?.value,
+                0
+            )
+            XCTAssertEqual(
+                (store.state.caches[scoped1AtomKey] as? AtomCache<ModifiedAtom<ScopedAtom<String, Int>, ChangesModifier<Int>>>)?.value,
+                0
+            )
             XCTAssertNil(store.state.caches[scoped2BaseAtomKey])
             XCTAssertNil(store.state.caches[scoped2AtomKey])
             XCTAssertNil(store.state.caches[baseAtomKey])


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

An atom that modified another atom with a Scoped attribute is usually expected to be also scoped.