### PR TITLE
Drop Swift 5 language mode support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,19 +44,6 @@ jobs:
             ${{ env.MACOS }} \
             ${{ env.TVOS_SIMULATOR }}
 
-  test_language_mode:
-    name: Test Swift 5 language mode
-    runs-on: macos-14
-    strategy:
-      matrix:
-        enable_upcoming_features:
-          - 0
-          - 1
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test Swift 5 language mode
-        run: ENABLE_UPCOMING_FEATURES=${{ matrix.enable_upcoming_features }} scripts/test.sh library SWIFT_VERSION=5 -destinations ${{ env.IOS_SIMULATOR }}
-
   benchmark:
     name: Benchmark
     runs-on: macos-14

--- a/Package.swift
+++ b/Package.swift
@@ -2,22 +2,9 @@
 
 import PackageDescription
 
-let swiftSettings: [SwiftSetting]
-
-if Context.environment["ENABLE_UPCOMING_FEATURES"] == "1" {
-    swiftSettings = [
-        .enableUpcomingFeature("DisableOutwardActorInference"),
-        .enableUpcomingFeature("InferSendableFromCaptures"),
-        .enableUpcomingFeature("IsolatedDefaultValues"),
-        .enableUpcomingFeature("StrictConcurrency"),
-        .enableUpcomingFeature("ExistentialAny"),
-    ]
-}
-else {
-    swiftSettings = [
-        .enableUpcomingFeature("ExistentialAny")
-    ]
-}
+let swiftSettings: [SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny")
+]
 
 let package = Package(
     name: "swiftui-atom-properties",
@@ -41,5 +28,5 @@ let package = Package(
             swiftSettings: swiftSettings
         ),
     ],
-    swiftLanguageModes: [.v5, .v6]
+    swiftLanguageModes: [.v6]
 )

--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ Open `Examples/Project.xcodeproj` and play around with it!
 
 ### Requirements
 
-|             |Minimum Version|
-|------------:|--------------:|
-|Language mode|5, 6           |
-|Xcode        |16.1           |
-|iOS          |16.0           |
-|macOS        |13.0           |
-|tvOS         |16.0           |
-|watchOS      |9.0            |
+|        |Minimum Version|
+|-------:|--------------:|
+|Language|6              |
+|Xcode   |16.1           |
+|iOS     |16.0           |
+|macOS   |13.0           |
+|tvOS    |16.0           |
+|watchOS |9.0            |
 
 ### Installation
 

