### PR TITLE
Replace deprecated @_inheritActorContext with isolation parameter

### DIFF
--- a/Sources/Atoms/AsyncPhase.swift
+++ b/Sources/Atoms/AsyncPhase.swift
@@ -30,7 +30,7 @@ public enum AsyncPhase<Success, Failure: Error> {
     /// - Parameters:
     ///   - isolation: The actor isolation of the calling context. The default value is
     ///     always used; do not pass a value for this parameter.
-    ///   - body: A async throwing closure to evaluate.
+    ///   - body: An async throwing closure to evaluate.
     public init(
         isolation: isolated (any Actor)? = #isolation,
         catching body: () async throws(Failure) -> Success

--- a/Sources/Atoms/AsyncPhase.swift
+++ b/Sources/Atoms/AsyncPhase.swift
@@ -27,9 +27,13 @@ public enum AsyncPhase<Success, Failure: Error> {
     /// Creates a new phase by evaluating a async throwing closure, capturing the
     /// returned value as a success, or thrown error as a failure.
     ///
-    /// - Parameter body: A async throwing closure to evaluate.
+    /// - Parameters:
+    ///   - isolation: The actor isolation of the calling context. The default value is
+    ///     always used; do not pass a value for this parameter.
+    ///   - body: A async throwing closure to evaluate.
     public init(
-        @_inheritActorContext catching body: () async throws(Failure) -> Success
+        isolation: isolated (any Actor)? = #isolation,
+        catching body: () async throws(Failure) -> Success
     ) async {
         do {
             let value = try await body()

--- a/Tests/AtomsTests/AsyncPhaseTests.swift
+++ b/Tests/AtomsTests/AsyncPhaseTests.swift
@@ -7,6 +7,11 @@ final class AsyncPhaseTests: XCTestCase {
         let value: Int
     }
 
+    @globalActor
+    actor TestActor {
+        static let shared = TestActor()
+    }
+
     let phases: [AsyncPhase<Int, TestError>] = [
         .suspending,
         .success(0),
@@ -83,6 +88,38 @@ final class AsyncPhaseTests: XCTestCase {
 
         XCTAssertEqual(success.value, 100)
         XCTAssertEqual(failure.error as? URLError, URLError(.badURL))
+    }
+
+    @MainActor
+    func testInitBodyInheritsMainActorIsolation() async {
+        // body should run on @MainActor when init is called from @MainActor context
+        let phase = await AsyncPhase<Void, Never> {
+            MainActor.assertIsolated()
+        }
+
+        XCTAssertNotNil(phase.value)
+    }
+
+    nonisolated func testInitBodyFromNonisolatedContext() async {
+        // body should run nonisolated when init is called from nonisolated context
+        var called = false
+        let phase = await AsyncPhase<Bool, Never> {
+            // No actor assertion — nonisolated context, body should simply run
+            called = true
+            return called
+        }
+
+        XCTAssertEqual(phase.value, true)
+    }
+
+    @TestActor
+    func testInitBodyInheritsCustomActorIsolation() async {
+        let phase = await AsyncPhase<Void, Never> {
+            // assertIsolated() precondition-fails if the current executor is not TestActor's
+            TestActor.shared.assertIsolated()
+        }
+
+        XCTAssertNotNil(phase.value)
     }
 
     func testMap() {

--- a/Tests/AtomsTests/AsyncPhaseTests.swift
+++ b/Tests/AtomsTests/AsyncPhaseTests.swift
@@ -102,11 +102,9 @@ final class AsyncPhaseTests: XCTestCase {
 
     nonisolated func testInitBodyFromNonisolatedContext() async {
         // body should run nonisolated when init is called from nonisolated context
-        var called = false
         let phase = await AsyncPhase<Bool, Never> {
-            // No actor assertion — nonisolated context, body should simply run
-            called = true
-            return called
+            XCTAssertNil(#isolation)
+            return true
         }
 
         XCTAssertEqual(phase.value, true)

--- a/Tests/AtomsTests/Utilities/Utilities.swift
+++ b/Tests/AtomsTests/Utilities/Utilities.swift
@@ -148,7 +148,7 @@ extension OverrideContainer {
 extension Task where Success == Never, Failure == Never {
     static func yield(
         isolation: isolated (any Actor)? = #isolation,
-        @_inheritActorContext until predicate: () -> Bool
+        until predicate: () -> Bool
     ) async {
         while !predicate() {
             await yield()


### PR DESCRIPTION
## Summary

- Replace `@_inheritActorContext` (deprecated in Swift 6.3.2 / Xcode 26.5) on `AsyncPhase.init(catching:)` with `isolation: isolated (any Actor)? = #isolation` (SE-0420)
- Remove `@_inheritActorContext` from a sync non-escaping closure `() -> Bool` in test utilities, where it was a no-op and now triggers a warning
- Add tests verifying that `body` inherits the actor isolation of the call site for `@MainActor`, nonisolated, and custom actor contexts

## Motivation

`isolation: isolated (any Actor)? = #isolation` captures the caller's actor isolation via `#isolation` at the call site and makes the init body run in that isolation. This preserves the semantics of `@_inheritActorContext` — `body` inherits the caller's actor context — while using the formally supported public API. It is also more correct for custom actor contexts, where `@_inheritActorContext` had a known limitation (compiler bug #82483).

## Test plan

- [ ] All tests pass (173 tests, 0 failures)
- [ ] `testInitBodyInheritsMainActorIsolation` — verifies `body` runs on `@MainActor`
- [ ] `testInitBodyFromNonisolatedContext` — verifies `body` runs nonisolated
- [ ] `testInitBodyInheritsCustomActorIsolation` — verifies `body` runs on a custom `@globalActor`
- [ ] `make lint` and `make format` pass with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)