### PR TITLE
Strict main actor isolation

### DIFF
--- a/Sources/Atoms/Context/AtomTransactionContext.swift
+++ b/Sources/Atoms/Context/AtomTransactionContext.swift
@@ -7,14 +7,14 @@ public struct AtomTransactionContext: AtomWatchableContext {
     @usableFromInline
     internal let _store: StoreContext
     @usableFromInline
-    internal let _transaction: Transaction
+    internal let _transactionState: TransactionState
 
     internal init(
         store: StoreContext,
-        transaction: Transaction
+        transactionState: TransactionState
     ) {
         self._store = store
-        self._transaction = transaction
+        self._transactionState = transactionState
     }
 
     /// Accesses the value associated with the given atom without watching it.
@@ -191,6 +191,6 @@ public struct AtomTransactionContext: AtomWatchableContext {
     @inlinable
     @discardableResult
     public func watch<Node: Atom>(_ atom: Node) -> Node.Produced {
-        _store.watch(atom, in: _transaction)
+        _store.watch(atom, in: _transactionState)
     }
 }

--- a/Sources/Atoms/Core/AtomState.swift
+++ b/Sources/Atoms/Core/AtomState.swift
@@ -6,6 +6,7 @@ internal protocol AtomStateProtocol: AnyObject {
     var transactionState: TransactionState? { get set }
 }
 
+@MainActor
 internal final class AtomState<Effect: AtomEffect>: AtomStateProtocol {
     let effect: Effect
     var transactionState: TransactionState?

--- a/Sources/Atoms/Core/AtomState.swift
+++ b/Sources/Atoms/Core/AtomState.swift
@@ -3,12 +3,12 @@ internal protocol AtomStateProtocol: AnyObject {
     associatedtype Effect: AtomEffect
 
     var effect: Effect { get }
-    var transaction: Transaction? { get set }
+    var transactionState: TransactionState? { get set }
 }
 
 internal final class AtomState<Effect: AtomEffect>: AtomStateProtocol {
     let effect: Effect
-    var transaction: Transaction?
+    var transactionState: TransactionState?
 
     init(effect: Effect) {
         self.effect = effect

--- a/Sources/Atoms/Core/ScopeKey.swift
+++ b/Sources/Atoms/Core/ScopeKey.swift
@@ -1,5 +1,6 @@
 @usableFromInline
 internal struct ScopeKey: Hashable, CustomStringConvertible {
+    @MainActor
     final class Token {}
 
     private let identifier: ObjectIdentifier

--- a/Sources/Atoms/Core/StoreState.swift
+++ b/Sources/Atoms/Core/StoreState.swift
@@ -1,4 +1,4 @@
-internal struct StoreState {
+internal final class StoreState {
     var caches = [AtomKey: any AtomCacheProtocol]()
     var states = [AtomKey: any AtomStateProtocol]()
     var subscriptions = [AtomKey: [SubscriberKey: Subscription]]()

--- a/Sources/Atoms/Core/StoreState.swift
+++ b/Sources/Atoms/Core/StoreState.swift
@@ -1,3 +1,4 @@
+@MainActor
 internal final class StoreState {
     var caches = [AtomKey: any AtomCacheProtocol]()
     var states = [AtomKey: any AtomStateProtocol]()

--- a/Sources/Atoms/Core/SubscriberKey.swift
+++ b/Sources/Atoms/Core/SubscriberKey.swift
@@ -1,4 +1,5 @@
 internal struct SubscriberKey: Hashable {
+    @MainActor
     final class Token {}
 
     private let identifier: ObjectIdentifier

--- a/Sources/Atoms/Core/SubscriberState.swift
+++ b/Sources/Atoms/Core/SubscriberState.swift
@@ -1,11 +1,21 @@
+import Foundation
+
+@MainActor
 internal final class SubscriberState {
     let token = SubscriberKey.Token()
     var subscribing = Set<AtomKey>()
     var unsubscribe: ((Set<AtomKey>) -> Void)?
 
-    init() {}
-
+    // TODO: Use isolated synchronous deinit once it's available.
+    // 0371-isolated-synchronous-deinit
     deinit {
-        unsubscribe?(subscribing)
+        if Thread.isMainThread {
+            unsubscribe?(subscribing)
+        }
+        else {
+            Task(priority: .high) { @MainActor [unsubscribe, subscribing] in
+                unsubscribe?(subscribing)
+            }
+        }
     }
 }

--- a/Sources/Atoms/Core/SubscriberState.swift
+++ b/Sources/Atoms/Core/SubscriberState.swift
@@ -1,4 +1,4 @@
-final class SubscriberState {
+internal final class SubscriberState {
     let token = SubscriberKey.Token()
     var subscribing = Set<AtomKey>()
     var unsubscribe: ((Set<AtomKey>) -> Void)?

--- a/Sources/Atoms/Core/Subscription.swift
+++ b/Sources/Atoms/Core/Subscription.swift
@@ -1,6 +1,5 @@
 @usableFromInline
-@MainActor
 internal struct Subscription {
     let location: SourceLocation
-    let update: () -> Void
+    let update: @MainActor @Sendable () -> Void
 }

--- a/Sources/Atoms/Core/TransactionState.swift
+++ b/Sources/Atoms/Core/TransactionState.swift
@@ -1,6 +1,6 @@
 @usableFromInline
 @MainActor
-internal final class Transaction {
+internal final class TransactionState {
     private var body: (() -> () -> Void)?
     private var cleanup: (() -> Void)?
 

--- a/Sources/Atoms/Core/TransactionState.swift
+++ b/Sources/Atoms/Core/TransactionState.swift
@@ -1,15 +1,18 @@
 @usableFromInline
 @MainActor
 internal final class TransactionState {
-    private var body: (() -> () -> Void)?
-    private var cleanup: (() -> Void)?
+    private var body: (@MainActor () -> @MainActor () -> Void)?
+    private var cleanup: (@MainActor () -> Void)?
 
     let key: AtomKey
 
     private var termination: (@MainActor () -> Void)?
     private(set) var isTerminated = false
 
-    init(key: AtomKey, _ body: @escaping () -> () -> Void) {
+    init(
+        key: AtomKey,
+        _ body: @MainActor @escaping () -> @MainActor () -> Void
+    ) {
         self.key = key
         self.body = body
     }

--- a/Sources/Atoms/Core/Utilities.swift
+++ b/Sources/Atoms/Core/Utilities.swift
@@ -1,4 +1,5 @@
-func `mutating`<T>(_ value: T, _ mutation: (inout T) -> Void) -> T {
+@inlinable
+internal func `mutating`<T>(_ value: T, _ mutation: (inout T) -> Void) -> T {
     var value = value
     mutation(&value)
     return value

--- a/Sources/Atoms/Effect/InitializeEffect.swift
+++ b/Sources/Atoms/Effect/InitializeEffect.swift
@@ -1,10 +1,10 @@
 /// An atom effect that performs an arbitrary action when the atom is first used and initialized,
 /// or once it is released and re-initialized again.
 public struct InitializeEffect: AtomEffect {
-    private let action: () -> Void
+    private let action: @MainActor () -> Void
 
     /// Creates an atom effect that performs the given action when the atom is initialized.
-    public init(perform action: @escaping () -> Void) {
+    public init(perform action: @MainActor @escaping () -> Void) {
         self.action = action
     }
 

--- a/Sources/Atoms/Effect/MergedEffect.swift
+++ b/Sources/Atoms/Effect/MergedEffect.swift
@@ -2,9 +2,9 @@
 // MergedEffect<each Effect: AtomEffect>
 /// An atom effect that merges multiple atom effects into one.
 public struct MergedEffect: AtomEffect {
-    private let initialized: (Context) -> Void
-    private let updated: (Context) -> Void
-    private let released: (Context) -> Void
+    private let initialized: @MainActor (Context) -> Void
+    private let updated: @MainActor (Context) -> Void
+    private let released: @MainActor (Context) -> Void
 
     /// Creates an atom effect that merges multiple atom effects into one.
     public init<each Effect: AtomEffect>(_ effect: repeat each Effect) {

--- a/Sources/Atoms/Effect/ReleaseEffect.swift
+++ b/Sources/Atoms/Effect/ReleaseEffect.swift
@@ -1,9 +1,9 @@
 /// An atom effect that performs an arbitrary action when the atom is no longer watched and released.
 public struct ReleaseEffect: AtomEffect {
-    private let action: () -> Void
+    private let action: @MainActor () -> Void
 
     /// Creates an atom effect that performs the given action when the atom is released.
-    public init(perform action: @escaping () -> Void) {
+    public init(perform action: @MainActor @escaping () -> Void) {
         self.action = action
     }
 

--- a/Sources/Atoms/Effect/UpdateEffect.swift
+++ b/Sources/Atoms/Effect/UpdateEffect.swift
@@ -1,9 +1,9 @@
 /// An atom effect that performs an arbitrary action when the atom is updated.
 public struct UpdateEffect: AtomEffect {
-    private let action: () -> Void
+    private let action: @MainActor () -> Void
 
     /// Creates an atom effect that performs the given action when the atom is updated.
-    public init(perform action: @escaping () -> Void) {
+    public init(perform action: @MainActor @escaping () -> Void) {
         self.action = action
     }
 

--- a/Sources/Atoms/PropertyWrapper/ViewContext.swift
+++ b/Sources/Atoms/PropertyWrapper/ViewContext.swift
@@ -58,7 +58,9 @@ public struct ViewContext: DynamicProperty {
             subscriber: Subscriber(state.subscriberState),
             subscription: Subscription(
                 location: location,
-                update: state.objectWillChange.send
+                update: { [weak state] in
+                    state?.objectWillChange.send()
+                }
             )
         )
     }

--- a/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
@@ -18,15 +18,15 @@ final class AtomCurrentContextTests: XCTestCase {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom))
+        let transactionState = TransactionState(key: AtomKey(atom))
         let storeContext = StoreContext(store: store)
         let context = AtomCurrentContext(store: storeContext)
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transaction), 100)
+        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 100)
 
         context.set(200, for: dependency)
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transaction), 200)
+        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 200)
     }
 
     @MainActor
@@ -58,15 +58,15 @@ final class AtomCurrentContextTests: XCTestCase {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom))
+        let transactionState = TransactionState(key: AtomKey(atom))
         let storeContext = StoreContext(store: store)
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transaction), 0)
+        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 0)
 
         context[dependency] = 100
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transaction), 100)
+        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 100)
 
         context.reset(dependency)
 
@@ -80,7 +80,7 @@ final class AtomCurrentContextTests: XCTestCase {
         let storeContext = StoreContext(store: store)
         let transactionAtom = TestValueAtom(value: 0)
         let atom = TestStateAtom(defaultValue: 0)
-        let transaction = Transaction(key: AtomKey(transactionAtom))
+        let transactionState = TransactionState(key: AtomKey(transactionAtom))
 
         let resettableAtom = TestCustomResettableAtom(
             defaultValue: { context in
@@ -91,17 +91,17 @@ final class AtomCurrentContextTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(storeContext.watch(atom, in: transaction), 0)
-        XCTAssertEqual(storeContext.watch(resettableAtom, in: transaction), 0)
+        XCTAssertEqual(storeContext.watch(atom, in: transactionState), 0)
+        XCTAssertEqual(storeContext.watch(resettableAtom, in: transactionState), 0)
 
         context[atom] = 100
 
-        XCTAssertEqual(storeContext.watch(atom, in: transaction), 100)
-        XCTAssertEqual(storeContext.watch(resettableAtom, in: transaction), 100)
+        XCTAssertEqual(storeContext.watch(atom, in: transactionState), 100)
+        XCTAssertEqual(storeContext.watch(resettableAtom, in: transactionState), 100)
 
         context.reset(resettableAtom)
 
-        XCTAssertEqual(storeContext.watch(atom, in: transaction), 300)
-        XCTAssertEqual(storeContext.watch(resettableAtom, in: transaction), 300)
+        XCTAssertEqual(storeContext.watch(atom, in: transactionState), 300)
+        XCTAssertEqual(storeContext.watch(resettableAtom, in: transactionState), 300)
     }
 }

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -8,8 +8,8 @@ final class AtomTransactionContextTests: XCTestCase {
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(atom))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         XCTAssertEqual(context.read(atom), 100)
     }
@@ -19,8 +19,8 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(atom))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         XCTAssertEqual(context.watch(dependency), 100)
 
@@ -34,8 +34,8 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom0 = TestValueAtom(value: 0)
         let atom1 = TestPublisherAtom { Just(100) }
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom0))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(atom0))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         XCTAssertTrue(context.watch(atom1).isSuspending)
 
@@ -54,8 +54,8 @@ final class AtomTransactionContextTests: XCTestCase {
             200
         }
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom0))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(atom0))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         XCTAssertEqual(context.watch(atom1), 100)
 
@@ -69,8 +69,8 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(atom))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         XCTAssertEqual(context.watch(dependency), 0)
 
@@ -97,8 +97,8 @@ final class AtomTransactionContextTests: XCTestCase {
         )
 
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(transactionAtom))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(transactionAtom))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         XCTAssertEqual(context.watch(atom), 0)
         XCTAssertEqual(context.watch(resettableAtom), 0)
