### PR TITLE
Update supported Xcode to 26.5 and modernize dev tools

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,12 +8,12 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.1.app
+  DEVELOPER_DIR: /Applications/Xcode_26.5.app
 
 jobs:
   publish-docs:
     name: Publish Documentation
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Build docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test example iOS
         run: scripts/test.sh example-ios -destinations ${{ env.IOS_SIMULATOR }}
-      - name: Test example cross platform
-        run: |
-          scripts/test.sh example-cross-platform -destinations \
-            ${{ env.MACOS }} \
-            ${{ env.TVOS_SIMULATOR }}
+      - name: Test example cross platform macOS
+        run: scripts/test.sh example-cross-platform -destinations ${{ env.MACOS }}
+      - name: Test example cross platform tvOS
+        run: scripts/test.sh example-cross-platform -destinations ${{ env.TVOS_SIMULATOR }}
 
   benchmark:
     name: Benchmark

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,16 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.1.app
-  IOS_SIMULATOR: '"platform=iOS Simulator,name=iPhone 16 Pro"'
+  DEVELOPER_DIR: /Applications/Xcode_26.5.app
+  IOS_SIMULATOR: '"platform=iOS Simulator,name=iPhone 17 Pro"'
   MACOS: '"platform=macOS"'
   TVOS_SIMULATOR: '"platform=tvOS Simulator,name=Apple TV 4K (3rd generation)"'
-  WATCHOS_SIMULATOR: '"platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)"'
+  WATCHOS_SIMULATOR: '"platform=watchOS Simulator,name=Apple Watch Ultra 3 (49mm)"'
 
 jobs:
   test:
     name: Test
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Test library iOS
@@ -33,7 +33,7 @@ jobs:
 
   test_examples:
     name: Test examples
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Test example iOS
@@ -46,7 +46,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Run benchmark test
@@ -54,7 +54,7 @@ jobs:
 
   validation:
     name: Validation
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Show environments

--- a/Benchmarks/Project.xcodeproj/project.pbxproj
+++ b/Benchmarks/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -105,6 +105,8 @@
 			dependencies = (
 			);
 			name = TestHostApp;
+			packageProductDependencies = (
+			);
 			productName = TestHostApp;
 			productReference = 1B958FC315257DE6087DC271 /* TestHostApp.app */;
 			productType = "com.apple.product-type.application";
@@ -147,7 +149,6 @@
 				};
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -155,9 +156,12 @@
 				en,
 			);
 			mainGroup = 293D0FF827366B513839236A;
+			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				46971BDB6A1F62470AB88C76 /* XCLocalSwiftPackageReference ".." */,
 			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = AC523591AC7BE9275003D2DB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/Benchmarks/Project.xcodeproj/xcshareddata/xcschemes/BenchmarkTests.xcscheme
+++ b/Benchmarks/Project.xcodeproj/xcshareddata/xcschemes/BenchmarkTests.xcscheme
@@ -40,7 +40,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6DA7AAFCA871E516913F5B46"

--- a/Examples/Project.xcodeproj/project.pbxproj
+++ b/Examples/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -171,7 +171,6 @@
 				};
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -179,10 +178,13 @@
 				en,
 			);
 			mainGroup = 293D0FF827366B513839236A;
+			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				E33DA6C4A12A51D5FE9E2326 /* XCLocalSwiftPackageReference "Packages/CrossPlatform" */,
 				0D7591B851157DD4AFC572BB /* XCLocalSwiftPackageReference "Packages/iOS" */,
 			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = AC523591AC7BE9275003D2DB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Open `Examples/Project.xcodeproj` and play around with it!
 |        |Minimum Version|
 |-------:|--------------:|
 |Language|6              |
-|Xcode   |16.1           |
+|Xcode   |26.5           |
 |iOS     |17.0           |
 |macOS   |14.0           |
 |tvOS    |17.0           |

--- a/Sources/Atoms/Effect/AtomEffectBuilder.swift
+++ b/Sources/Atoms/Effect/AtomEffectBuilder.swift
@@ -53,6 +53,7 @@ public enum AtomEffectBuilder {
 }
 
 public extension AtomEffectBuilder {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     struct ConditionalEffect<TrueEffect: AtomEffect, FalseEffect: AtomEffect>: AtomEffect {
         internal enum Storage {
             case trueEffect(TrueEffect)

--- a/Tools/Package.resolved
+++ b/Tools/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a807c1694a525436ee3bf845fdaabded7e6aef74d71d09780253d4058fecf5a7",
+  "originHash" : "c32add3485f9a9f24d606acf1ae8a68ac4b797fc842ff3daab4afb31806c24f1",
   "pins" : [
     {
       "identity" : "aexml",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tadija/AEXML.git",
       "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-format.git",
       "state" : {
-        "revision" : "65f9da9aad84adb7e2028eb32ca95164aa590e3b",
-        "version" : "600.0.0"
+        "revision" : "62eaad2822b865407b8cde56c36386c00800f7ec",
+        "version" : "602.0.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/yonaskolb/XcodeGen.git",
       "state" : {
-        "revision" : "82c6ab9bbd5b6075fc0887d897733fc0c4ffc9ab",
-        "version" : "2.42.0"
+        "revision" : "8d3d3476a69ae3e5d68e1adccc701c410c05eb36",
+        "version" : "2.45.4"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "447c159b0c5fb047a024fd8d942d4a76cf47dde0",
-        "version" : "8.16.0"
+        "revision" : "01bb77000bc8c23a09ea2058f4954612f03cb705",
+        "version" : "9.10.1"
       }
     },
     {

--- a/Tools/Package.swift
+++ b/Tools/Package.swift
@@ -6,8 +6,8 @@ let package = Package(
     name: "dev-tools",
     dependencies: [
         .package(name: "swiftui-atom-properties", path: ".."),
-        .package(url: "https://github.com/apple/swift-format.git", exact: "600.0.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", exact: "1.4.3"),
-        .package(url: "https://github.com/yonaskolb/XcodeGen.git", exact: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-format.git", exact: "602.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", exact: "1.5.0"),
+        .package(url: "https://github.com/yonaskolb/XcodeGen.git", exact: "2.45.4"),
     ]
 )


### PR DESCRIPTION
## Summary

- **CI runner**: `macos-14` → `macos-26` (all 4 jobs), update `DEVELOPER_DIR` to `Xcode_26.5.app`
- **Simulator**: `iPhone 16 Pro` → `iPhone 17 Pro`, `Apple Watch Ultra 2 (49mm)` → `Apple Watch Ultra 3 (49mm)` (updated to match preinstalled devices on macos-26)
- **Dev tools**: swift-format `600.0.0` → `602.0.0`, swift-docc-plugin `1.4.3` → `1.5.0`, XcodeGen `2.42.0` → `2.45.4`
- **Xcode project**: regenerated via `make proj` (objectVersion 54 → 77)
- **swift-format 602 lint fix**: add `// swift-format-ignore: AllPublicDeclarationsHaveDocumentation` before `ConditionalEffect` (newly flagged boilerplate protocol witnesses in 602)

## Notes

- The `@_inheritActorContext` warning in `AsyncPhase.swift:32` is intentionally deferred to a separate PR

## Test plan

- [ ] `validation` job (lint, format, make proj) passes
- [ ] `test` / `test_examples` / `benchmark` jobs pass on macos-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)