### PR TITLE
Update TransactionState.swift - build fix for Xcode 26 toolchain

### DIFF
--- a/Sources/Atoms/Core/TransactionState.swift
+++ b/Sources/Atoms/Core/TransactionState.swift
@@ -14,7 +14,7 @@ internal final class TransactionState {
         _ body: @MainActor @escaping () -> @MainActor () -> Void
     ) {
         self.key = key
-        self.body = body
+        self.body = { return body() } /// wrap `body` closure to allow for type inference in Xcode 26 toolchain
     }
 
     var onTermination: (@MainActor () -> Void)? {


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Chore

## Description

As the new Xcode 26 uses a newer toolchain, it introduces stricter type inference that cannot be disabled (this stricter inference applies to both Swift 5 and Swift 6, and to my knowledge, cannot be bypassed using any compiler flag).

This stricter behavior causes a severe build error for which I couldn’t find any compilation workaround. For reference, I have tried several compilation flags and custom Swiftly toolchains, but the issue lies somewhere deep in the Xcode 26 built-in toolchain.

The fix has been tested on Xcode 26 beta 2 and will most likely be required for the upcoming stable release as well.


## Motivation

The motivation for this fix was to ensure that projects written in Swift 5 / Swift 6, which currently build successfully in Xcode 18, also build cleanly in newer versions of Xcode 26.

Please take a look and consider merging this fix — or suggest an alternative solution — as soon as possible, since many users will likely want to use the library with Xcode 26.


## Issue, fix, and the impact on existing code

The issue lies in assigning the `body` closure to a member with a slightly different type. The fix wraps the `body` closure in another closure that calls the original, ensuring proper type alignment.

This change should not have any significant effect on the existing code. However, please verify this — especially if the change interacts with the @MainActor annotation in a non-obvious way.

**I'm not entirely sure if this is the best way to resolve the issue — it may be possible to adjust the member's type instead. However, as I'm not deeply familiar with the project's domain, I'm leaving that decision to the author.**

Personally, I believe this closure assignment was more likely an oversight or leftover code that happened to compile due to the more permissive type inference in the Xcode 18 (or earlier) toolchain, rather than a deliberate design choice.