@@ -119,8 +119,8 @@ final class AtomTransactionContextTests: XCTestCase {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)
         let store = AtomStore()
-        let transaction = Transaction(key: AtomKey(atom0))
-        let context = AtomTransactionContext(store: StoreContext(store: store), transaction: transaction)
+        let transactionState = TransactionState(key: AtomKey(atom0))
+        let context = AtomTransactionContext(store: StoreContext(store: store), transactionState: transactionState)
 
         let value = context.watch(atom1)
 

--- a/Tests/AtomsTests/Core/AtomKeyTests.swift
+++ b/Tests/AtomsTests/Core/AtomKeyTests.swift
@@ -39,6 +39,7 @@ final class AtomKeyTests: XCTestCase {
         XCTAssertEqual(dictionary[key2], 300)
     }
 
+    @MainActor
     func testDescription() {
         let atom = TestAtom(value: 0)
         let token = ScopeKey.Token()

--- a/Tests/AtomsTests/Core/AtomProducerContextTests.swift
+++ b/Tests/AtomsTests/Core/AtomProducerContextTests.swift
@@ -6,10 +6,10 @@ final class AtomProducerContextTests: XCTestCase {
     @MainActor
     func testUpdate() {
         let atom = TestValueAtom(value: 0)
-        let transaction = Transaction(key: AtomKey(atom))
+        let transactionState = TransactionState(key: AtomKey(atom))
         var updatedValue: Int?
 
-        let context = AtomProducerContext<Int>(store: StoreContext(), transaction: transaction) { value in
+        let context = AtomProducerContext<Int>(store: StoreContext(), transactionState: transactionState) { value in
             updatedValue = value
         }
 
@@ -21,13 +21,13 @@ final class AtomProducerContextTests: XCTestCase {
     @MainActor
     func testOnTermination() {
         let atom = TestValueAtom(value: 0)
-        let transaction = Transaction(key: AtomKey(atom))
-        let context = AtomProducerContext<Int>(store: StoreContext(), transaction: transaction) { _ in }
+        let transactionState = TransactionState(key: AtomKey(atom))
+        let context = AtomProducerContext<Int>(store: StoreContext(), transactionState: transactionState) { _ in }
 
         context.onTermination = {}
         XCTAssertNotNil(context.onTermination)
 
-        transaction.terminate()
+        transactionState.terminate()
         XCTAssertNil(context.onTermination)
 
         context.onTermination = {}
@@ -39,11 +39,11 @@ final class AtomProducerContextTests: XCTestCase {
         let atom = TestValueAtom(value: 0)
         var didBegin = false
         var didCommit = false
-        let transaction = Transaction(key: AtomKey(atom)) {
+        let transactionState = TransactionState(key: AtomKey(atom)) {
             didBegin = true
             return { didCommit = true }
         }
-        let context = AtomProducerContext<Int>(store: StoreContext(), transaction: transaction) { _ in }
+        let context = AtomProducerContext<Int>(store: StoreContext(), transactionState: transactionState) { _ in }
 
         context.transaction { _ in }
 
@@ -56,11 +56,11 @@ final class AtomProducerContextTests: XCTestCase {
         let atom = TestValueAtom(value: 0)
         var didBegin = false
         var didCommit = false
-        let transaction = Transaction(key: AtomKey(atom)) {
+        let transactionState = TransactionState(key: AtomKey(atom)) {
             didBegin = true
             return { didCommit = true }
         }
-        let context = AtomProducerContext<Int>(store: StoreContext(), transaction: transaction) { _ in }
+        let context = AtomProducerContext<Int>(store: StoreContext(), transactionState: transactionState) { _ in }
 
         await context.transaction { _ in
             try? await Task.sleep(seconds: 0)

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -1380,7 +1380,7 @@ final class StoreContextTests: XCTestCase {
         }
 
         final class SubscriberHost {
-            var subscriberState: SubscriberState? = SubscriberState()
+            var subscriberState: SubscriberState?
         }
 
         // Flaky.
@@ -1388,6 +1388,8 @@ final class StoreContextTests: XCTestCase {
             let store = AtomStore()
             let context = StoreContext(store: store)
             let host = SubscriberHost()
+            host.subscriberState = SubscriberState()
+
             let subscriber = Subscriber(host.subscriberState!)
 
             _ = context.watch(
@@ -1426,6 +1428,7 @@ final class StoreContextTests: XCTestCase {
             wait(for: [expectation], timeout: 0.5)
             XCTAssertNil(context.lookup(TestAtom1()))
             XCTAssertNil(context.lookup(TestAtom2()))
+            XCTAssertTrue(store.state.subscriptions.isEmpty)
         }
     }
 

--- a/Tests/AtomsTests/Core/SubscriberKeyTests.swift
+++ b/Tests/AtomsTests/Core/SubscriberKeyTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import Atoms
 
 final class SubscriberKeyTests: XCTestCase {
+    @MainActor
     func testKeyHashableForSameToken() {
         let token = SubscriberKey.Token()
         let key0 = SubscriberKey(token: token)
@@ -12,6 +13,7 @@ final class SubscriberKeyTests: XCTestCase {
         XCTAssertEqual(key0.hashValue, key1.hashValue)
     }
 
+    @MainActor
     func testKeyHashableForDifferentToken() {
         let token0 = SubscriberKey.Token()
         let token1 = SubscriberKey.Token()

--- a/Tests/AtomsTests/Core/TransactionTests.swift
+++ b/Tests/AtomsTests/Core/TransactionTests.swift
@@ -8,7 +8,7 @@ final class TransactionTests: XCTestCase {
         let key = AtomKey(TestValueAtom(value: 0))
         var beginCount = 0
         var commitCount = 0
-        let transaction = Transaction(key: key) {
+        let transactionState = TransactionState(key: key) {
             beginCount += 1
             return { commitCount += 1 }
         }
@@ -16,23 +16,23 @@ final class TransactionTests: XCTestCase {
         XCTAssertEqual(beginCount, 0)
         XCTAssertEqual(commitCount, 0)
 
-        transaction.commit()
+        transactionState.commit()
 
         XCTAssertEqual(beginCount, 0)
         XCTAssertEqual(commitCount, 0)
 
-        transaction.begin()
+        transactionState.begin()
 
         XCTAssertEqual(beginCount, 1)
         XCTAssertEqual(commitCount, 0)
 
-        transaction.commit()
+        transactionState.commit()
 
         XCTAssertEqual(beginCount, 1)
         XCTAssertEqual(commitCount, 1)
 
-        transaction.begin()
-        transaction.commit()
+        transactionState.begin()
+        transactionState.commit()
 
         XCTAssertEqual(beginCount, 1)
         XCTAssertEqual(commitCount, 1)
@@ -41,18 +41,18 @@ final class TransactionTests: XCTestCase {
     @MainActor
     func testOnTermination() {
         let key = AtomKey(TestValueAtom(value: 0))
-        let transaction = Transaction(key: key)
+        let transactionState = TransactionState(key: key)
 
-        XCTAssertNil(transaction.onTermination)
+        XCTAssertNil(transactionState.onTermination)
 
-        transaction.onTermination = {}
-        XCTAssertNotNil(transaction.onTermination)
+        transactionState.onTermination = {}
+        XCTAssertNotNil(transactionState.onTermination)
 
-        transaction.terminate()
-        XCTAssertNil(transaction.onTermination)
+        transactionState.terminate()
+        XCTAssertNil(transactionState.onTermination)
 
-        transaction.onTermination = {}
-        XCTAssertNil(transaction.onTermination)
+        transactionState.onTermination = {}
+        XCTAssertNil(transactionState.onTermination)
     }
 
     @MainActor
@@ -61,36 +61,36 @@ final class TransactionTests: XCTestCase {
         var didBegin = false
         var didCommit = false
         var didTerminate = false
-        let transaction = Transaction(key: key) {
+        let transactionState = TransactionState(key: key) {
             didBegin = true
             return { didCommit = true }
         }
 
-        transaction.onTermination = {
+        transactionState.onTermination = {
             didTerminate = true
         }
 
         XCTAssertFalse(didBegin)
         XCTAssertFalse(didCommit)
         XCTAssertFalse(didTerminate)
-        XCTAssertFalse(transaction.isTerminated)
-        XCTAssertNotNil(transaction.onTermination)
+        XCTAssertFalse(transactionState.isTerminated)
+        XCTAssertNotNil(transactionState.onTermination)
 
-        transaction.begin()
-        transaction.terminate()
+        transactionState.begin()
+        transactionState.terminate()
 
         XCTAssertTrue(didBegin)
         XCTAssertTrue(didCommit)
         XCTAssertTrue(didTerminate)
-        XCTAssertTrue(transaction.isTerminated)
-        XCTAssertNil(transaction.onTermination)
+        XCTAssertTrue(transactionState.isTerminated)
+        XCTAssertNil(transactionState.onTermination)
 
         didTerminate = false
-        transaction.onTermination = {
+        transactionState.onTermination = {
             didTerminate = true
         }
 
         XCTAssertTrue(didTerminate)
-        XCTAssertNil(transaction.onTermination)
+        XCTAssertNil(transactionState.onTermination)
     }
 }

--- a/Tests/AtomsTests/Utilities/Utilities.swift
+++ b/Tests/AtomsTests/Utilities/Utilities.swift
@@ -110,7 +110,7 @@ extension AtomCache: Equatable where Node: Equatable, Node.Produced: Equatable {
     }
 }
 
-extension Transaction {
+extension TransactionState {
     convenience init(key: AtomKey) {
         self.init(key: key, { {} })
     }

--- a/Tests/AtomsTests/Utilities/Utilities.swift
+++ b/Tests/AtomsTests/Utilities/Utilities.swift
@@ -73,7 +73,20 @@ final class ResettableSubject<Output, Failure: Error>: Publisher, Subject {
 extension StoreContext {
     init(
         store: AtomStore = AtomStore(),
-        scopeKey: ScopeKey = ScopeKey(token: ScopeKey.Token()),
+        observers: [Observer] = [],
+        overrides: [OverrideKey: any OverrideProtocol] = [:]
+    ) {
+        self.init(
+            store: store,
+            scopeKey: ScopeKey(token: ScopeKey.Token()),
+            observers: observers,
+            overrides: overrides
+        )
+    }
+
+    init(
+        store: AtomStore = AtomStore(),
+        scopeKey: ScopeKey,
         observers: [Observer] = [],
         overrides: [OverrideKey: any OverrideProtocol] = [:]
     ) {
@@ -96,7 +109,7 @@ extension AtomKey {
 }
 
 extension Atoms.Subscription {
-    init(update: @escaping () -> Void = {}) {
+    init(update: @MainActor @Sendable @escaping () -> Void = {}) {
         let location = SourceLocation()
         self.init(location: location, update: update)
     }


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

Workaround for issues that can cause data races if for some reason a view with atoms property wrappers is dismantled on a background thread.
Using the [isolated synchronous deinit](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md) which is under proposal review as of now should be the best option in the future.