### PR TITLE
Fix shared storage in previous/latest modifiers

### DIFF
--- a/Sources/Atoms/Modifier/LatestModifier.swift
+++ b/Sources/Atoms/Modifier/LatestModifier.swift
@@ -139,7 +139,7 @@ public struct LatestModifier<Base>: AtomModifier {
         AtomProducer { context in
             context.transaction { context in
                 let value = context.watch(atom)
-                let storage = context.watch(StorageAtom())
+                let storage = context.watch(StorageAtom(base: atom, modifier: self))
 
                 if value[keyPath: keyPath] {
                     storage.latest = value
@@ -157,7 +157,29 @@ private extension LatestModifier {
         var latest: Base?
     }
 
-    struct StorageAtom: ValueAtom, Hashable {
+    struct StorageAtom<Node: Atom>: ValueAtom {
+        struct Key: Hashable, Sendable {
+            private let baseKey: Node.Key
+            private let modifierKey: LatestModifier.Key
+
+            init(baseKey: Node.Key, modifierKey: LatestModifier.Key) {
+                self.baseKey = baseKey
+                self.modifierKey = modifierKey
+            }
+        }
+
+        private let base: Node
+        private let modifier: LatestModifier
+
+        var key: Key {
+            Key(baseKey: base.key, modifierKey: modifier.key)
+        }
+
+        init(base: Node, modifier: LatestModifier) {
+            self.base = base
+            self.modifier = modifier
+        }
+
         func value(context: Context) -> Storage {
             Storage()
         }

--- a/Sources/Atoms/Modifier/LatestModifier.swift
+++ b/Sources/Atoms/Modifier/LatestModifier.swift
@@ -185,3 +185,9 @@ private extension LatestModifier {
         }
     }
 }
+
+extension LatestModifier.StorageAtom: Scoped where Node: Scoped {
+    var scopeID: Node.ScopeID {
+        base.scopeID
+    }
+}

--- a/Sources/Atoms/Modifier/PreviousModifier.swift
+++ b/Sources/Atoms/Modifier/PreviousModifier.swift
@@ -54,7 +54,7 @@ public struct PreviousModifier<Base>: AtomModifier {
         AtomProducer { context in
             context.transaction { context in
                 let value = context.watch(atom)
-                let storage = context.watch(StorageAtom())
+                let storage = context.watch(StorageAtom(base: atom, modifier: self))
                 let previous = storage.previous
                 storage.previous = value
                 return previous
@@ -69,7 +69,29 @@ private extension PreviousModifier {
         var previous: Base?
     }
 
-    struct StorageAtom: ValueAtom, Hashable {
+    struct StorageAtom<Node: Atom>: ValueAtom {
+        struct Key: Hashable, Sendable {
+            private let baseKey: Node.Key
+            private let modifierKey: PreviousModifier.Key
+
+            init(baseKey: Node.Key, modifierKey: PreviousModifier.Key) {
+                self.baseKey = baseKey
+                self.modifierKey = modifierKey
+            }
+        }
+
+        private let base: Node
+        private let modifier: PreviousModifier
+
+        var key: Key {
+            Key(baseKey: base.key, modifierKey: modifier.key)
+        }
+
+        init(base: Node, modifier: PreviousModifier) {
+            self.base = base
+            self.modifier = modifier
+        }
+
         func value(context: Context) -> Storage {
             Storage()
         }

--- a/Sources/Atoms/Modifier/PreviousModifier.swift
+++ b/Sources/Atoms/Modifier/PreviousModifier.swift
@@ -97,3 +97,9 @@ private extension PreviousModifier {
         }
     }
 }
+
+extension PreviousModifier.StorageAtom: Scoped where Node: Scoped {
+    var scopeID: Node.ScopeID {
+        base.scopeID
+    }
+}

--- a/Tests/AtomsTests/Modifier/LatestModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/LatestModifierTests.swift
@@ -125,6 +125,41 @@ final class LatestModifierTests: XCTestCase {
     }
 
     @MainActor
+    func testLatestIsolatedPerScope() {
+        struct ScopedItemAtom: StateAtom, Scoped, Hashable, @unchecked Sendable {
+            let key = UniqueKey()
+            let scopeID = DefaultScopeID()
+
+            func defaultValue(context: Context) -> Item {
+                Item(id: 0, isValid: false)
+            }
+        }
+
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let scope1Token = ScopeKey.Token()
+        let scope2Token = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let scope1 = context.scoped(scopeID: ScopeID(DefaultScopeID()), scopeKey: scope1Token.key)
+        let scope2 = context.scoped(scopeID: ScopeID(DefaultScopeID()), scopeKey: scope2Token.key)
+        let subscriber1 = Subscriber(SubscriberState())
+        let subscriber2 = Subscriber(SubscriberState())
+        let atom = ScopedItemAtom()
+
+        // Drive `latest` in scope1 so its StorageAtom retains a valid item.
+        XCTAssertNil(scope1.watch(atom.latest(\.isValid), subscriber: subscriber1, subscription: Subscription()))
+        scope1.set(Item(id: 10, isValid: true), for: atom)
+        XCTAssertEqual(
+            scope1.watch(atom.latest(\.isValid), subscriber: subscriber1, subscription: Subscription())?.id,
+            10
+        )
+
+        // First read of `latest` in scope2. With un-scoped storage this would
+        // leak scope1's id=10; with per-scope storage it must be nil.
+        XCTAssertNil(scope2.watch(atom.latest(\.isValid), subscriber: subscriber2, subscription: Subscription()))
+    }
+
+    @MainActor
     func testLatestIsolatedPerKeyPath() {
         let atom = TestStateAtom(defaultValue: Item(id: 0, isValid: false, isUnique: false))
         let context = AtomTestContext()

--- a/Tests/AtomsTests/Modifier/LatestModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/LatestModifierTests.swift
@@ -4,8 +4,9 @@ import XCTest
 
 final class LatestModifierTests: XCTestCase {
     struct Item {
-        let id: Int
-        let isValid: Bool
+        var id: Int
+        var isValid: Bool
+        var isUnique = false
     }
 
     @MainActor
@@ -121,6 +122,46 @@ final class LatestModifierTests: XCTestCase {
 
         // Should return the new true value
         XCTAssertEqual(context.watch(atom.latest(\.self)), true)
+    }
+
+    @MainActor
+    func testLatestIsolatedPerKeyPath() {
+        let atom = TestStateAtom(defaultValue: Item(id: 0, isValid: false, isUnique: false))
+        let context = AtomTestContext()
+
+        // Drive A through a valid emission so any shared storage now retains id=10.
+        XCTAssertNil(context.watch(atom.latest(\.isValid)))
+        context[atom] = Item(id: 10, isValid: true, isUnique: false)
+        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 10)
+
+        // First read of B — has never seen a B-valid value. With shared storage
+        // it would leak A's id=10; with per-(base, keyPath) storage it must be nil.
+        XCTAssertNil(context.watch(atom.latest(\.isUnique)))
+    }
+
+    @MainActor
+    func testLatestIsolatedPerBaseAtomInstance() {
+        struct ItemAtom: StateAtom, Hashable {
+            let id: Int
+
+            func defaultValue(context: Context) -> Item {
+                Item(id: id, isValid: false)
+            }
+        }
+
+        let context = AtomTestContext()
+        let a = ItemAtom(id: 1)
+        let b = ItemAtom(id: 2)
+
+        // Drive `a.latest` so that — under the shared-storage bug —
+        // the StorageAtom now retains `Item(id: 10, isValid: true)`.
+        XCTAssertNil(context.watch(a.latest(\.isValid)))
+        context[a] = Item(id: 10, isValid: true)
+        XCTAssertEqual(context.watch(a.latest(\.isValid))?.id, 10)
+
+        // First read of `b.latest`. With shared storage this would leak
+        // `a`'s last valid item; with per-base storage it must be nil.
+        XCTAssertNil(context.watch(b.latest(\.isValid)))
     }
 
     @MainActor

--- a/Tests/AtomsTests/Modifier/PreviousModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/PreviousModifierTests.swift
@@ -86,6 +86,36 @@ final class PreviousModifierTests: XCTestCase {
     }
 
     @MainActor
+    func testPreviousIsolatedPerScope() {
+        struct ScopedIntAtom: StateAtom, Scoped, Hashable, @unchecked Sendable {
+            let key = UniqueKey()
+            let scopeID = DefaultScopeID()
+
+            func defaultValue(context: Context) -> Int { 0 }
+        }
+
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let scope1Token = ScopeKey.Token()
+        let scope2Token = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let scope1 = context.scoped(scopeID: ScopeID(DefaultScopeID()), scopeKey: scope1Token.key)
+        let scope2 = context.scoped(scopeID: ScopeID(DefaultScopeID()), scopeKey: scope2Token.key)
+        let subscriber1 = Subscriber(SubscriberState())
+        let subscriber2 = Subscriber(SubscriberState())
+        let atom = ScopedIntAtom()
+
+        // Drive `previous` in scope1 so its StorageAtom holds the latest value.
+        XCTAssertNil(scope1.watch(atom.previous, subscriber: subscriber1, subscription: Subscription()))
+        scope1.set(1, for: atom)
+        XCTAssertEqual(scope1.watch(atom.previous, subscriber: subscriber1, subscription: Subscription()), 0)
+
+        // First read of `previous` in scope2. With un-scoped storage this would
+        // leak scope1's value; with per-scope storage it must be nil.
+        XCTAssertNil(scope2.watch(atom.previous, subscriber: subscriber2, subscription: Subscription()))
+    }
+
+    @MainActor
     func testPreviousIsolatedPerBaseAtomInstance() {
         struct ItemAtom: StateAtom, Hashable {
             let id: Int

--- a/Tests/AtomsTests/Modifier/PreviousModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/PreviousModifierTests.swift
@@ -84,4 +84,29 @@ final class PreviousModifierTests: XCTestCase {
         XCTAssertEqual(modifier.key, modifier.key)
         XCTAssertEqual(modifier.key.hashValue, modifier.key.hashValue)
     }
+
+    @MainActor
+    func testPreviousIsolatedPerBaseAtomInstance() {
+        struct ItemAtom: StateAtom, Hashable {
+            let id: Int
+
+            func defaultValue(context: Context) -> String {
+                "initial-\(id)"
+            }
+        }
+
+        let context = AtomTestContext()
+        let a = ItemAtom(id: 1)
+        let b = ItemAtom(id: 2)
+
+        // Drive `a.previous` so that — under the shared-storage bug —
+        // the StorageAtom's `previous` now holds `"a-new"`.
+        XCTAssertNil(context.watch(a.previous))
+        context[a] = "a-new"
+        XCTAssertEqual(context.watch(a.previous), "initial-1")
+
+        // First read of `b.previous`. With shared storage this would leak
+        // `"a-new"`; with per-base storage it must be nil.
+        XCTAssertNil(context.watch(b.previous))
+    }
 }


### PR DESCRIPTION
Closes #202.

## Summary
- `PreviousModifier` / `LatestModifier` backed `.previous` / `.latest` with a parameter-less private `StorageAtom`, making all instances `Hashable`-equal regardless of which base atom — or, for `LatestModifier`, which `keyPath` — was being evaluated.
- State leaked across atom clusters: e.g. `A.previous` would return whatever `B` last emitted whenever `B` shared the same `Base.Produced` type. `LatestModifier` had the same issue across keyPaths on a single base.
- Key each `StorageAtom` by `(base.key, modifier.key)` so every `(base atom instance, modifier configuration)` pair gets its own storage.

## Test plan
- [x] New regression `testPreviousIsolatedPerBaseAtomInstance` — fails on unfixed source (`"a-new"` leaks into `b.previous`), passes after fix.
- [x] New regression `testLatestIsolatedPerBaseAtomInstance` — fails on unfixed source, passes after fix.
- [x] New regression `testLatestIsolatedPerKeyPath` — fails on unfixed source (A's id=10 leaks into the first read of `latest(\.B)`), passes after fix.
- [x] `swift test` — all 168 tests pass.