--- a/Sources/Atoms/Core/ScopeState.swift
+++ b/Sources/Atoms/Core/ScopeState.swift
@@ -3,10 +3,6 @@
 internal final class ScopeState {
     let token = ScopeKey.Token()
 
-    #if !hasFeature(IsolatedDefaultValues)
-        nonisolated init() {}
-    #endif
-
     nonisolated(unsafe) var unregister: (@MainActor () -> Void)?
 
     // TODO: Use isolated synchronous deinit once it's available.

--- a/Sources/Atoms/Core/SubscriberState.swift
+++ b/Sources/Atoms/Core/SubscriberState.swift
@@ -2,10 +2,6 @@
 internal final class SubscriberState {
     let token = SubscriberKey.Token()
 
-    #if !hasFeature(IsolatedDefaultValues)
-        nonisolated init() {}
-    #endif
-
     nonisolated(unsafe) var unsubscribe: (@MainActor () -> Void)?
 
     // TODO: Use isolated synchronous deinit once it's available.

--- a/Sources/Atoms/Modifier/ChangesOfModifier.swift
+++ b/Sources/Atoms/Modifier/ChangesOfModifier.swift
@@ -1,67 +1,34 @@
 public extension Atom {
-    #if hasFeature(InferSendableFromCaptures)
-        /// Derives a partial property with the specified key path from the original atom and prevent it
-        /// from updating its downstream when its new value is equivalent to old value.
-        ///
-        /// ## Example
-        ///
-        /// ```swift
-        /// struct IntAtom: ValueAtom, Hashable {
-        ///     func value(context: Context) -> Int {
-        ///         12345
-        ///     }
-        /// }
-        ///
-        /// struct ExampleView: View {
-        ///     @Watch(IntAtom().changes(of: \.description))
-        ///     var description
-        ///
-        ///     var body: some View {
-        ///         Text(description)
-        ///     }
-        /// }
-        /// ```
-        ///
-        /// - Parameter keyPath: A key path for the property of the original atom value.
-        ///
-        /// - Returns: An atom that provides the partial property of the original atom value.
-        func changes<T: Equatable>(
-            of keyPath: any KeyPath<Produced, T> & Sendable
-        ) -> ModifiedAtom<Self, ChangesOfModifier<Produced, T>> {
-            modifier(ChangesOfModifier(keyPath: keyPath))
-        }
-    #else
-        /// Derives a partial property with the specified key path from the original atom and prevent it
-        /// from updating its downstream when its new value is equivalent to old value.
-        ///
-        /// ## Example
-        ///
-        /// ```swift
-        /// struct IntAtom: ValueAtom, Hashable {
-        ///     func value(context: Context) -> Int {
-        ///         12345
-        ///     }
-        /// }
-        ///
-        /// struct ExampleView: View {
-        ///     @Watch(IntAtom().changes(of: \.description))
-        ///     var description
-        ///
-        ///     var body: some View {
-        ///         Text(description)
-        ///     }
-        /// }
-        /// ```
-        ///
-        /// - Parameter keyPath: A key path for the property of the original atom value.
-        ///
-        /// - Returns: An atom that provides the partial property of the original atom value.
-        func changes<T: Equatable>(
-            of keyPath: KeyPath<Produced, T>
-        ) -> ModifiedAtom<Self, ChangesOfModifier<Produced, T>> {
-            modifier(ChangesOfModifier(keyPath: keyPath))
-        }
-    #endif
+    /// Derives a partial property with the specified key path from the original atom and prevent it
+    /// from updating its downstream when its new value is equivalent to old value.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// struct IntAtom: ValueAtom, Hashable {
+    ///     func value(context: Context) -> Int {
+    ///         12345
+    ///     }
+    /// }
+    ///
+    /// struct ExampleView: View {
+    ///     @Watch(IntAtom().changes(of: \.description))
+    ///     var description
+    ///
+    ///     var body: some View {
+    ///         Text(description)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter keyPath: A key path for the property of the original atom value.
+    ///
+    /// - Returns: An atom that provides the partial property of the original atom value.
+    func changes<T: Equatable>(
+        of keyPath: any KeyPath<Produced, T> & Sendable
+    ) -> ModifiedAtom<Self, ChangesOfModifier<Produced, T>> {
+        modifier(ChangesOfModifier(keyPath: keyPath))
+    }
 }
 
 /// A modifier that derives a partial property with the specified key path from the original atom
@@ -75,49 +42,25 @@ public struct ChangesOfModifier<Base, Produced: Equatable>: AtomModifier {
     /// A type of value the modified atom produces.
     public typealias Produced = Produced
 
-    #if hasFeature(InferSendableFromCaptures)
-        /// A type representing the stable identity of this modifier.
-        public struct Key: Hashable, Sendable {
-            private let keyPath: any KeyPath<Base, Produced> & Sendable
-
-            fileprivate init(keyPath: any KeyPath<Base, Produced> & Sendable) {
-                self.keyPath = keyPath
-            }
-        }
-
+    /// A type representing the stable identity of this modifier.
+    public struct Key: Hashable, Sendable {
         private let keyPath: any KeyPath<Base, Produced> & Sendable
 
-        internal init(keyPath: any KeyPath<Base, Produced> & Sendable) {
+        fileprivate init(keyPath: any KeyPath<Base, Produced> & Sendable) {
             self.keyPath = keyPath
         }
+    }
 
-        /// A unique value used to identify the modifier internally.
-        public var key: Key {
-            Key(keyPath: keyPath)
-        }
-    #else
-        public struct Key: Hashable, Sendable {
-            private let keyPath: UnsafeUncheckedSendable<KeyPath<Base, Produced>>
+    private let keyPath: any KeyPath<Base, Produced> & Sendable
 
-            fileprivate init(keyPath: UnsafeUncheckedSendable<KeyPath<Base, Produced>>) {
-                self.keyPath = keyPath
-            }
-        }
+    internal init(keyPath: any KeyPath<Base, Produced> & Sendable) {
+        self.keyPath = keyPath
+    }
 
-        private let _keyPath: UnsafeUncheckedSendable<KeyPath<Base, Produced>>
-        private var keyPath: KeyPath<Base, Produced> {
-            _keyPath.value
-        }
-
-        internal init(keyPath: KeyPath<Base, Produced>) {
-            _keyPath = UnsafeUncheckedSendable(keyPath)
-        }
-
-        /// A unique value used to identify the modifier internally.
-        public var key: Key {
-            Key(keyPath: _keyPath)
-        }
-    #endif
+    /// A unique value used to identify the modifier internally.
+    public var key: Key {
+        Key(keyPath: keyPath)
+    }
 
     /// A producer that produces the value of this atom.
     public func producer(atom: some Atom<Base>) -> AtomProducer<Produced> {

--- a/Sources/Atoms/Modifier/LatestModifier.swift
+++ b/Sources/Atoms/Modifier/LatestModifier.swift
@@ -1,83 +1,42 @@
 public extension Atom {
-    #if hasFeature(InferSendableFromCaptures)
-        /// Provides the latest value that matches the specified condition instead of the current value.
-        ///
-        /// ## Example
-        ///
-        /// ```swift
-        /// struct Item {
-        ///     let id: Int
-        ///     let isValid: Bool
-        /// }
-        ///
-        /// struct ItemAtom: StateAtom, Hashable {
-        ///     func defaultValue(context: Context) -> Item {
-        ///         Item(id: 0, isValid: false)
-        ///     }
-        /// }
-        ///
-        /// struct ExampleView: View {
-        ///     @Watch(ItemAtom())
-        ///     var currentItem
-        ///
-        ///     @Watch(ItemAtom().latest(\.isValid))
-        ///     var latestValidItem
-        ///
-        ///     var body: some View {
-        ///         VStack {
-        ///             Text("Current ID: \(currentItem.id)")
-        ///             Text("Latest Valid ID: \(latestValidItem?.id ?? 0)")
-        ///         }
-        ///     }
-        /// }
-        /// ```
-        ///
-        /// - Parameter keyPath: A key path to a `Bool` property of the atom value that determines whether the value should be retained as the latest.
-        ///
-        /// - Returns: An atom that provides the latest value that matches the specified condition, or `nil` if no value has matched yet.
-        func latest(_ keyPath: any KeyPath<Produced, Bool> & Sendable) -> ModifiedAtom<Self, LatestModifier<Produced>> {
-            modifier(LatestModifier(keyPath: keyPath))
-        }
-    #else
-        /// Provides the latest value that matches the specified condition instead of the current value.
-        ///
-        /// ## Example
-        ///
-        /// ```swift
-        /// struct Item {
-        ///     let id: Int
-        ///     let isValid: Bool
-        /// }
-        ///
-        /// struct ItemAtom: StateAtom, Hashable {
-        ///     func defaultValue(context: Context) -> Item {
-        ///         Item(id: 0, isValid: false)
-        ///     }
-        /// }
-        ///
-        /// struct ExampleView: View {
-        ///     @Watch(ItemAtom())
-        ///     var currentItem
-        ///
-        ///     @Watch(ItemAtom().latest(\.isValid))
-        ///     var latestValidItem
-        ///
-        ///     var body: some View {
-        ///         VStack {
-        ///             Text("Current ID: \(currentItem.id)")
-        ///             Text("Latest Valid ID: \(latestValidItem?.id ?? 0)")
-        ///         }
-        ///     }
-        /// }
-        /// ```
-        ///
-        /// - Parameter keyPath: A key path to a `Bool` property of the atom value that determines whether the value should be retained as the latest.
-        ///
-        /// - Returns: An atom that provides the latest value that matches the specified condition, or `nil` if no value has matched yet.
-        func latest(_ keyPath: KeyPath<Produced, Bool>) -> ModifiedAtom<Self, LatestModifier<Produced>> {
-            modifier(LatestModifier(keyPath: keyPath))
-        }
-    #endif
+    /// Provides the latest value that matches the specified condition instead of the current value.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// struct Item {
+    ///     let id: Int
+    ///     let isValid: Bool
+    /// }
+    ///
+    /// struct ItemAtom: StateAtom, Hashable {
+    ///     func defaultValue(context: Context) -> Item {
+    ///         Item(id: 0, isValid: false)
+    ///     }
+    /// }
+    ///
+    /// struct ExampleView: View {
+    ///     @Watch(ItemAtom())
+    ///     var currentItem
+    ///
+    ///     @Watch(ItemAtom().latest(\.isValid))
+    ///     var latestValidItem
+    ///
+    ///     var body: some View {
+    ///         VStack {
+    ///             Text("Current ID: \(currentItem.id)")
+    ///             Text("Latest Valid ID: \(latestValidItem?.id ?? 0)")
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter keyPath: A key path to a `Bool` property of the atom value that determines whether the value should be retained as the latest.
+    ///
+    /// - Returns: An atom that provides the latest value that matches the specified condition, or `nil` if no value has matched yet.
+    func latest(_ keyPath: any KeyPath<Produced, Bool> & Sendable) -> ModifiedAtom<Self, LatestModifier<Produced>> {
+        modifier(LatestModifier(keyPath: keyPath))
+    }
 }
 
 /// A modifier that provides the latest value that matches the specified condition instead of the current value.
@@ -90,49 +49,25 @@ public struct LatestModifier<Base>: AtomModifier {
     /// A type of value the modified atom produces.
     public typealias Produced = Base?
 
-    #if hasFeature(InferSendableFromCaptures)
-        /// A type representing the stable identity of this modifier.
-        public struct Key: Hashable, Sendable {
-            private let keyPath: any KeyPath<Base, Bool> & Sendable
-
-            fileprivate init(keyPath: any KeyPath<Base, Bool> & Sendable) {
-                self.keyPath = keyPath
-            }
-        }
-
+    /// A type representing the stable identity of this modifier.
+    public struct Key: Hashable, Sendable {
         private let keyPath: any KeyPath<Base, Bool> & Sendable
 
-        internal init(keyPath: any KeyPath<Base, Bool> & Sendable) {
+        fileprivate init(keyPath: any KeyPath<Base, Bool> & Sendable) {
             self.keyPath = keyPath
         }
+    }
 
-        /// A unique value used to identify the modifier internally.
-        public var key: Key {
-            Key(keyPath: keyPath)
-        }
-    #else
-        public struct Key: Hashable, Sendable {
-            private let keyPath: UnsafeUncheckedSendable<KeyPath<Base, Bool>>
+    private let keyPath: any KeyPath<Base, Bool> & Sendable
 
-            fileprivate init(keyPath: UnsafeUncheckedSendable<KeyPath<Base, Bool>>) {
-                self.keyPath = keyPath
-            }
-        }
+    internal init(keyPath: any KeyPath<Base, Bool> & Sendable) {
+        self.keyPath = keyPath
+    }
 
-        private let _keyPath: UnsafeUncheckedSendable<KeyPath<Base, Bool>>
-        private var keyPath: KeyPath<Base, Bool> {
-            _keyPath.value
-        }
-
-        internal init(keyPath: KeyPath<Base, Bool>) {
-            _keyPath = UnsafeUncheckedSendable(keyPath)
-        }
-
-        /// A unique value used to identify the modifier internally.
-        public var key: Key {
-            Key(keyPath: _keyPath)
-        }
-    #endif
+    /// A unique value used to identify the modifier internally.
+    public var key: Key {
+        Key(keyPath: keyPath)
+    }
 
     /// A producer that produces the value of this atom.
     public func producer(atom: some Atom<Base>) -> AtomProducer<Produced> {

--- a/Sources/Atoms/PropertyWrapper/ViewContext.swift
+++ b/Sources/Atoms/PropertyWrapper/ViewContext.swift
@@ -52,9 +52,7 @@ public struct ViewContext: DynamicProperty {
     /// This property provides primary access to the view context. However you don't
     /// access ``wrappedValue`` directly.
     /// Instead, you use the property variable created with the `@ViewContext` attribute.
-    #if hasFeature(DisableOutwardActorInference)
-        @MainActor
-    #endif
+    @MainActor
     public var wrappedValue: AtomViewContext {
         AtomViewContext(
             store: store,

--- a/Sources/Atoms/PropertyWrapper/Watch.swift
+++ b/Sources/Atoms/PropertyWrapper/Watch.swift
@@ -40,9 +40,7 @@ public struct Watch<Node: Atom>: DynamicProperty {
     /// access ``wrappedValue`` directly. Instead, you use the property variable created
     /// with the `@Watch` attribute.
     /// Accessing this property starts watching the atom.
-    #if hasFeature(DisableOutwardActorInference)
-        @MainActor
-    #endif
+    @MainActor
     public var wrappedValue: Node.Produced {
         context.watch(atom)
     }

--- a/Sources/Atoms/PropertyWrapper/WatchState.swift
+++ b/Sources/Atoms/PropertyWrapper/WatchState.swift
@@ -50,9 +50,7 @@ public struct WatchState<Node: StateAtom>: DynamicProperty {
     /// with the `@WatchState` attribute.
     /// Accessing to the getter of this property starts watching the atom, but doesn't
     /// by setting a new value.
-    #if hasFeature(DisableOutwardActorInference)
-        @MainActor
-    #endif
+    @MainActor
     public var wrappedValue: Node.Produced {
         get { context.watch(atom) }
         nonmutating set { context.set(newValue, for: atom) }
@@ -64,9 +62,7 @@ public struct WatchState<Node: StateAtom>: DynamicProperty {
     /// To get the ``projectedValue``, prefix the property variable with `$`.
     /// Accessing this property itself does not start watching the atom, but does when
     /// the view accesses to the getter of the binding.
-    #if hasFeature(DisableOutwardActorInference)
-        @MainActor
-    #endif
+    @MainActor
     public var projectedValue: Binding<Node.Produced> {
         context.binding(atom)
     }

--- a/Sources/Atoms/PropertyWrapper/WatchStateObject.swift
+++ b/Sources/Atoms/PropertyWrapper/WatchStateObject.swift
@@ -84,9 +84,7 @@ public struct WatchStateObject<Node: ObservableObjectAtom>: DynamicProperty {
     /// access ``wrappedValue`` directly. Instead, you use the property variable created
     /// with the `@WatchStateObject` attribute.
     /// Accessing this property starts watching the atom.
-    #if hasFeature(DisableOutwardActorInference)
-        @MainActor
-    #endif
+    @MainActor
     public var wrappedValue: Node.Produced {
         context.watch(atom)
     }
@@ -95,9 +93,7 @@ public struct WatchStateObject<Node: ObservableObjectAtom>: DynamicProperty {
     ///
     /// Use the projected value to pass a binding value down a view hierarchy.
     /// To get the projected value, prefix the property variable with `$`.
-    #if hasFeature(DisableOutwardActorInference)
-        @MainActor
-    #endif
+    @MainActor
     public var projectedValue: Wrapper {
         Wrapper(wrappedValue)
     }


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [x] Chore

## Issue for this PR

Link:

## Description

Drops Swift 5 *language mode* support, leaving Swift 6 language mode only. The package already requires the Swift 6 compiler (`swift-tools-version:6.0`, Xcode 16.1), so this only removes the language-mode-5 support and its compatibility shims.

- **`Package.swift`**: `swiftLanguageModes` `[.v5, .v6]` → `[.v6]`; removed the `ENABLE_UPCOMING_FEATURES` `if/else`. `ExistentialAny` stays explicitly enabled (it is *not* a default even in Swift 6 mode); the other four features (`StrictConcurrency`, `IsolatedDefaultValues`, `InferSendableFromCaptures`, `DisableOutwardActorInference`) are default-on in Swift 6 mode and no longer need listing. This also makes the root package's upcoming-feature set match the Examples packages.
- **Resolved every `#if hasFeature(...)` block to its Swift 6 side and deleted the dead fallbacks**:
  - `SubscriberState` / `ScopeState`: dropped the `nonisolated init() {}` shim guarded by `!hasFeature(IsolatedDefaultValues)` (the synthesized `@MainActor` init is used; all call sites are `@MainActor`).
  - `ChangesOfModifier` / `LatestModifier`: dropped the `UnsafeUncheckedSendable<KeyPath>` fallback, keeping the `any KeyPath & Sendable` implementation.
  - `Watch` / `WatchState` / `WatchStateObject` / `ViewContext`: `wrappedValue` / `projectedValue` are now unconditionally `@MainActor`.
- **CI**: removed the `test_language_mode` job (the `SWIFT_VERSION=5` × upcoming 0/1 matrix).
- **README**: updated the requirements table (`Language mode: 5, 6` → `Language: 6`).

## Motivation and Context

The Swift 5 language mode and the `ENABLE_UPCOMING_FEATURES` toggle existed only to verify forward-compatibility while supporting mode 5. Since mode 6 is now the sole supported mode, these branches and their fallback implementations are dead code that adds maintenance overhead.

## Impact on Existing Code

No public API or runtime behavior change for Swift 6 mode consumers — the kept branches are exactly what mode-6 builds already compiled against (e.g. the `any KeyPath & Sendable` signatures, unconditional `@MainActor`). Consumers still building in Swift 5 language mode are no longer supported.

Verification:
- `swift build` ✅
- `swift test` ✅ (170 tests pass)
- `make lint` ✅ / `make format` ✅ (no diff)

## Screenshot/Video/Gif