### PR TITLE
Deprecate Refreshable and Resettable

### DIFF
--- a/Sources/Atoms/Attribute/Refreshable.swift
+++ b/Sources/Atoms/Attribute/Refreshable.swift
@@ -21,6 +21,7 @@
 /// }
 /// ```
 ///
+@available(*, deprecated, message: "`Refreshable` is deprecated. Use a custom refresh function or other alternatives instead.")
 public protocol Refreshable where Self: Atom {
     /// Refreshes and then return a result value.
     ///

--- a/Sources/Atoms/Attribute/Resettable.swift
+++ b/Sources/Atoms/Attribute/Resettable.swift
@@ -21,6 +21,7 @@
 /// }
 /// ```
 ///
+@available(*, deprecated, message: "`Resettable` is deprecated. Use a custom reset function or other alternatives instead.")
 public protocol Resettable where Self: Atom {
     /// Arbitrary reset method to be executed on atom reset.
     ///

--- a/Sources/Atoms/Context/AtomContext.swift
+++ b/Sources/Atoms/Context/AtomContext.swift
@@ -99,6 +99,7 @@ public protocol AtomContext {
     /// - Parameter atom: An atom to refresh.
     ///
     /// - Returns: The value after the refreshing associated with the given atom is completed.
+    @available(*, deprecated, message: "`Refreshable` is deprecated. Use a custom refresh function or other alternatives instead.")
     @discardableResult
     func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Produced
 
@@ -136,6 +137,7 @@ public protocol AtomContext {
     /// ```
     ///
     /// - Parameter atom: An atom to reset.
+    @available(*, deprecated, message: "`Resettable` is deprecated. Use a custom reset function or other alternatives instead.")
     func reset(_ atom: some Resettable)
 }
 

--- a/Sources/Atoms/Context/AtomCurrentContext.swift
+++ b/Sources/Atoms/Context/AtomCurrentContext.swift
@@ -113,6 +113,7 @@ public struct AtomCurrentContext: AtomContext {
     /// - Parameter atom: An atom to refresh.
     ///
     /// - Returns: The value after the refreshing associated with the given atom is completed.
+    @available(*, deprecated, message: "`Refreshable` is deprecated. Use a custom refresh function or other alternatives instead.")
     @inlinable
     @discardableResult
     public func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Produced {
@@ -155,6 +156,7 @@ public struct AtomCurrentContext: AtomContext {
     /// ```
     ///
     /// - Parameter atom: An atom to reset.
+    @available(*, deprecated, message: "`Resettable` is deprecated. Use a custom reset function or other alternatives instead.")
     @inlinable
     public func reset(_ atom: some Resettable) {
         _store.reset(atom)

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -257,6 +257,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// - Parameter atom: An atom to refresh.
     ///
     /// - Returns: The value after the refreshing associated with the given atom is completed.
+    @available(*, deprecated, message: "`Refreshable` is deprecated. Use a custom refresh function or other alternatives instead.")
     @inlinable
     @discardableResult
     public func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Produced {
@@ -300,6 +301,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// ```
     ///
     /// - Parameter atom: An atom to reset.
+    @available(*, deprecated, message: "`Resettable` is deprecated. Use a custom reset function or other alternatives instead.")
     @inlinable
     public func reset(_ atom: some Resettable) {
         _store.reset(atom)

--- a/Sources/Atoms/Context/AtomTransactionContext.swift
+++ b/Sources/Atoms/Context/AtomTransactionContext.swift
@@ -123,6 +123,7 @@ public struct AtomTransactionContext: AtomWatchableContext {
     /// - Parameter atom: An atom to refresh.
     ///
     /// - Returns: The value after the refreshing associated with the given atom is completed.
+    @available(*, deprecated, message: "`Refreshable` is deprecated. Use a custom refresh function or other alternatives instead.")
     @inlinable
     @discardableResult
     public func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Produced {
@@ -166,6 +167,7 @@ public struct AtomTransactionContext: AtomWatchableContext {
     /// ```
     ///
     /// - Parameter atom: An atom to reset.
+    @available(*, deprecated, message: "`Resettable` is deprecated. Use a custom reset function or other alternatives instead.")
     @inlinable
     public func reset(_ atom: some Resettable) {
         _store.reset(atom)

--- a/Sources/Atoms/Context/AtomViewContext.swift
+++ b/Sources/Atoms/Context/AtomViewContext.swift
@@ -129,6 +129,7 @@ public struct AtomViewContext: AtomWatchableContext {
     /// - Parameter atom: An atom to refresh.
     ///
     /// - Returns: The value after the refreshing associated with the given atom is completed.
+    @available(*, deprecated, message: "`Refreshable` is deprecated. Use a custom refresh function or other alternatives instead.")
     @inlinable
     @discardableResult
     public func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Produced {
@@ -172,6 +173,7 @@ public struct AtomViewContext: AtomWatchableContext {
     /// ```
     ///
     /// - Parameter atom: An atom to reset.
+    @available(*, deprecated, message: "`Resettable` is deprecated. Use a custom reset function or other alternatives instead.")
     @inlinable
     public func reset(_ atom: some Resettable) {
         _store.reset(atom)

--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -158,6 +158,7 @@ internal struct StoreContext {
         return value
     }
 
+    @available(*, deprecated)
     @usableFromInline
     func refresh<Node: Refreshable>(_ atom: Node) async -> Node.Produced {
         let (key, _) = lookupAtomKeyAndOverride(of: atom)
@@ -199,6 +200,7 @@ internal struct StoreContext {
         }
     }
 
+    @available(*, deprecated)
     @usableFromInline
     func reset(_ atom: some Resettable) {
         let (key, _) = lookupAtomKeyAndOverride(of: atom)

--- a/Tests/AtomsTests/Attribute/RefreshableTests.swift
+++ b/Tests/AtomsTests/Attribute/RefreshableTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Atoms
 
+@available(*, deprecated)
 final class RefreshableTests: XCTestCase {
     @MainActor
     func testCustomRefresh() async {

--- a/Tests/AtomsTests/Attribute/ResettableTests.swift
+++ b/Tests/AtomsTests/Attribute/ResettableTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Atoms
 
+@available(*, deprecated)
 final class ResettableTests: XCTestCase {
     @MainActor
     func testCustomReset() {

--- a/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
@@ -46,6 +46,7 @@ final class AtomCurrentContextTests: XCTestCase {
         XCTAssertEqual(value, 100)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomRefresh() async {
         let atom = TestCustomRefreshableAtom { _ in
@@ -84,6 +85,7 @@ final class AtomCurrentContextTests: XCTestCase {
         XCTAssertEqual(storeContext.read(dependency), 0)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomReset() {
         let store = AtomStore()

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -209,6 +209,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(updateCount, 1)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomRefresh() async {
         let atom = TestCustomRefreshableAtom { _ in
@@ -248,6 +249,7 @@ final class AtomTestContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 0)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomReset() {
         let atom = TestStateAtom(defaultValue: 0)

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -57,6 +57,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom1).value, 100)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomRefresh() async {
         let atom0 = TestValueAtom(value: 0)
@@ -103,6 +104,7 @@ final class AtomTransactionContextTests: XCTestCase {
         XCTAssertEqual(context.read(dependency), 0)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomReset() {
         let transactionAtom = TestValueAtom(value: 0)

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -58,6 +58,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.watch(atom).value, 100)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomRefresh() async {
         let atom = TestCustomRefreshableAtom { _ in
@@ -104,6 +105,7 @@ final class AtomViewContextTests: XCTestCase {
         XCTAssertEqual(context.read(atom), 0)
     }
 
+    @available(*, deprecated)
     @MainActor
     func testCustomReset() {
         let store = AtomStore()

--- a/Tests/AtomsTests/Utilities/TestAtom.swift
+++ b/Tests/AtomsTests/Utilities/TestAtom.swift
@@ -95,6 +95,7 @@ struct TestAsyncPhaseAtom<Success, Failure: Error>: AsyncPhaseAtom, @unchecked S
     }
 }
 
+@available(*, deprecated)
 struct TestCustomRefreshableAtom<T: Sendable>: ValueAtom, Refreshable, @unchecked Sendable {
     var getValue: (Context) -> T
     var refresh: (CurrentContext) async -> T
@@ -112,6 +113,7 @@ struct TestCustomRefreshableAtom<T: Sendable>: ValueAtom, Refreshable, @unchecke
     }
 }
 
+@available(*, deprecated)
 struct TestCustomResettableAtom<T>: StateAtom, Resettable, @unchecked Sendable {
     var defaultValue: (Context) -> T
     var reset: (CurrentContext) -> Void


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

With the introduction of `AsyncPhaseAtom`, there is not so much demand to make it possible to define atoms that wrap other atoms. Now that the cost of maintaining the stability and code maintainability of the `Refreshable` and `Resettable` behavior is no longer worth their convenience, they're being deprecated in this version and removed in the next version.