### PR TITLE
Add TODO comments for SE-0371 isolated deinit migration

### DIFF
--- a/Sources/Atoms/Core/ScopeState.swift
+++ b/Sources/Atoms/Core/ScopeState.swift
@@ -5,8 +5,7 @@ internal final class ScopeState {
 
     nonisolated(unsafe) var unregister: (@MainActor () -> Void)?
 
-    // TODO: Use isolated synchronous deinit once it's available.
-    // 0371-isolated-synchronous-deinit
+    // TODO: Replace with `isolated deinit` (SE-0371) once swiftlang/swift#85663 is fixed.
     deinit {
         MainActor.performIsolated { [unregister] in
             unregister?()

--- a/Sources/Atoms/Core/SubscriberState.swift
+++ b/Sources/Atoms/Core/SubscriberState.swift
@@ -4,8 +4,7 @@ internal final class SubscriberState {
 
     nonisolated(unsafe) var unsubscribe: (@MainActor () -> Void)?
 
-    // TODO: Use isolated synchronous deinit once it's available.
-    // 0371-isolated-synchronous-deinit
+    // TODO: Replace with `isolated deinit` (SE-0371) once swiftlang/swift#85663 is fixed.
     deinit {
         MainActor.performIsolated { [unsubscribe] in
             unsubscribe?()

--- a/Sources/Atoms/Suspense.swift
+++ b/Sources/Atoms/Suspense.swift
@@ -206,6 +206,7 @@ private extension Suspense {
             }
         }
 
+        // TODO: Replace with `isolated deinit` (SE-0371) once swiftlang/swift#85663 is fixed.
         deinit {
             suspensionTask?.cancel()
         }


### PR DESCRIPTION
## Summary

- Replaces the generic `// TODO: Use isolated synchronous deinit once it's available.` comments in `SubscriberState` and `ScopeState` with a concrete reference to the blocking Swift bug
- Adds the same TODO to `Suspense.State.deinit`, which is also a candidate for `isolated deinit`

## Background

SE-0371 (`isolated deinit`) was investigated for adoption. All three `@MainActor` classes benefit from it:

- `SubscriberState` — calls `unsubscribe?()` in deinit
- `ScopeState` — calls `unregister?()` in deinit
- `Suspense.State` — cancels `suspensionTask` in deinit

However, Swift 6.2.1's back-deploy shim (`swift_task_deinitOnExecutorMainActorBackDeploy`) crashes with a malloc error in `swift::TaskLocal::StopLookupScope::~StopLookupScope()` when `isolated deinit` is triggered from a synchronous `@MainActor` context. This affects both unit tests and production code — making adoption unsafe until the upstream bug is resolved.

Tracked upstream: https://github.com/swiftlang/swift/issues/85663

🤖 Generated with [Claude Code](https://claude.com/claude-code)