### PR TITLE
Migrate test suite from XCTest to Swift Testing

### DIFF
--- a/Examples/Packages/CrossPlatform/Tests/ExampleCounterTests/ExampleCounterTests.swift
+++ b/Examples/Packages/CrossPlatform/Tests/ExampleCounterTests/ExampleCounterTests.swift
@@ -1,18 +1,19 @@
 import Atoms
-import XCTest
+import Testing
 
 @testable import ExampleCounter
 
-final class ExampleCounterTests: XCTestCase {
+struct ExampleCounterTests {
     @MainActor
+    @Test
     func testCounterAtom() {
         let context = AtomTestContext()
         let atom = CounterAtom()
 
-        XCTAssertEqual(context.watch(atom), 0)
+        #expect(context.watch(atom) == 0)
 
         context[atom] = 1
 
-        XCTAssertEqual(context.watch(atom), 1)
+        #expect(context.watch(atom) == 1)
     }
 }

--- a/Examples/Packages/CrossPlatform/Tests/ExampleTodoTests/ExampleTodoTests.swift
+++ b/Examples/Packages/CrossPlatform/Tests/ExampleTodoTests/ExampleTodoTests.swift
@@ -1,9 +1,10 @@
 import Atoms
-import XCTest
+import Foundation
+import Testing
 
 @testable import ExampleTodo
 
-final class ExampleTodoTests: XCTestCase {
+struct ExampleTodoTests {
     let completedTodos = [
         Todo(
             id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
@@ -30,6 +31,7 @@ final class ExampleTodoTests: XCTestCase {
     }
 
     @MainActor
+    @Test
     func testFilteredTodosAtom() {
         let context = AtomTestContext()
         let atom = FilteredTodosAtom()
@@ -38,22 +40,23 @@ final class ExampleTodoTests: XCTestCase {
 
         context[TodosAtom()] = []
 
-        XCTAssertEqual(context.watch(atom), [])
+        #expect(context.watch(atom) == [])
 
         context[TodosAtom()] = allTodos
 
-        XCTAssertEqual(context.watch(atom), allTodos)
+        #expect(context.watch(atom) == allTodos)
 
         context[FilterAtom()] = .completed
 
-        XCTAssertEqual(context.watch(atom), completedTodos)
+        #expect(context.watch(atom) == completedTodos)
 
         context[FilterAtom()] = .uncompleted
 
-        XCTAssertEqual(context.watch(atom), uncompleteTodos)
+        #expect(context.watch(atom) == uncompleteTodos)
     }
 
     @MainActor
+    @Test
     func testStatsAtom() {
         let context = AtomTestContext()
         let atom = StatsAtom()
@@ -62,50 +65,50 @@ final class ExampleTodoTests: XCTestCase {
 
         context[TodosAtom()] = []
 
-        XCTAssertEqual(
-            context.watch(atom),
-            Stats(
-                total: 0,
-                totalCompleted: 0,
-                totalUncompleted: 0,
-                percentCompleted: 0
-            )
+        #expect(
+            context.watch(atom)
+                == Stats(
+                    total: 0,
+                    totalCompleted: 0,
+                    totalUncompleted: 0,
+                    percentCompleted: 0
+                )
         )
 
         context[TodosAtom()] = completedTodos
 
-        XCTAssertEqual(
-            context.watch(atom),
-            Stats(
-                total: 1,
-                totalCompleted: 1,
-                totalUncompleted: 0,
-                percentCompleted: 1
-            )
+        #expect(
+            context.watch(atom)
+                == Stats(
+                    total: 1,
+                    totalCompleted: 1,
+                    totalUncompleted: 0,
+                    percentCompleted: 1
+                )
         )
 
         context[TodosAtom()] = uncompleteTodos
 
-        XCTAssertEqual(
-            context.watch(atom),
-            Stats(
-                total: 2,
-                totalCompleted: 0,
-                totalUncompleted: 2,
-                percentCompleted: 0
-            )
+        #expect(
+            context.watch(atom)
+                == Stats(
+                    total: 2,
+                    totalCompleted: 0,
+                    totalUncompleted: 2,
+                    percentCompleted: 0
+                )
         )
 
         context[TodosAtom()] = allTodos
 
-        XCTAssertEqual(
-            context.watch(atom),
-            Stats(
-                total: 3,
-                totalCompleted: 1,
-                totalUncompleted: 2,
-                percentCompleted: 1 / 3
-            )
+        #expect(
+            context.watch(atom)
+                == Stats(
+                    total: 3,
+                    totalCompleted: 1,
+                    totalUncompleted: 2,
+                    percentCompleted: 1 / 3
+                )
         )
     }
 }

--- a/Examples/Packages/iOS/Tests/ExampleMapTests/ExampleMapTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMapTests/ExampleMapTests.swift
@@ -1,11 +1,12 @@
 import Atoms
 import CoreLocation
-import XCTest
+import Testing
 
 @testable import ExampleMap
 
-final class ExampleMapTests: XCTestCase {
+struct ExampleMapTests {
     @MainActor
+    @Test
     func testLocationObserverAtom() {
         let atom = LocationObserverAtom()
         let context = AtomTestContext()
@@ -17,15 +18,16 @@ final class ExampleMapTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertNotNil(manager.delegate)
-        XCTAssertTrue(manager.isUpdatingLocation)
+        #expect(manager.delegate != nil)
+        #expect(manager.isUpdatingLocation)
 
         context.unwatch(atom)
 
-        XCTAssertFalse(manager.isUpdatingLocation)
+        #expect(!manager.isUpdatingLocation)
     }
 
     @MainActor
+    @Test
     func testCoordinateAtom() {
         let atom = CoordinateAtom()
         let context = AtomTestContext()
@@ -37,11 +39,12 @@ final class ExampleMapTests: XCTestCase {
 
         manager.location = CLLocation(latitude: 1, longitude: 2)
 
-        XCTAssertEqual(context.watch(atom)?.latitude, 1)
-        XCTAssertEqual(context.watch(atom)?.longitude, 2)
+        #expect(context.watch(atom)?.latitude == 1)
+        #expect(context.watch(atom)?.longitude == 2)
     }
 
     @MainActor
+    @Test
     func testAuthorizationStatusAtom() async {
         let atom = AuthorizationStatusAtom()
         let manager = MockLocationManager()
@@ -54,7 +57,7 @@ final class ExampleMapTests: XCTestCase {
 
         manager.authorizationStatus = .authorizedWhenInUse
 
-        XCTAssertEqual(context.watch(atom), .authorizedWhenInUse)
+        #expect(context.watch(atom) == .authorizedWhenInUse)
 
         manager.authorizationStatus = .authorizedAlways
 
@@ -64,12 +67,12 @@ final class ExampleMapTests: XCTestCase {
 
         await context.waitForUpdate()
 
-        XCTAssertEqual(context.watch(atom), .authorizedAlways)
+        #expect(context.watch(atom) == .authorizedAlways)
 
         observer.objectWillChange.send()
         let didUpdate = await context.waitForUpdate(timeout: 0.1)
 
         // Should not update if authorizationStatus is not changed.
-        XCTAssertFalse(didUpdate)
+        #expect(!didUpdate)
     }
 }

--- a/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleMovieDBTests/ExampleMovieDBTests.swift
@@ -1,10 +1,12 @@
 import Atoms
-import XCTest
+import Testing
+import UIKit
 
 @testable import ExampleMovieDB
 
-final class ExampleMovieDBTests: XCTestCase {
+struct ExampleMovieDBTests {
     @MainActor
+    @Test
     func testImageAtom() async {
         let apiClient = MockAPIClient()
         let atom = ImageAtom(path: "", size: .original)
@@ -17,7 +19,7 @@ final class ExampleMovieDBTests: XCTestCase {
 
         let successPhase = await AsyncPhase(context.watch(atom).result)
 
-        XCTAssertEqual(successPhase.value, image)
+        #expect(successPhase.value == image)
 
         context.reset(atom)
 
@@ -26,10 +28,11 @@ final class ExampleMovieDBTests: XCTestCase {
 
         let failurePhase = await AsyncPhase(context.watch(atom).result)
 
-        XCTAssertEqual(failurePhase.error as? URLError, error)
+        #expect(failurePhase.error as? URLError == error)
     }
 
     @MainActor
+    @Test
     func testMovieLoader() async {
         let apiClient = MockAPIClient()
         let atom = MovieLoaderAtom()
@@ -47,52 +50,55 @@ final class ExampleMovieDBTests: XCTestCase {
 
             await context.watch(atom).refresh()
 
-            XCTAssertEqual(context.watch(atom).pages.value, [expected])
+            #expect(context.watch(atom).pages.value == [expected])
 
             await context.watch(atom).loadNext()
 
-            XCTAssertEqual(context.watch(atom).pages.value, [expected, expected])
+            #expect(context.watch(atom).pages.value == [expected, expected])
 
             context.reset(atom)
             apiClient.filteredMovieResponse = .failure(error)
 
             await context.watch(atom).refresh()
 
-            XCTAssertEqual(context.watch(atom).pages.error as? URLError, error)
+            #expect(context.watch(atom).pages.error as? URLError == error)
         }
     }
 
     @MainActor
+    @Test
     func testMyListAtom() {
         let atom = MyListAtom()
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom).movies, [])
+        #expect(context.watch(atom).movies == [])
 
         context.watch(atom).insert(movie: .stub(id: 0))
 
-        XCTAssertEqual(context.watch(atom).movies, [.stub(id: 0)])
+        #expect(context.watch(atom).movies == [.stub(id: 0)])
 
         context.watch(atom).insert(movie: .stub(id: 1))
 
-        XCTAssertEqual(context.watch(atom).movies, [.stub(id: 0), .stub(id: 1)])
+        #expect(context.watch(atom).movies == [.stub(id: 0), .stub(id: 1)])
 
         context.watch(atom).insert(movie: .stub(id: 0))
 
-        XCTAssertEqual(context.watch(atom).movies, [.stub(id: 1)])
+        #expect(context.watch(atom).movies == [.stub(id: 1)])
     }
 
     @MainActor
+    @Test
     func testIsInMyListAtom() {
         let context = AtomTestContext()
 
         context.watch(MyListAtom()).insert(movie: .stub(id: 0))
 
-        XCTAssertTrue(context.watch(IsInMyListAtom(movie: .stub(id: 0))))
-        XCTAssertFalse(context.watch(IsInMyListAtom(movie: .stub(id: 1))))
+        #expect(context.watch(IsInMyListAtom(movie: .stub(id: 0))))
+        #expect(!context.watch(IsInMyListAtom(movie: .stub(id: 1))))
     }
 
     @MainActor
+    @Test
     func testCastsAtom() async {
         let apiClient = MockAPIClient()
         let atom = CastsAtom(movieID: 0)
@@ -107,17 +113,18 @@ final class ExampleMovieDBTests: XCTestCase {
 
         let successPhase = await AsyncPhase(context.watch(atom).result)
 
-        XCTAssertEqual(successPhase.value, expected)
+        #expect(successPhase.value == expected)
 
         apiClient.creditsResponse = .failure(error)
         context.reset(atom)
 
         let failurePhase = await AsyncPhase(context.watch(atom).result)
 
-        XCTAssertEqual(failurePhase.error as? URLError, error)
+        #expect(failurePhase.error as? URLError == error)
     }
 
     @MainActor
+    @Test
     func testSearchMoviesAtom() async {
         let apiClient = MockAPIClient()
         let atom = SearchMoviesAtom()
@@ -132,19 +139,19 @@ final class ExampleMovieDBTests: XCTestCase {
 
         let empty = await context.refresh(atom)
 
-        XCTAssertEqual(empty.value, [])
+        #expect(empty.value == [])
 
         context[SearchQueryAtom()] = "query"
 
         let success = await context.refresh(atom)
 
-        XCTAssertEqual(success.value, expected.results)
+        #expect(success.value == expected.results)
 
         apiClient.searchMoviesResponse = .failure(expectedError)
 
         let failure = await context.refresh(atom)
 
-        XCTAssertEqual(failure.error as? URLError, expectedError)
+        #expect(failure.error as? URLError == expectedError)
     }
 }
 

--- a/Examples/Packages/iOS/Tests/ExampleTimeTravelTests/ExampleTimeTravelTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleTimeTravelTests/ExampleTimeTravelTests.swift
@@ -1,19 +1,20 @@
 import Atoms
-import XCTest
+import Testing
 
 @testable import ExampleTimeTravel
 
-final class ExampleTimeTravelTests: XCTestCase {
+struct ExampleTimeTravelTests {
     @MainActor
+    @Test
     func testTextAtom() {
         let context = AtomTestContext()
         let atom = InputStateAtom()
 
-        XCTAssertEqual(context.watch(atom), InputState())
+        #expect(context.watch(atom) == InputState())
 
         context[atom].text = "modified"
         context[atom].latestInput = 1
 
-        XCTAssertEqual(context.watch(atom), InputState(text: "modified", latestInput: 1))
+        #expect(context.watch(atom) == InputState(text: "modified", latestInput: 1))
     }
 }

--- a/Examples/Packages/iOS/Tests/ExampleVoiceMemoTests/ExampleVoiceMemoTests.swift
+++ b/Examples/Packages/iOS/Tests/ExampleVoiceMemoTests/ExampleVoiceMemoTests.swift
@@ -1,24 +1,27 @@
 import AVFAudio
 import Atoms
 import Combine
-import XCTest
+import Foundation
+import Testing
 
 @testable import ExampleVoiceMemo
 
-final class ExampleVoiceMemoTests: XCTestCase {
+struct ExampleVoiceMemoTests {
     @MainActor
+    @Test
     func testIsRecordingAtom() {
         let context = AtomTestContext()
         let atom = IsRecordingAtom()
 
         context.override(RecordingDataAtom()) { _ in nil }
-        XCTAssertFalse(context.read(atom))
+        #expect(!context.read(atom))
 
         context.override(RecordingDataAtom()) { _ in .stub() }
-        XCTAssertTrue(context.read(atom))
+        #expect(context.read(atom))
     }
 
     @MainActor
+    @Test
     func testRecordingDataAtom() {
         let context = AtomTestContext()
         let atom = RecordingDataAtom()
@@ -29,34 +32,35 @@ final class ExampleVoiceMemoTests: XCTestCase {
         context.override(AudioSessionAtom()) { _ in audioSession }
         context.override(AudioRecorderAtom()) { _ in audioRecorder }
 
-        XCTAssertNil(context.watch(atom))
-        XCTAssertTrue(context.watch(VoiceMemosAtom()).isEmpty)
-        XCTAssertFalse(context.watch(IsRecordingFailedAtom()))
+        #expect(context.watch(atom) == nil)
+        #expect(context.watch(VoiceMemosAtom()).isEmpty)
+        #expect(!context.watch(IsRecordingFailedAtom()))
 
         context[atom] = recordingData
 
-        XCTAssertEqual(audioSession.currentCategory, .playAndRecord)
-        XCTAssertEqual(audioSession.currentMode, .default)
-        XCTAssertEqual(audioSession.currentOptions, .defaultToSpeaker)
-        XCTAssertTrue(audioSession.isActive)
-        XCTAssertTrue(audioRecorder.isRecording)
+        #expect(audioSession.currentCategory == .playAndRecord)
+        #expect(audioSession.currentMode == .default)
+        #expect(audioSession.currentOptions == .defaultToSpeaker)
+        #expect(audioSession.isActive)
+        #expect(audioRecorder.isRecording)
 
         context[atom] = nil
 
-        XCTAssertEqual(
-            context.watch(VoiceMemosAtom()),
-            [VoiceMemo(url: recordingData.url, date: recordingData.date, duration: audioRecorder.currentTime)]
+        #expect(
+            context.watch(VoiceMemosAtom())
+                == [VoiceMemo(url: recordingData.url, date: recordingData.date, duration: audioRecorder.currentTime)]
         )
-        XCTAssertFalse(audioSession.isActive)
-        XCTAssertFalse(audioRecorder.isRecording)
+        #expect(!audioSession.isActive)
+        #expect(!audioRecorder.isRecording)
 
         audioRecorder.recordingError = URLError(.unknown)
         context[atom] = recordingData
 
-        XCTAssertTrue(context.watch(IsRecordingFailedAtom()))
+        #expect(context.watch(IsRecordingFailedAtom()))
     }
 
     @MainActor
+    @Test
     func testRecordingElapsedTimeAtom() async {
         let context = AtomTestContext()
         let atom = RecordingElapsedTimeAtom()
@@ -65,23 +69,24 @@ final class ExampleVoiceMemoTests: XCTestCase {
         context.override(ValueGeneratorAtom()) { _ in .stub() }
         context.override(TimerAtom.self) { _ in Just(10).eraseToAnyPublisher() }
 
-        XCTAssertEqual(context.watch(atom), .suspending)
+        #expect(context.watch(atom) == .suspending)
 
         await context.waitForUpdate()
 
-        XCTAssertEqual(context.watch(atom), .success(.zero))
+        #expect(context.watch(atom) == .success(.zero))
 
         context.override(IsRecordingAtom()) { _ in true }
         context.reset(IsRecordingAtom())
 
-        XCTAssertEqual(context.watch(atom), .suspending)
+        #expect(context.watch(atom) == .suspending)
 
         await context.waitForUpdate()
 
-        XCTAssertEqual(context.watch(atom), .success(10))
+        #expect(context.watch(atom) == .success(10))
     }
 
     @MainActor
+    @Test
     func testToggleRecording() {
         let context = AtomTestContext()
         let actions = VoiceMemoActions(context: context)
@@ -95,41 +100,42 @@ final class ExampleVoiceMemoTests: XCTestCase {
 
         audioSession.recordPermission = .undetermined
 
-        XCTAssertEqual(context.watch(AudioRecordPermissionAtom()), .undetermined)
-        XCTAssertFalse(context.watch(IsRecordingFailedAtom()))
-        XCTAssertNil(context.watch(RecordingDataAtom()))
+        #expect(context.watch(AudioRecordPermissionAtom()) == .undetermined)
+        #expect(!context.watch(IsRecordingFailedAtom()))
+        #expect(context.watch(RecordingDataAtom()) == nil)
 
         actions.toggleRecording()
         audioSession.recordPermission = .denied
         audioSession.requestRecordPermissionResponse!(true)
 
-        XCTAssertEqual(context.watch(AudioRecordPermissionAtom()), .denied)
+        #expect(context.watch(AudioRecordPermissionAtom()) == .denied)
 
         actions.toggleRecording()
 
-        XCTAssertTrue(context.watch(IsRecordingFailedAtom()))
+        #expect(context.watch(IsRecordingFailedAtom()))
 
         audioSession.recordPermission = .granted
         context.reset(AudioRecordPermissionAtom())
         actions.toggleRecording()
 
-        XCTAssertEqual(
-            context.watch(RecordingDataAtom()),
-            RecordingData(
-                url: URL(fileURLWithPath: generator.temporaryDirectory())
-                    .appendingPathComponent(generator.uuid().uuidString)
-                    .appendingPathExtension("m4a"),
-                date: generator.date()
-            )
+        #expect(
+            context.watch(RecordingDataAtom())
+                == RecordingData(
+                    url: URL(fileURLWithPath: generator.temporaryDirectory())
+                        .appendingPathComponent(generator.uuid().uuidString)
+                        .appendingPathExtension("m4a"),
+                    date: generator.date()
+                )
         )
 
         context.override(IsRecordingAtom()) { _ in true }
         actions.toggleRecording()
 
-        XCTAssertNil(context.watch(RecordingDataAtom()))
+        #expect(context.watch(RecordingDataAtom()) == nil)
     }
 
     @MainActor
+    @Test
     func testDelete() {
         let context = AtomTestContext()
         let actions = VoiceMemoActions(context: context)
@@ -138,16 +144,17 @@ final class ExampleVoiceMemoTests: XCTestCase {
         context.override(VoiceMemosAtom()) { _ in [voiceMemo] }
         context.override(IsPlayingAtom.self) { _ in true }
 
-        XCTAssertEqual(context.watch(VoiceMemosAtom()), [voiceMemo])
-        XCTAssertTrue(context.watch(IsPlayingAtom(voiceMemo: voiceMemo)))
+        #expect(context.watch(VoiceMemosAtom()) == [voiceMemo])
+        #expect(context.watch(IsPlayingAtom(voiceMemo: voiceMemo)))
 
         actions.delete(at: [0])
 
-        XCTAssertTrue(context.watch(VoiceMemosAtom()).isEmpty)
-        XCTAssertFalse(context.watch(IsPlayingAtom(voiceMemo: voiceMemo)))
+        #expect(context.watch(VoiceMemosAtom()).isEmpty)
+        #expect(!context.watch(IsPlayingAtom(voiceMemo: voiceMemo)))
     }
 
     @MainActor
+    @Test
     func testIsPlayingAtom() {
         let context = AtomTestContext()
         let audioPlayer = MockAudioPlayer()
@@ -156,24 +163,25 @@ final class ExampleVoiceMemoTests: XCTestCase {
 
         context.override(AudioPlayerAtom.self) { _ in audioPlayer }
 
-        XCTAssertFalse(context.watch(atom))
-        XCTAssertFalse(context.watch(IsPlaybackFailedAtom()))
+        #expect(!context.watch(atom))
+        #expect(!context.watch(IsPlaybackFailedAtom()))
 
         context[atom] = true
 
-        XCTAssertTrue(audioPlayer.isPlaying)
+        #expect(audioPlayer.isPlaying)
 
         context[atom] = false
 
-        XCTAssertFalse(audioPlayer.isPlaying)
+        #expect(!audioPlayer.isPlaying)
 
         audioPlayer.playingError = URLError(.unknown)
         context[atom] = true
 
-        XCTAssertTrue(context.watch(IsPlaybackFailedAtom()))
+        #expect(context.watch(IsPlaybackFailedAtom()))
     }
 
     @MainActor
+    @Test
     func testPlayingElapsedTimeAtom() async {
         let context = AtomTestContext()
         let voiceMemo = VoiceMemo.stub()
@@ -183,20 +191,20 @@ final class ExampleVoiceMemoTests: XCTestCase {
         context.override(ValueGeneratorAtom()) { _ in .stub() }
         context.override(TimerAtom.self) { _ in Just(10).eraseToAnyPublisher() }
 
-        XCTAssertEqual(context.watch(atom), .suspending)
+        #expect(context.watch(atom) == .suspending)
 
         await context.waitForUpdate()
 
-        XCTAssertEqual(context.watch(atom), .success(.zero))
+        #expect(context.watch(atom) == .success(.zero))
 
         context.override(IsPlayingAtom.self) { _ in true }
         context.reset(IsPlayingAtom(voiceMemo: voiceMemo))
 
-        XCTAssertEqual(context.watch(atom), .suspending)
+        #expect(context.watch(atom) == .suspending)
 
         await context.waitForUpdate()
 
-        XCTAssertEqual(context.watch(atom), .success(10))
+        #expect(context.watch(atom) == .success(10))
     }
 }
 

--- a/Tests/AtomsTests/AsyncPhaseTests.swift
+++ b/Tests/AtomsTests/AsyncPhaseTests.swift
@@ -1,8 +1,9 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Atoms
 
-final class AsyncPhaseTests: XCTestCase {
+struct AsyncPhaseTests {
     struct TestError: Error, Equatable {
         let value: Int
     }
@@ -18,6 +19,7 @@ final class AsyncPhaseTests: XCTestCase {
         .failure(TestError(value: 0)),
     ]
 
+    @Test
     func testIsSuspending() {
         let expected = [
             true,
@@ -25,9 +27,10 @@ final class AsyncPhaseTests: XCTestCase {
             false,
         ]
 
-        XCTAssertEqual(phases.map(\.isSuspending), expected)
+        #expect(phases.map(\.isSuspending) == expected)
     }
 
+    @Test
     func testIsSuccess() {
         let expected = [
             false,
@@ -35,9 +38,10 @@ final class AsyncPhaseTests: XCTestCase {
             false,
         ]
 
-        XCTAssertEqual(phases.map(\.isSuccess), expected)
+        #expect(phases.map(\.isSuccess) == expected)
     }
 
+    @Test
     func testIsFailure() {
         let expected = [
             false,
@@ -45,9 +49,10 @@ final class AsyncPhaseTests: XCTestCase {
             true,
         ]
 
-        XCTAssertEqual(phases.map(\.isFailure), expected)
+        #expect(phases.map(\.isFailure) == expected)
     }
 
+    @Test
     func testValue() {
         let expected = [
             nil,
@@ -55,9 +60,10 @@ final class AsyncPhaseTests: XCTestCase {
             nil,
         ]
 
-        XCTAssertEqual(phases.map(\.value), expected)
+        #expect(phases.map(\.value) == expected)
     }
 
+    @Test
     func testError() {
         let expected = [
             nil,
@@ -65,9 +71,10 @@ final class AsyncPhaseTests: XCTestCase {
             TestError(value: 0),
         ]
 
-        XCTAssertEqual(phases.map(\.error), expected)
+        #expect(phases.map(\.error) == expected)
     }
 
+    @Test
     func testInitWithResult() {
         let results: [Result<Int, TestError>] = [
             .success(0),
@@ -79,158 +86,164 @@ final class AsyncPhaseTests: XCTestCase {
             .failure(TestError(value: 0)),
         ]
 
-        XCTAssertEqual(results.map(AsyncPhase.init), expected)
+        #expect(results.map(AsyncPhase.init) == expected)
     }
 
+    @Test
     func testAsyncInit() async {
         let success = await AsyncPhase { 100 }
         let failure = await AsyncPhase { throw URLError(.badURL) }
 
-        XCTAssertEqual(success.value, 100)
-        XCTAssertEqual(failure.error as? URLError, URLError(.badURL))
+        #expect(success.value == 100)
+        #expect(failure.error as? URLError == URLError(.badURL))
     }
 
     @MainActor
+    @Test
     func testInitBodyInheritsMainActorIsolation() async {
         // body should run on @MainActor when init is called from @MainActor context
         let phase = await AsyncPhase<Void, Never> {
             MainActor.assertIsolated()
         }
 
-        XCTAssertNotNil(phase.value)
+        #expect(phase.value != nil)
     }
 
+    @Test
     nonisolated func testInitBodyFromNonisolatedContext() async {
         // body should run nonisolated when init is called from nonisolated context
         let phase = await AsyncPhase<Bool, Never> {
-            XCTAssertNil(#isolation)
+            #expect(#isolation == nil)
             return true
         }
 
-        XCTAssertEqual(phase.value, true)
+        #expect(phase.value == true)
     }
 
     @TestActor
+    @Test
     func testInitBodyInheritsCustomActorIsolation() async {
         let phase = await AsyncPhase<Void, Never> {
             // assertIsolated() precondition-fails if the current executor is not TestActor's
             TestActor.shared.assertIsolated()
         }
 
-        XCTAssertNotNil(phase.value)
+        #expect(phase.value != nil)
     }
 
+    @Test
     func testMap() {
         let phase = AsyncPhase<Int, any Error>.success(0)
             .map(String.init)
 
-        XCTAssertEqual(phase.value, "0")
+        #expect(phase.value == "0")
     }
 
+    @Test
     func testMapError() {
         let phase = AsyncPhase<Int, TestError>.failure(TestError(value: 0))
             .mapError { _ in URLError(.badURL) }
 
-        XCTAssertEqual(phase.error, URLError(.badURL))
+        #expect(phase.error == URLError(.badURL))
     }
 
-    @MainActor
-    func testFlatMap() {
-        XCTContext.runActivity(named: "To suspending") { _ in
-            let transformed = phases.map { phase in
-                phase.flatMap { _ -> AsyncPhase<Int, _> in
-                    .suspending
-                }
+    @Test
+    func testFlatMapToSuspending() {
+        let transformed = phases.map { phase in
+            phase.flatMap { _ -> AsyncPhase<Int, _> in
+                .suspending
             }
-
-            let expected: [AsyncPhase<Int, TestError>] = [
-                .suspending,
-                .suspending,
-                .failure(TestError(value: 0)),
-            ]
-
-            XCTAssertEqual(transformed, expected)
         }
 
-        XCTContext.runActivity(named: "To success") { _ in
-            let transformed = phases.map { phase in
-                phase.flatMap { .success(String($0)) }
-            }
+        let expected: [AsyncPhase<Int, TestError>] = [
+            .suspending,
+            .suspending,
+            .failure(TestError(value: 0)),
+        ]
 
-            let expected: [AsyncPhase<String, TestError>] = [
-                .suspending,
-                .success("0"),
-                .failure(TestError(value: 0)),
-            ]
-
-            XCTAssertEqual(transformed, expected)
-        }
-
-        XCTContext.runActivity(named: "To failure") { _ in
-            let transformed = phases.map { phase in
-                phase.flatMap { _ -> AsyncPhase<Int, _> in
-                    .failure(TestError(value: 1))
-                }
-            }
-
-            let expected: [AsyncPhase<Int, TestError>] = [
-                .suspending,
-                .failure(TestError(value: 1)),
-                .failure(TestError(value: 0)),
-            ]
-
-            XCTAssertEqual(transformed, expected)
-        }
+        #expect(transformed == expected)
     }
 
-    @MainActor
-    func testFlatMapError() {
-        XCTContext.runActivity(named: "To suspending") { _ in
-            let transformed = phases.map { phase in
-                phase.flatMapError { _ -> AsyncPhase<_, TestError> in
-                    .suspending
-                }
-            }
-
-            let expected: [AsyncPhase<Int, TestError>] = [
-                .suspending,
-                .success(0),
-                .suspending,
-            ]
-
-            XCTAssertEqual(transformed, expected)
+    @Test
+    func testFlatMapToSuccess() {
+        let transformed = phases.map { phase in
+            phase.flatMap { .success(String($0)) }
         }
 
-        XCTContext.runActivity(named: "To success") { _ in
-            let transformed = phases.map { phase in
-                phase.flatMapError { _ -> AsyncPhase<_, TestError> in
-                    .success(1)
-                }
+        let expected: [AsyncPhase<String, TestError>] = [
+            .suspending,
+            .success("0"),
+            .failure(TestError(value: 0)),
+        ]
+
+        #expect(transformed == expected)
+    }
+
+    @Test
+    func testFlatMapToFailure() {
+        let transformed = phases.map { phase in
+            phase.flatMap { _ -> AsyncPhase<Int, _> in
+                .failure(TestError(value: 1))
             }
-
-            let expected: [AsyncPhase<Int, TestError>] = [
-                .suspending,
-                .success(0),
-                .success(1),
-            ]
-
-            XCTAssertEqual(transformed, expected)
         }
 
-        XCTContext.runActivity(named: "To failure") { _ in
-            let transformed = phases.map { phase in
-                phase.flatMapError { _ -> AsyncPhase<_, URLError> in
-                    .failure(URLError(.badURL))
-                }
+        let expected: [AsyncPhase<Int, TestError>] = [
+            .suspending,
+            .failure(TestError(value: 1)),
+            .failure(TestError(value: 0)),
+        ]
+
+        #expect(transformed == expected)
+    }
+
+    @Test
+    func testFlatMapErrorToSuspending() {
+        let transformed = phases.map { phase in
+            phase.flatMapError { _ -> AsyncPhase<_, TestError> in
+                .suspending
             }
-
-            let expected: [AsyncPhase<Int, URLError>] = [
-                .suspending,
-                .success(0),
-                .failure(URLError(.badURL)),
-            ]
-
-            XCTAssertEqual(transformed, expected)
         }
+
+        let expected: [AsyncPhase<Int, TestError>] = [
+            .suspending,
+            .success(0),
+            .suspending,
+        ]
+
+        #expect(transformed == expected)
+    }
+
+    @Test
+    func testFlatMapErrorToSuccess() {
+        let transformed = phases.map { phase in
+            phase.flatMapError { _ -> AsyncPhase<_, TestError> in
+                .success(1)
+            }
+        }
+
+        let expected: [AsyncPhase<Int, TestError>] = [
+            .suspending,
+            .success(0),
+            .success(1),
+        ]
+
+        #expect(transformed == expected)
+    }
+
+    @Test
+    func testFlatMapErrorToFailure() {
+        let transformed = phases.map { phase in
+            phase.flatMapError { _ -> AsyncPhase<_, URLError> in
+                .failure(URLError(.badURL))
+            }
+        }
+
+        let expected: [AsyncPhase<Int, URLError>] = [
+            .suspending,
+            .success(0),
+            .failure(URLError(.badURL)),
+        ]
+
+        #expect(transformed == expected)
     }
 }

--- a/Tests/AtomsTests/Atom/AsyncPhaseAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncPhaseAtomTests.swift
@@ -1,9 +1,11 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Atoms
 
-final class AsyncPhaseAtomTests: XCTestCase {
+struct AsyncPhaseAtomTests {
     @MainActor
+    @Test
     func test() async {
         var result = Result<Int, URLError>.success(0)
         let atom = TestAsyncPhaseAtom { result }
@@ -12,14 +14,14 @@ final class AsyncPhaseAtomTests: XCTestCase {
         do {
             // Initial value
             let phase = context.watch(atom)
-            XCTAssertTrue(phase.isSuspending)
+            #expect(phase.isSuspending)
         }
 
         do {
             // Value
             await context.wait(for: atom, until: \.isSuccess)
             let phase = context.watch(atom)
-            XCTAssertEqual(phase.value, 0)
+            #expect(phase.value == 0)
         }
 
         do {
@@ -31,7 +33,7 @@ final class AsyncPhaseAtomTests: XCTestCase {
 
             let phase = context.watch(atom)
 
-            XCTAssertEqual(phase.error, URLError(.badURL))
+            #expect(phase.error == URLError(.badURL))
         }
 
         do {
@@ -40,11 +42,12 @@ final class AsyncPhaseAtomTests: XCTestCase {
             context.override(atom) { _ in .success(200) }
 
             let phase = context.watch(atom)
-            XCTAssertEqual(phase.value, 200)
+            #expect(phase.value == 200)
         }
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let atom = TestAsyncPhaseAtom<Int, any Error> { .success(0) }
         let context = AtomTestContext()
@@ -56,8 +59,8 @@ final class AsyncPhaseAtomTests: XCTestCase {
             context.watch(atom)
 
             let phase0 = await context.refresh(atom)
-            XCTAssertEqual(phase0.value, 0)
-            XCTAssertEqual(updateCount, 1)
+            #expect(phase0.value == 0)
+            #expect(updateCount == 1)
         }
 
         do {
@@ -69,7 +72,7 @@ final class AsyncPhaseAtomTests: XCTestCase {
             refreshTask.cancel()
 
             let phase = await refreshTask.value
-            XCTAssertTrue(phase.isSuspending)
+            #expect(phase.isSuspending)
         }
 
         do {
@@ -77,11 +80,12 @@ final class AsyncPhaseAtomTests: XCTestCase {
             context.override(atom) { _ in .success(300) }
 
             let phase = await context.refresh(atom)
-            XCTAssertEqual(phase.value, 300)
+            #expect(phase.value == 300)
         }
     }
 
     @MainActor
+    @Test
     func testReleaseDependencies() async {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -103,22 +107,23 @@ final class AsyncPhaseAtomTests: XCTestCase {
         await context.wait(for: atom, until: \.isSuccess)
 
         let phase0 = context.watch(atom)
-        XCTAssertEqual(phase0.value, 0)
+        #expect(phase0.value == 0)
 
         context[DependencyAtom()] = 100
         await context.wait(for: atom, until: \.isSuccess)
 
         let phase1 = context.watch(atom)
         // Dependencies should not be released until task value is returned.
-        XCTAssertEqual(phase1.value, 100)
+        #expect(phase1.value == 100)
 
         context.unwatch(atom)
 
         let dependencyValue = context.read(DependencyAtom())
-        XCTAssertEqual(dependencyValue, 0)
+        #expect(dependencyValue == 0)
     }
 
     @MainActor
+    @Test
     func testEffect() {
         let effect = TestEffect()
         let atom = TestAsyncPhaseAtom<Int, any Error>(effect: effect) { .success(0) }
@@ -126,22 +131,22 @@ final class AsyncPhaseAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         context.reset(atom)
         context.reset(atom)
         context.reset(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
+++ b/Tests/AtomsTests/Atom/AsyncSequenceAtomTests.swift
@@ -1,16 +1,18 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Atoms
 
-final class AsyncSequenceAtomTests: XCTestCase {
+struct AsyncSequenceAtomTests {
     @MainActor
+    @Test
     func testValue() async {
         let pipe = AsyncThrowingStreamPipe<Int>()
         let atom = TestAsyncSequenceAtom { pipe.stream }
         let context = AtomTestContext()
 
         do {
-            XCTAssertTrue(context.watch(atom).isSuspending)
+            #expect(context.watch(atom).isSuspending)
         }
 
         do {
@@ -18,7 +20,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             pipe.continuation.yield(0)
             await context.wait(for: atom, until: \.isSuccess)
 
-            XCTAssertEqual(context.watch(atom).value, 0)
+            #expect(context.watch(atom).value == 0)
         }
 
         do {
@@ -26,7 +28,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             pipe.continuation.finish(throwing: URLError(.badURL))
             await context.wait(for: atom, until: \.isFailure)
 
-            XCTAssertEqual(context.watch(atom).error as? URLError, URLError(.badURL))
+            #expect(context.watch(atom).error as? URLError == URLError(.badURL))
         }
 
         do {
@@ -34,7 +36,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             pipe.continuation.yield(1)
             let didUpdate = await context.waitForUpdate(timeout: 0.1)
 
-            XCTAssertFalse(didUpdate)
+            #expect(!(didUpdate))
         }
 
         do {
@@ -45,7 +47,7 @@ final class AsyncSequenceAtomTests: XCTestCase {
             pipe.continuation.yield(0)
             let didUpdate = await context.waitForUpdate(timeout: 0.1)
 
-            XCTAssertFalse(didUpdate)
+            #expect(!(didUpdate))
         }
 
         do {
@@ -56,25 +58,26 @@ final class AsyncSequenceAtomTests: XCTestCase {
             pipe.continuation.finish(throwing: URLError(.badURL))
             let didUpdate = await context.waitForUpdate(timeout: 0.1)
 
-            XCTAssertFalse(didUpdate)
+            #expect(!(didUpdate))
         }
 
         do {
             // Override
             context.override(atom) { _ in .success(100) }
 
-            XCTAssertEqual(context.watch(atom).value, 100)
+            #expect(context.watch(atom).value == 100)
         }
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let pipe = AsyncThrowingStreamPipe<Int>()
         let atom = TestAsyncSequenceAtom { pipe.stream }
         let context = AtomTestContext()
 
         do {
-            XCTAssertTrue(context.watch(atom).isSuspending)
+            #expect(context.watch(atom).isSuspending)
         }
 
         do {
@@ -90,8 +93,8 @@ final class AsyncSequenceAtomTests: XCTestCase {
 
             let phase = await context.refresh(atom)
 
-            XCTAssertEqual(phase.value, 0)
-            XCTAssertEqual(updateCount, 1)
+            #expect(phase.value == 0)
+            #expect(updateCount == 1)
         }
 
         do {
@@ -111,8 +114,8 @@ final class AsyncSequenceAtomTests: XCTestCase {
 
             let phase = await refreshTask.value
 
-            XCTAssertTrue(phase.isSuspending)
-            XCTAssertEqual(updateCount, 0)
+            #expect(phase.isSuspending)
+            #expect(updateCount == 0)
         }
 
         do {
@@ -123,16 +126,17 @@ final class AsyncSequenceAtomTests: XCTestCase {
             pipe.reset()
 
             context.unwatch(atom)
-            XCTAssertEqual(context.watch(atom).value, 200)
+            #expect(context.watch(atom).value == 200)
 
             let phase = await context.refresh(atom)
 
-            XCTAssertEqual(phase.value, 200)
-            XCTAssertEqual(updateCount, 1)
+            #expect(phase.value == 200)
+            #expect(updateCount == 1)
         }
     }
 
     @MainActor
+    @Test
     func testEffect() async {
         let effect = TestEffect()
         let pipe = AsyncThrowingStreamPipe<Int>()
@@ -141,9 +145,9 @@ final class AsyncSequenceAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         pipe.continuation.yield(0)
         await context.waitForUpdate()
@@ -154,14 +158,14 @@ final class AsyncSequenceAtomTests: XCTestCase {
         pipe.continuation.yield(2)
         await context.waitForUpdate()
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
@@ -122,7 +122,7 @@ struct ObservableObjectAtomTests {
 
     @MainActor
     @Test
-    func testUpdateMultipletimes() async {
+    func testUpdateMultipleTimes() async {
         final class TestObject: ObservableObject {
             @Published
             var value0 = 0

--- a/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ObservableObjectAtomTests.swift
@@ -1,9 +1,11 @@
-import XCTest
+import Combine
+import Testing
 
 @testable import Atoms
 
-final class ObservableObjectAtomTests: XCTestCase {
+struct ObservableObjectAtomTests {
     @MainActor
+    @Test
     func test() async {
         let atom = TestObservableObjectAtom()
         let context = AtomTestContext()
@@ -11,7 +13,7 @@ final class ObservableObjectAtomTests: XCTestCase {
         do {
             // Initial value
             let object = context.watch(atom)
-            XCTAssertEqual(object.updatedCount, 0)
+            #expect(object.updatedCount == 0)
         }
 
         do {
@@ -27,7 +29,7 @@ final class ObservableObjectAtomTests: XCTestCase {
             object.update()
             await context.waitForUpdate()
 
-            XCTAssertEqual(snapshot, 1)
+            #expect(snapshot == 1)
         }
 
         do {
@@ -44,7 +46,7 @@ final class ObservableObjectAtomTests: XCTestCase {
             object.update()
             await context.waitForUpdate()
 
-            XCTAssertEqual(updateCount, 1)
+            #expect(updateCount == 1)
         }
 
         do {
@@ -62,8 +64,8 @@ final class ObservableObjectAtomTests: XCTestCase {
             object.update()
             await context.waitForUpdate()
 
-            XCTAssertTrue(object === overrideObject)
-            XCTAssertEqual(updateCount, 1)
+            #expect(object === overrideObject)
+            #expect(updateCount == 1)
         }
 
         do {
@@ -81,21 +83,22 @@ final class ObservableObjectAtomTests: XCTestCase {
             object.update()
             await context.waitForUpdate()
 
-            XCTAssertTrue(object === overrideObject)
-            XCTAssertEqual(updateCount, 1)
+            #expect(object === overrideObject)
+            #expect(updateCount == 1)
         }
     }
 
     @MainActor
+    @Test
     func testEffect() async {
         let effect = TestEffect()
         let atom = TestObservableObjectAtom(effect: effect)
         let context = AtomTestContext()
         let object = context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         object.update()
         await context.waitForUpdate()
@@ -106,18 +109,19 @@ final class ObservableObjectAtomTests: XCTestCase {
         object.update()
         await context.waitForUpdate()
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 
     @MainActor
+    @Test
     func testUpdateMultipletimes() async {
         final class TestObject: ObservableObject {
             @Published
@@ -149,12 +153,13 @@ final class ObservableObjectAtomTests: XCTestCase {
         object.update()
         await context.waitForUpdate()
 
-        XCTAssertEqual(updatedCount, 1)
-        XCTAssertEqual(object.value0, 1)
-        XCTAssertEqual(object.value1, 1)
+        #expect(updatedCount == 1)
+        #expect(object.value0 == 1)
+        #expect(object.value1 == 1)
     }
 
     @MainActor
+    @Test
     func testUpdateOnNonIsolatedContext() async {
         final class TestObject: ObservableObject, @unchecked Sendable {
             @Published
@@ -186,7 +191,7 @@ final class ObservableObjectAtomTests: XCTestCase {
 
         await context.waitForUpdate()
 
-        XCTAssertEqual(updatedCount, 1)
-        XCTAssertEqual(object.value, 1)
+        #expect(updatedCount == 1)
+        #expect(object.value == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/PublisherAtomTests.swift
+++ b/Tests/AtomsTests/Atom/PublisherAtomTests.swift
@@ -1,10 +1,12 @@
 import Combine
-import XCTest
+import Foundation
+import Testing
 
 @testable import Atoms
 
-final class PublisherAtomTests: XCTestCase {
+struct PublisherAtomTests {
     @MainActor
+    @Test
     func testValue() async {
         let subject = ResettableSubject<Int, URLError>()
         let atom = TestPublisherAtom { subject }
@@ -13,7 +15,7 @@ final class PublisherAtomTests: XCTestCase {
         do {
             // Initial value
             let phase = context.watch(atom)
-            XCTAssertEqual(phase, .suspending)
+            #expect(phase == .suspending)
         }
 
         do {
@@ -21,7 +23,7 @@ final class PublisherAtomTests: XCTestCase {
             subject.send(0)
 
             await context.wait(for: atom, until: \.isSuccess)
-            XCTAssertEqual(context.watch(atom), .success(0))
+            #expect(context.watch(atom) == .success(0))
         }
 
         do {
@@ -29,7 +31,7 @@ final class PublisherAtomTests: XCTestCase {
             subject.send(completion: .failure(URLError(.badURL)))
 
             await context.wait(for: atom, until: \.isFailure)
-            XCTAssertEqual(context.watch(atom), .failure(URLError(.badURL)))
+            #expect(context.watch(atom) == .failure(URLError(.badURL)))
         }
 
         do {
@@ -37,7 +39,7 @@ final class PublisherAtomTests: XCTestCase {
             subject.send(1)
 
             let didUpdate = await context.waitForUpdate(timeout: 0.1)
-            XCTAssertFalse(didUpdate)
+            #expect(!(didUpdate))
         }
 
         do {
@@ -46,7 +48,7 @@ final class PublisherAtomTests: XCTestCase {
             subject.send(0)
 
             let didUpdate = await context.waitForUpdate(timeout: 0.1)
-            XCTAssertFalse(didUpdate)
+            #expect(!(didUpdate))
         }
 
         do {
@@ -55,25 +57,26 @@ final class PublisherAtomTests: XCTestCase {
             subject.send(completion: .failure(URLError(.badURL)))
 
             let didUpdate = await context.waitForUpdate(timeout: 0.1)
-            XCTAssertFalse(didUpdate)
+            #expect(!(didUpdate))
         }
 
         do {
             // Override
             context.override(atom) { _ in .success(100) }
 
-            XCTAssertEqual(context.watch(atom), .success(100))
+            #expect(context.watch(atom) == .success(100))
         }
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let subject = ResettableSubject<Int, URLError>()
         let atom = TestPublisherAtom { subject }
         let context = AtomTestContext()
 
         do {
-            XCTAssertTrue(context.watch(atom).isSuspending)
+            #expect(context.watch(atom).isSuspending)
         }
 
         do {
@@ -89,8 +92,8 @@ final class PublisherAtomTests: XCTestCase {
 
             let phase = await context.refresh(atom)
 
-            XCTAssertEqual(phase.value, 0)
-            XCTAssertEqual(updateCount, 1)
+            #expect(phase.value == 0)
+            #expect(updateCount == 1)
         }
 
         do {
@@ -110,8 +113,8 @@ final class PublisherAtomTests: XCTestCase {
 
             let phase = await refreshTask.value
 
-            XCTAssertEqual(phase, .suspending)
-            XCTAssertEqual(updateCount, 0)
+            #expect(phase == .suspending)
+            #expect(updateCount == 0)
         }
 
         do {
@@ -122,16 +125,17 @@ final class PublisherAtomTests: XCTestCase {
             subject.reset()
 
             context.unwatch(atom)
-            XCTAssertEqual(context.watch(atom).value, 200)
+            #expect(context.watch(atom).value == 200)
 
             let phase = await context.refresh(atom)
 
-            XCTAssertEqual(phase.value, 200)
-            XCTAssertEqual(updateCount, 1)
+            #expect(phase.value == 200)
+            #expect(updateCount == 1)
         }
     }
 
     @MainActor
+    @Test
     func testEffect() async {
         let effect = TestEffect()
         let subject = ResettableSubject<Int, URLError>()
@@ -140,9 +144,9 @@ final class PublisherAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         subject.send(0)
         await context.waitForUpdate()
@@ -153,14 +157,14 @@ final class PublisherAtomTests: XCTestCase {
         subject.send(2)
         await context.waitForUpdate()
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/StateAtomTests.swift
+++ b/Tests/AtomsTests/Atom/StateAtomTests.swift
@@ -1,16 +1,17 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class StateAtomTests: XCTestCase {
+struct StateAtomTests {
     @MainActor
+    @Test
     func testValue() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
         do {
             // Value
-            XCTAssertEqual(context.watch(atom), 0)
+            #expect(context.watch(atom) == 0)
         }
 
         do {
@@ -18,37 +19,40 @@ final class StateAtomTests: XCTestCase {
             context.unwatch(atom)
             context.override(atom) { _ in 200 }
 
-            XCTAssertEqual(context.watch(atom), 200)
+            #expect(context.watch(atom) == 200)
         }
     }
 
     @MainActor
+    @Test
     func testSet() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom), 0)
+        #expect(context.watch(atom) == 0)
 
         context[atom] = 100
 
-        XCTAssertEqual(context.watch(atom), 100)
+        #expect(context.watch(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testSetOverride() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
         context.override(atom) { _ in 200 }
 
-        XCTAssertEqual(context.watch(atom), 200)
+        #expect(context.watch(atom) == 200)
 
         context[atom] = 100
 
-        XCTAssertEqual(context.watch(atom), 100)
+        #expect(context.watch(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testDependency() async {
         struct Dependency1Atom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -65,12 +69,12 @@ final class StateAtomTests: XCTestCase {
         let context = AtomTestContext()
 
         let value0 = context.watch(TestAtom())
-        XCTAssertEqual(value0, 0)
+        #expect(value0 == 0)
 
         context[TestAtom()] = 1
 
         let value1 = context.watch(TestAtom())
-        XCTAssertEqual(value1, 1)
+        #expect(value1 == 1)
 
         // Updated by the depenency update.
 
@@ -81,10 +85,11 @@ final class StateAtomTests: XCTestCase {
         await context.waitForUpdate()
 
         let value2 = context.watch(TestAtom())
-        XCTAssertEqual(value2, 0)
+        #expect(value2 == 0)
     }
 
     @MainActor
+    @Test
     func testEffect() {
         let effect = TestEffect()
         let atom = TestStateAtom(defaultValue: 0, effect: effect)
@@ -92,22 +97,22 @@ final class StateAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         context.set(1, for: atom)
         context.set(2, for: atom)
         context.set(3, for: atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/StateAtomTests.swift
+++ b/Tests/AtomsTests/Atom/StateAtomTests.swift
@@ -76,7 +76,7 @@ struct StateAtomTests {
         let value1 = context.watch(TestAtom())
         #expect(value1 == 1)
 
-        // Updated by the depenency update.
+        // Updated by the dependency update.
 
         Task {
             context[Dependency1Atom()] = 0

--- a/Tests/AtomsTests/Atom/TaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/TaskAtomTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class TaskAtomTests: XCTestCase {
+struct TaskAtomTests {
     @MainActor
+    @Test
     func testValue() async {
         let atom = TestTaskAtom { 0 }
         let context = AtomTestContext()
@@ -11,7 +12,7 @@ final class TaskAtomTests: XCTestCase {
         do {
             // Initial value
             let value = await context.watch(atom).value
-            XCTAssertEqual(value, 0)
+            #expect(value == 0)
         }
 
         do {
@@ -19,7 +20,7 @@ final class TaskAtomTests: XCTestCase {
             let task = context.watch(atom)
             context.unwatch(atom)
 
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
 
         do {
@@ -27,7 +28,7 @@ final class TaskAtomTests: XCTestCase {
             context.override(atom) { _ in Task { 200 } }
 
             let value1 = await context.watch(atom).value
-            XCTAssertEqual(value1, 200)
+            #expect(value1 == 200)
         }
 
         do {
@@ -37,11 +38,12 @@ final class TaskAtomTests: XCTestCase {
             let task = context.watch(atom)
             context.unwatch(atom)
 
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         var value = 0
         let atom = TestTaskAtom<Int> { value }
@@ -54,14 +56,14 @@ final class TaskAtomTests: XCTestCase {
             context.watch(atom)
 
             let value0 = await context.refresh(atom).value
-            XCTAssertEqual(value0, 0)
-            XCTAssertEqual(updateCount, 1)
+            #expect(value0 == 0)
+            #expect(updateCount == 1)
 
             value = 1
 
             let value1 = await context.refresh(atom).value
-            XCTAssertEqual(value1, 1)
-            XCTAssertEqual(updateCount, 2)
+            #expect(value1 == 1)
+            #expect(updateCount == 2)
         }
 
         do {
@@ -73,7 +75,7 @@ final class TaskAtomTests: XCTestCase {
             refreshTask.cancel()
 
             let task = await refreshTask.value
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
 
         do {
@@ -81,7 +83,7 @@ final class TaskAtomTests: XCTestCase {
             context.override(atom) { _ in Task { 300 } }
 
             let value = await context.refresh(atom).value
-            XCTAssertEqual(value, 300)
+            #expect(value == 300)
         }
 
         do {
@@ -95,11 +97,12 @@ final class TaskAtomTests: XCTestCase {
             refreshTask.cancel()
 
             let task = await refreshTask.value
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
     }
 
     @MainActor
+    @Test
     func testReleaseDependencies() async {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -118,23 +121,24 @@ final class TaskAtomTests: XCTestCase {
 
         let value0 = await context.watch(TestAtom()).value
 
-        XCTAssertEqual(value0, 0)
+        #expect(value0 == 0)
 
         context[DependencyAtom()] = 100
 
         let value1 = await context.watch(TestAtom()).value
 
         // Dependencies should not be released until task value is returned.
-        XCTAssertEqual(value1, 100)
+        #expect(value1 == 100)
 
         context.unwatch(TestAtom())
 
         let dependencyValue = context.read(DependencyAtom())
 
-        XCTAssertEqual(dependencyValue, 0)
+        #expect(dependencyValue == 0)
     }
 
     @MainActor
+    @Test
     func testEffect() {
         let effect = TestEffect()
         let atom = TestTaskAtom(effect: effect) { 0 }
@@ -142,22 +146,22 @@ final class TaskAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         context.reset(atom)
         context.reset(atom)
         context.reset(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
@@ -1,9 +1,11 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Atoms
 
-final class ThrowingTaskAtomTests: XCTestCase {
+struct ThrowingTaskAtomTests {
     @MainActor
+    @Test
     func test() async throws {
         var result = Result<Int, any Error>.success(0)
         let atom = TestThrowingTaskAtom { result }
@@ -12,7 +14,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
         do {
             // Initial value
             let value = try await context.watch(atom).value
-            XCTAssertEqual(value, 0)
+            #expect(value == 0)
         }
 
         do {
@@ -23,10 +25,10 @@ final class ThrowingTaskAtomTests: XCTestCase {
 
                 _ = try await context.watch(atom).value
 
-                XCTFail("Accessing to value should throw an error")
+                Issue.record("Accessing to value should throw an error")
             }
             catch {
-                XCTAssertEqual(error as? URLError, URLError(.badURL))
+                #expect(error as? URLError == URLError(.badURL))
             }
         }
 
@@ -35,7 +37,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
             let task = context.watch(atom)
             context.unwatch(atom)
 
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
 
         do {
@@ -43,7 +45,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
             context.override(atom) { _ in Task { 200 } }
 
             let value = try await context.watch(atom).value
-            XCTAssertEqual(value, 200)
+            #expect(value == 200)
 
             // Override termination
 
@@ -52,11 +54,12 @@ final class ThrowingTaskAtomTests: XCTestCase {
             let task = context.watch(atom)
             context.unwatch(atom)
 
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
     }
 
     @MainActor
+    @Test
     func testRefresh() async throws {
         var result = Result<Int, any Error>.success(0)
         let atom = TestThrowingTaskAtom { result }
@@ -69,14 +72,14 @@ final class ThrowingTaskAtomTests: XCTestCase {
             context.watch(atom)
 
             let value0 = try await context.refresh(atom).value
-            XCTAssertEqual(value0, 0)
-            XCTAssertEqual(updateCount, 1)
+            #expect(value0 == 0)
+            #expect(updateCount == 1)
 
             result = .success(1)
 
             let value1 = try await context.refresh(atom).value
-            XCTAssertEqual(value1, 1)
-            XCTAssertEqual(updateCount, 2)
+            #expect(value1 == 1)
+            #expect(updateCount == 2)
         }
 
         do {
@@ -88,7 +91,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
             refreshTask.cancel()
 
             let task = await refreshTask.value
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
 
         do {
@@ -96,7 +99,7 @@ final class ThrowingTaskAtomTests: XCTestCase {
             context.override(atom) { _ in Task { 300 } }
 
             let value = try await context.refresh(atom).value
-            XCTAssertEqual(value, 300)
+            #expect(value == 300)
         }
 
         do {
@@ -110,11 +113,12 @@ final class ThrowingTaskAtomTests: XCTestCase {
             refreshTask.cancel()
 
             let task = await refreshTask.value
-            XCTAssertTrue(task.isCancelled)
+            #expect(task.isCancelled)
         }
     }
 
     @MainActor
+    @Test
     func testReleaseDependencies() async throws {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -133,23 +137,24 @@ final class ThrowingTaskAtomTests: XCTestCase {
 
         let value0 = try await context.watch(TestAtom()).value
 
-        XCTAssertEqual(value0, 0)
+        #expect(value0 == 0)
 
         context[DependencyAtom()] = 100
 
         let value1 = try await context.watch(TestAtom()).value
 
         // Dependencies should not be released until task value is returned.
-        XCTAssertEqual(value1, 100)
+        #expect(value1 == 100)
 
         context.unwatch(TestAtom())
 
         let dependencyValue = context.read(DependencyAtom())
 
-        XCTAssertEqual(dependencyValue, 0)
+        #expect(dependencyValue == 0)
     }
 
     @MainActor
+    @Test
     func testEffect() {
         let effect = TestEffect()
         let atom = TestThrowingTaskAtom(effect: effect) { .success(0) }
@@ -157,22 +162,22 @@ final class ThrowingTaskAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         context.reset(atom)
         context.reset(atom)
         context.reset(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ThrowingTaskAtomTests.swift
@@ -25,7 +25,7 @@ struct ThrowingTaskAtomTests {
 
                 _ = try await context.watch(atom).value
 
-                Issue.record("Accessing to value should throw an error")
+                Issue.record("Accessing the value should throw an error")
             }
             catch {
                 #expect(error as? URLError == URLError(.badURL))

--- a/Tests/AtomsTests/Atom/ValueAtomTests.swift
+++ b/Tests/AtomsTests/Atom/ValueAtomTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ValueAtomTests: XCTestCase {
+struct ValueAtomTests {
     @MainActor
+    @Test
     func testValue() {
         let atom = TestValueAtom(value: 0)
         let context = AtomTestContext()
@@ -11,7 +12,7 @@ final class ValueAtomTests: XCTestCase {
         do {
             // Initial value
             let value = context.watch(atom)
-            XCTAssertEqual(value, 0)
+            #expect(value == 0)
         }
 
         do {
@@ -19,11 +20,12 @@ final class ValueAtomTests: XCTestCase {
             context.unwatch(atom)
             context.override(atom) { _ in 1 }
 
-            XCTAssertEqual(context.watch(atom), 1)
+            #expect(context.watch(atom) == 1)
         }
     }
 
     @MainActor
+    @Test
     func testEffect() async {
         let effect = TestEffect()
         let atom = TestValueAtom(value: 0, effect: effect)
@@ -31,22 +33,22 @@ final class ValueAtomTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         context.reset(atom)
         context.reset(atom)
         context.reset(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom)
 
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 3)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 3)
+        #expect(effect.releasedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Attribute/KeepAliveTests.swift
+++ b/Tests/AtomsTests/Attribute/KeepAliveTests.swift
@@ -1,137 +1,144 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class KeepAliveTests: XCTestCase {
+struct KeepAliveTests {
+    struct KeepAliveAtom<T: Hashable & Sendable>: ValueAtom, KeepAlive, Hashable {
+        let value: T
+
+        func value(context: Context) -> T {
+            value
+        }
+    }
+
+    struct ScopedKeepAliveAtom<T: Hashable & Sendable>: ValueAtom, KeepAlive, Scoped, Hashable {
+        let value: T
+
+        func value(context: Context) -> T {
+            value
+        }
+    }
+
     @MainActor
-    func testKeepAliveAtoms() {
-        struct KeepAliveAtom<T: Hashable & Sendable>: ValueAtom, KeepAlive, Hashable {
-            let value: T
+    @Test
+    func testShouldNotBeReleased() {
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let atom = KeepAliveAtom(value: 0)
+        let key = AtomKey(atom)
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
 
-            func value(context: Context) -> T {
-                value
-            }
-        }
+        _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
+        #expect(store.caches[key] != nil)
 
-        struct ScopedKeepAliveAtom<T: Hashable & Sendable>: ValueAtom, KeepAlive, Scoped, Hashable {
-            let value: T
+        context.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[key] != nil)
+    }
 
-            func value(context: Context) -> T {
-                value
-            }
-        }
+    @MainActor
+    @Test
+    func testShouldNotBeReleasedWhenNotScoped() {
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let atom = ScopedKeepAliveAtom(value: 0)
+        let key = AtomKey(atom, scopeKey: nil)
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
 
-        XCTContext.runActivity(named: "Should not be released") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let atom = KeepAliveAtom(value: 0)
-            let key = AtomKey(atom)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
+        _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
+        #expect(store.caches[key] != nil)
 
-            _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
-            XCTAssertNotNil(store.caches[key])
+        context.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[key] != nil)
+    }
 
-            context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNotNil(store.caches[key])
-        }
+    @MainActor
+    @Test
+    func testShouldNotBeReleasedUntilScopeIsReleasedWhenOverriddenInScope() {
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let atom = KeepAliveAtom(value: 0)
+        var scopeState: ScopeState! = ScopeState()
+        let key = AtomKey(atom, scopeKey: scopeState.token.key)
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
+        let scopedContext = context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scopeState.token.key,
+            observers: [],
+            overrideContainer: OverrideContainer()
+                .addingOverride(for: atom) { _ in
+                    10
+                }
+        )
 
-        XCTContext.runActivity(named: "Should not be released when not scoped") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let atom = ScopedKeepAliveAtom(value: 0)
-            let key = AtomKey(atom, scopeKey: nil)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
+        scopedContext.registerScope(state: scopeState)
 
-            _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
-            XCTAssertNotNil(store.caches[key])
+        _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
+        #expect(store.caches[key] != nil)
 
-            context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNotNil(store.caches[key])
-        }
+        scopedContext.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[key] != nil)
 
-        XCTContext.runActivity(named: "Should not be released until scope is released when overridden in scope") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let atom = KeepAliveAtom(value: 0)
-            var scopeState: ScopeState! = ScopeState()
-            let key = AtomKey(atom, scopeKey: scopeState.token.key)
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
-            let scopedContext = context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scopeState.token.key,
-                observers: [],
-                overrideContainer: OverrideContainer()
-                    .addingOverride(for: atom) { _ in
-                        10
-                    }
-            )
+        scopeState = nil
+        #expect(store.caches[key] == nil)
+    }
 
-            scopedContext.registerScope(state: scopeState)
+    @MainActor
+    @Test
+    func testShouldNotBeReleasedUntilScopeIsReleasedWhenScoped() {
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let atom = ScopedKeepAliveAtom(value: 0)
+        var scopeState: ScopeState! = ScopeState()
+        let key = AtomKey(atom, scopeKey: scopeState.token.key)
+        let scopedContext = context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scopeState.token.key
+        )
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
 
-            _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
-            XCTAssertNotNil(store.caches[key])
+        scopedContext.registerScope(state: scopeState)
 
-            scopedContext.unwatch(atom, subscriber: subscriber)
-            XCTAssertNotNil(store.caches[key])
+        _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
+        #expect(store.caches[key] != nil)
 
-            scopeState = nil
-            XCTAssertNil(store.caches[key])
-        }
+        scopedContext.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[key] != nil)
 
-        XCTContext.runActivity(named: "Should not be released until scope is released when scoped") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let atom = ScopedKeepAliveAtom(value: 0)
-            var scopeState: ScopeState! = ScopeState()
-            let key = AtomKey(atom, scopeKey: scopeState.token.key)
-            let scopedContext = context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scopeState.token.key
-            )
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
+        scopeState = nil
+        #expect(store.caches[key] == nil)
+    }
 
-            scopedContext.registerScope(state: scopeState)
+    @MainActor
+    @Test
+    func testShouldBeReleasedWhenScopeIsAlreadyReleasedWhenScoped() {
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let atom = ScopedKeepAliveAtom(value: 0)
+        var scopeState: ScopeState! = ScopeState()
+        let key = AtomKey(atom, scopeKey: scopeState.token.key)
+        let scopedContext = context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scopeState.token.key
+        )
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
 
-            _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
-            XCTAssertNotNil(store.caches[key])
+        scopedContext.registerScope(state: scopeState)
+        scopeState = nil
 
-            scopedContext.unwatch(atom, subscriber: subscriber)
-            XCTAssertNotNil(store.caches[key])
+        _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
+        #expect(store.caches[key] != nil)
 
-            scopeState = nil
-            XCTAssertNil(store.caches[key])
-        }
-
-        XCTContext.runActivity(named: "Should be released when scope is already released when scoped") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let atom = ScopedKeepAliveAtom(value: 0)
-            var scopeState: ScopeState! = ScopeState()
-            let key = AtomKey(atom, scopeKey: scopeState.token.key)
-            let scopedContext = context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scopeState.token.key
-            )
-            let subscriberState = SubscriberState()
-            let subscriber = Subscriber(subscriberState)
-
-            scopedContext.registerScope(state: scopeState)
-            scopeState = nil
-
-            _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
-            XCTAssertNotNil(store.caches[key])
-
-            scopedContext.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.caches[key])
-        }
+        scopedContext.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[key] == nil)
     }
 }

--- a/Tests/AtomsTests/Attribute/ScopedTests.swift
+++ b/Tests/AtomsTests/Attribute/ScopedTests.swift
@@ -1,140 +1,123 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ScopedTests: XCTestCase {
-    @MainActor
-    func testScopedAtoms() {
-        struct ScopedAtom<ID: Hashable, T: Hashable>: ValueAtom, Scoped, Equatable, @unchecked Sendable {
-            let key = UniqueKey()
-            let scopeID: ID
-            let value: T
+struct ScopedTests {
+    struct ScopedAtom<ID: Hashable, T: Hashable>: ValueAtom, Scoped, Equatable, @unchecked Sendable {
+        let key = UniqueKey()
+        let scopeID: ID
+        let value: T
 
-            func value(context: Context) -> T {
-                value
-            }
+        func value(context: Context) -> T {
+            value
         }
+    }
 
+    @Test
+    @MainActor
+    func testScopedAtomsShouldBeScoped() {
         let scope1Token = ScopeKey.Token()
         let scope2Token = ScopeKey.Token()
         let subscriberState = SubscriberState()
         let subscriber = Subscriber(subscriberState)
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let scoped1Context = context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scope1Token.key
+        )
+        let scoped2Context = scoped1Context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scope2Token.key
+        )
+        let atom = ScopedAtom(scopeID: DefaultScopeID(), value: 0)
+        let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Token.key)
+        let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Token.key)
 
-        XCTContext.runActivity(named: "Should be scoped") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let scoped1Context = context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scope1Token.key
-            )
-            let scoped2Context = scoped1Context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scope2Token.key
-            )
-            let atom = ScopedAtom(scopeID: DefaultScopeID(), value: 0)
-            let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Token.key)
-            let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Token.key)
+        #expect(scoped1Context.watch(atom, subscriber: subscriber, subscription: Subscription()) == 0)
+        #expect(store.caches[scoped1AtomKey] as? AtomCache<ScopedAtom<DefaultScopeID, Int>> == AtomCache(atom: atom, value: 0))
+        #expect(store.caches[scoped2AtomKey] == nil)
 
-            XCTAssertEqual(
-                scoped1Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
-                0
-            )
-            XCTAssertEqual(
-                store.caches[scoped1AtomKey] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
-                AtomCache(atom: atom, value: 0)
-            )
-            XCTAssertNil(store.caches[scoped2AtomKey])
+        scoped1Context.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[scoped1AtomKey] == nil)
 
-            scoped1Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.caches[scoped1AtomKey])
+        #expect(scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()) == 0)
+        #expect(store.caches[scoped2AtomKey] as? AtomCache<ScopedAtom<DefaultScopeID, Int>> == AtomCache(atom: atom, value: 0))
 
-            XCTAssertEqual(
-                scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
-                0
-            )
-            XCTAssertEqual(
-                store.caches[scoped2AtomKey] as? AtomCache<ScopedAtom<DefaultScopeID, Int>>,
-                AtomCache(atom: atom, value: 0)
-            )
+        scoped2Context.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[scoped2AtomKey] == nil)
+    }
 
-            scoped2Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.caches[scoped2AtomKey])
-        }
+    @Test
+    @MainActor
+    func testScopedAtomsShouldBeScopedInParticularScope() {
+        let scope1Token = ScopeKey.Token()
+        let scope2Token = ScopeKey.Token()
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let scopeID = "Scope 1"
+        let scoped1Context = context.scoped(
+            scopeID: ScopeID(scopeID),
+            scopeKey: scope1Token.key
+        )
+        let scoped2Context = scoped1Context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scope2Token.key
+        )
+        let atom = ScopedAtom(scopeID: scopeID, value: 0)
+        let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Token.key)
+        let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Token.key)
 
-        XCTContext.runActivity(named: "Should be scoped in particular scope") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let scopeID = "Scope 1"
-            let scoped1Context = context.scoped(
-                scopeID: ScopeID(scopeID),
-                scopeKey: scope1Token.key
-            )
-            let scoped2Context = scoped1Context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scope2Token.key
-            )
-            let atom = ScopedAtom(scopeID: scopeID, value: 0)
-            let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Token.key)
-            let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Token.key)
+        #expect(scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()) == 0)
+        #expect(store.caches[scoped1AtomKey] as? AtomCache<ScopedAtom<String, Int>> == AtomCache(atom: atom, value: 0))
+        #expect(store.caches[scoped2AtomKey] == nil)
 
-            XCTAssertEqual(
-                scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
-                0
-            )
-            XCTAssertEqual(
-                store.caches[scoped1AtomKey] as? AtomCache<ScopedAtom<String, Int>>,
-                AtomCache(atom: atom, value: 0)
-            )
-            XCTAssertNil(store.caches[scoped2AtomKey])
+        scoped2Context.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[scoped1AtomKey] == nil)
+    }
 
-            scoped2Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.caches[scoped1AtomKey])
-        }
+    @Test
+    @MainActor
+    func testScopedAtomsModifiedAtomsShouldAlsoBeScoped() {
+        let scope1Token = ScopeKey.Token()
+        let scope2Token = ScopeKey.Token()
+        let subscriberState = SubscriberState()
+        let subscriber = Subscriber(subscriberState)
+        let store = AtomStore()
+        let rootScopeToken = ScopeKey.Token()
+        let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
+        let scopeID = "Scope 1"
+        let scoped1Context = context.scoped(
+            scopeID: ScopeID(scopeID),
+            scopeKey: scope1Token.key
+        )
+        let scoped2Context = scoped1Context.scoped(
+            scopeID: ScopeID(DefaultScopeID()),
+            scopeKey: scope2Token.key
+        )
+        let baseAtom = ScopedAtom(scopeID: scopeID, value: 0)
+        let atom = baseAtom.changes
+        let baseAtomKey = AtomKey(baseAtom, scopeKey: nil)
+        let atomKey = AtomKey(atom, scopeKey: nil)
+        let scoped1BaseAtomKey = AtomKey(baseAtom, scopeKey: scope1Token.key)
+        let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Token.key)
+        let scoped2BaseAtomKey = AtomKey(baseAtom, scopeKey: scope2Token.key)
+        let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Token.key)
 
-        XCTContext.runActivity(named: "Modified atoms should also be scoped") { _ in
-            let store = AtomStore()
-            let rootScopeToken = ScopeKey.Token()
-            let context = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
-            let scopeID = "Scope 1"
-            let scoped1Context = context.scoped(
-                scopeID: ScopeID(scopeID),
-                scopeKey: scope1Token.key
-            )
-            let scoped2Context = scoped1Context.scoped(
-                scopeID: ScopeID(DefaultScopeID()),
-                scopeKey: scope2Token.key
-            )
-            let baseAtom = ScopedAtom(scopeID: scopeID, value: 0)
-            let atom = baseAtom.changes
-            let baseAtomKey = AtomKey(baseAtom, scopeKey: nil)
-            let atomKey = AtomKey(atom, scopeKey: nil)
-            let scoped1BaseAtomKey = AtomKey(baseAtom, scopeKey: scope1Token.key)
-            let scoped1AtomKey = AtomKey(atom, scopeKey: scope1Token.key)
-            let scoped2BaseAtomKey = AtomKey(baseAtom, scopeKey: scope2Token.key)
-            let scoped2AtomKey = AtomKey(atom, scopeKey: scope2Token.key)
+        #expect(scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()) == 0)
+        #expect((store.caches[scoped1BaseAtomKey] as? AtomCache<ScopedAtom<String, Int>>)?.value == 0)
+        #expect((store.caches[scoped1AtomKey] as? AtomCache<ModifiedAtom<ScopedAtom<String, Int>, ChangesModifier<Int>>>)?.value == 0)
+        #expect(store.caches[scoped2BaseAtomKey] == nil)
+        #expect(store.caches[scoped2AtomKey] == nil)
+        #expect(store.caches[baseAtomKey] == nil)
+        #expect(store.caches[atomKey] == nil)
 
-            XCTAssertEqual(
-                scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()),
-                0
-            )
-            XCTAssertEqual(
-                (store.caches[scoped1BaseAtomKey] as? AtomCache<ScopedAtom<String, Int>>)?.value,
-                0
-            )
-            XCTAssertEqual(
-                (store.caches[scoped1AtomKey] as? AtomCache<ModifiedAtom<ScopedAtom<String, Int>, ChangesModifier<Int>>>)?.value,
-                0
-            )
-            XCTAssertNil(store.caches[scoped2BaseAtomKey])
-            XCTAssertNil(store.caches[scoped2AtomKey])
-            XCTAssertNil(store.caches[baseAtomKey])
-            XCTAssertNil(store.caches[atomKey])
-
-            scoped2Context.unwatch(atom, subscriber: subscriber)
-            XCTAssertNil(store.caches[scoped1BaseAtomKey])
-            XCTAssertNil(store.caches[scoped1AtomKey])
-        }
+        scoped2Context.unwatch(atom, subscriber: subscriber)
+        #expect(store.caches[scoped1BaseAtomKey] == nil)
+        #expect(store.caches[scoped1AtomKey] == nil)
     }
 }

--- a/Tests/AtomsTests/Context/AtomContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomContextTests.swift
@@ -1,17 +1,18 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomContextTests: XCTestCase {
+struct AtomContextTests {
     @MainActor
+    @Test
     func testSubscript() {
         let atom = TestStateAtom(defaultValue: 0)
         let context: any AtomWatchableContext = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom), 0)
+        #expect(context.watch(atom) == 0)
 
         context[atom] = 100
 
-        XCTAssertEqual(context[atom], 100)
+        #expect(context[atom] == 100)
     }
 }

--- a/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomCurrentContextTests.swift
@@ -1,10 +1,11 @@
 import Combine
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomCurrentContextTests: XCTestCase {
+struct AtomCurrentContextTests {
     @MainActor
+    @Test
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
@@ -13,10 +14,11 @@ final class AtomCurrentContextTests: XCTestCase {
             store: .root(store: store, scopeKey: rootScopeToken.key)
         )
 
-        XCTAssertEqual(context.read(atom), 100)
+        #expect(context.read(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testSet() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 100)
@@ -26,14 +28,15 @@ final class AtomCurrentContextTests: XCTestCase {
         let storeContext = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
         let context = AtomCurrentContext(store: storeContext)
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 100)
+        #expect(storeContext.watch(dependency, in: transactionState) == 100)
 
         context.set(200, for: dependency)
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 200)
+        #expect(storeContext.watch(dependency, in: transactionState) == 200)
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let store = AtomStore()
@@ -43,10 +46,11 @@ final class AtomCurrentContextTests: XCTestCase {
         )
         let value = await context.refresh(atom).value
 
-        XCTAssertEqual(value, 100)
+        #expect(value == 100)
     }
 
     @MainActor
+    @Test
     func testReset() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 0)
@@ -56,15 +60,15 @@ final class AtomCurrentContextTests: XCTestCase {
         let storeContext = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
         let context = AtomTransactionContext(store: storeContext, transactionState: transactionState)
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 0)
+        #expect(storeContext.watch(dependency, in: transactionState) == 0)
 
         context[dependency] = 100
 
-        XCTAssertEqual(storeContext.watch(dependency, in: transactionState), 100)
+        #expect(storeContext.watch(dependency, in: transactionState) == 100)
 
         context.reset(dependency)
 
-        XCTAssertEqual(storeContext.read(dependency), 0)
+        #expect(storeContext.read(dependency) == 0)
     }
 
 }

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -1,10 +1,11 @@
 import Combine
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomTestContextTests: XCTestCase {
+struct AtomTestContextTests {
     @MainActor
+    @Test
     func testOnUpdate() {
         let atom = TestValueAtom(value: 100)
         let context = AtomTestContext()
@@ -21,18 +22,19 @@ final class AtomTestContextTests: XCTestCase {
 
         context.reset(atom)
 
-        XCTAssertFalse(isCalled)
+        #expect(!(isCalled))
 
         context.watch(atom)
 
-        XCTAssertFalse(isCalled)
+        #expect(!(isCalled))
 
         context.reset(atom)
 
-        XCTAssertTrue(isCalled)
+        #expect(isCalled)
     }
 
     @MainActor
+    @Test
     func testWaitForUpdate() async {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -45,14 +47,15 @@ final class AtomTestContextTests: XCTestCase {
 
         let didUpdate0 = await context.waitForUpdate()
 
-        XCTAssertTrue(didUpdate0)
+        #expect(didUpdate0)
 
         let didUpdate1 = await context.waitForUpdate(timeout: 0.1)
 
-        XCTAssertFalse(didUpdate1)
+        #expect(!(didUpdate1))
     }
 
     @MainActor
+    @Test
     func testWaitFor() async {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -61,7 +64,7 @@ final class AtomTestContextTests: XCTestCase {
 
         for i in 1...3 {
             Task {
-                try? await Task.sleep(seconds: Double(i) / 100)
+                try? await Task.sleep(seconds: Double(i) / 10)
                 context[atom] += 1
             }
         }
@@ -70,63 +73,66 @@ final class AtomTestContextTests: XCTestCase {
             $0 == 0
         }
 
-        XCTAssertFalse(didUpdate0)
+        #expect(!(didUpdate0))
 
         let didUpdate1 = await context.wait(for: atom) {
             $0 == 3
         }
 
-        XCTAssertTrue(didUpdate1)
+        #expect(didUpdate1)
 
         let didUpdate2 = await context.wait(for: atom, timeout: 0.1) {
             $0 == 100
         }
 
-        XCTAssertFalse(didUpdate2)
+        #expect(!(didUpdate2))
 
         let didUpdate3 = await context.wait(for: atom) {
             $0 == 3
         }
 
-        XCTAssertFalse(didUpdate3)
+        #expect(!(didUpdate3))
     }
 
     @MainActor
+    @Test
     func testOverride() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.read(atom0), 100)
-        XCTAssertEqual(context.read(atom1), 200)
+        #expect(context.read(atom0) == 100)
+        #expect(context.read(atom1) == 200)
 
         context.override(atom0) { _ in 300 }
 
-        XCTAssertEqual(context.read(atom0), 300)
-        XCTAssertEqual(context.read(atom1), 200)
+        #expect(context.read(atom0) == 300)
+        #expect(context.read(atom1) == 200)
     }
 
     @MainActor
+    @Test
     func testOverrideWithType() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestValueAtom(value: 200)
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.read(atom0), 100)
-        XCTAssertEqual(context.read(atom1), 200)
+        #expect(context.read(atom0) == 100)
+        #expect(context.read(atom1) == 200)
 
         context.override(TestValueAtom.self) { _ in 300 }
 
-        XCTAssertEqual(context.read(atom0), 300)
-        XCTAssertEqual(context.read(atom1), 300)
+        #expect(context.read(atom0) == 300)
+        #expect(context.read(atom1) == 300)
     }
 
     @MainActor
+    @Test
     func testTerminate() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom), 100)
+        #expect(context.watch(atom) == 100)
 
         context[atom] = 200
 
@@ -138,11 +144,12 @@ final class AtomTestContextTests: XCTestCase {
 
         context.unwatch(atom)
 
-        XCTAssertEqual(context.read(atom), 100)
-        XCTAssertEqual(updateCount, 0)
+        #expect(context.read(atom) == 100)
+        #expect(updateCount == 0)
     }
 
     @MainActor
+    @Test
     func testSubscript() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
@@ -154,24 +161,26 @@ final class AtomTestContextTests: XCTestCase {
 
         context.watch(atom)
 
-        XCTAssertEqual(context[atom], 100)
-        XCTAssertEqual(updateCount, 0)
+        #expect(context[atom] == 100)
+        #expect(updateCount == 0)
 
         context[atom] = 200
 
-        XCTAssertEqual(context[atom], 200)
-        XCTAssertEqual(updateCount, 1)
+        #expect(context[atom] == 200)
+        #expect(updateCount == 1)
     }
 
     @MainActor
+    @Test
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.read(atom), 100)
+        #expect(context.read(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testWatch() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
@@ -181,16 +190,17 @@ final class AtomTestContextTests: XCTestCase {
             updateCount += 1
         }
 
-        XCTAssertEqual(context.watch(atom), 100)
-        XCTAssertEqual(updateCount, 0)
+        #expect(context.watch(atom) == 100)
+        #expect(updateCount == 0)
 
         context[atom] = 200
 
-        XCTAssertEqual(context.watch(atom), 200)
-        XCTAssertEqual(updateCount, 1)
+        #expect(context.watch(atom) == 200)
+        #expect(updateCount == 1)
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let context = AtomTestContext()
@@ -200,29 +210,30 @@ final class AtomTestContextTests: XCTestCase {
             updateCount += 1
         }
 
-        XCTAssertTrue(context.watch(atom).isSuspending)
+        #expect(context.watch(atom).isSuspending)
 
         let value = await context.refresh(atom).value
 
-        XCTAssertEqual(value, 100)
-        XCTAssertEqual(context.watch(atom).value, 100)
-        XCTAssertEqual(updateCount, 1)
+        #expect(value == 100)
+        #expect(context.watch(atom).value == 100)
+        #expect(updateCount == 1)
     }
 
     @MainActor
+    @Test
     func testReset() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom), 0)
+        #expect(context.watch(atom) == 0)
 
         context[atom] = 100
 
-        XCTAssertEqual(context.read(atom), 100)
+        #expect(context.read(atom) == 100)
 
         context.reset(atom)
 
-        XCTAssertEqual(context.read(atom), 0)
+        #expect(context.read(atom) == 0)
     }
 
 }

--- a/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTransactionContextTests.swift
@@ -1,10 +1,11 @@
 import Combine
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomTransactionContextTests: XCTestCase {
+struct AtomTransactionContextTests {
     @MainActor
+    @Test
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
@@ -15,10 +16,11 @@ final class AtomTransactionContextTests: XCTestCase {
             transactionState: transactionState
         )
 
-        XCTAssertEqual(context.read(atom), 100)
+        #expect(context.read(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testSet() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 100)
@@ -30,14 +32,15 @@ final class AtomTransactionContextTests: XCTestCase {
             transactionState: transactionState
         )
 
-        XCTAssertEqual(context.watch(dependency), 100)
+        #expect(context.watch(dependency) == 100)
 
         context.set(200, for: dependency)
 
-        XCTAssertEqual(context.watch(dependency), 200)
+        #expect(context.watch(dependency) == 200)
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let atom0 = TestValueAtom(value: 0)
         let atom1 = TestPublisherAtom { Just(100) }
@@ -49,15 +52,16 @@ final class AtomTransactionContextTests: XCTestCase {
             transactionState: transactionState
         )
 
-        XCTAssertTrue(context.watch(atom1).isSuspending)
+        #expect(context.watch(atom1).isSuspending)
 
         let value = await context.refresh(atom1).value
 
-        XCTAssertEqual(value, 100)
-        XCTAssertEqual(context.watch(atom1).value, 100)
+        #expect(value == 100)
+        #expect(context.watch(atom1).value == 100)
     }
 
     @MainActor
+    @Test
     func testReset() {
         let atom = TestValueAtom(value: 0)
         let dependency = TestStateAtom(defaultValue: 0)
@@ -69,18 +73,19 @@ final class AtomTransactionContextTests: XCTestCase {
             transactionState: transactionState
         )
 
-        XCTAssertEqual(context.watch(dependency), 0)
+        #expect(context.watch(dependency) == 0)
 
         context[dependency] = 100
 
-        XCTAssertEqual(context.watch(dependency), 100)
+        #expect(context.watch(dependency) == 100)
 
         context.reset(dependency)
 
-        XCTAssertEqual(context.read(dependency), 0)
+        #expect(context.read(dependency) == 0)
     }
 
     @MainActor
+    @Test
     func testWatch() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)
@@ -94,8 +99,8 @@ final class AtomTransactionContextTests: XCTestCase {
 
         let value = context.watch(atom1)
 
-        XCTAssertEqual(value, 200)
-        XCTAssertEqual(store.children, [AtomKey(atom1): [AtomKey(atom0)]])
-        XCTAssertEqual(store.dependencies, [AtomKey(atom0): [AtomKey(atom1)]])
+        #expect(value == 200)
+        #expect(store.children == [AtomKey(atom1): [AtomKey(atom0)]])
+        #expect(store.dependencies == [AtomKey(atom0): [AtomKey(atom1)]])
     }
 }

--- a/Tests/AtomsTests/Context/AtomViewContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomViewContextTests.swift
@@ -1,10 +1,11 @@
 import Combine
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomViewContextTests: XCTestCase {
+struct AtomViewContextTests {
     @MainActor
+    @Test
     func testRead() {
         let atom = TestValueAtom(value: 100)
         let store = AtomStore()
@@ -16,10 +17,11 @@ final class AtomViewContextTests: XCTestCase {
             subscription: Subscription()
         )
 
-        XCTAssertEqual(context.read(atom), 100)
+        #expect(context.read(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testSet() {
         let atom = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
@@ -31,14 +33,15 @@ final class AtomViewContextTests: XCTestCase {
             subscription: Subscription()
         )
 
-        XCTAssertEqual(context.watch(atom), 100)
+        #expect(context.watch(atom) == 100)
 
         context.set(200, for: atom)
 
-        XCTAssertEqual(context.watch(atom), 200)
+        #expect(context.watch(atom) == 200)
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let atom = TestPublisherAtom { Just(100) }
         let store = AtomStore()
@@ -50,15 +53,16 @@ final class AtomViewContextTests: XCTestCase {
             subscription: Subscription()
         )
 
-        XCTAssertTrue(context.watch(atom).isSuspending)
+        #expect(context.watch(atom).isSuspending)
 
         let value = await context.refresh(atom).value
 
-        XCTAssertEqual(value, 100)
-        XCTAssertEqual(context.watch(atom).value, 100)
+        #expect(value == 100)
+        #expect(context.watch(atom).value == 100)
     }
 
     @MainActor
+    @Test
     func testReset() {
         let atom = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
@@ -70,18 +74,19 @@ final class AtomViewContextTests: XCTestCase {
             subscription: Subscription()
         )
 
-        XCTAssertEqual(context.watch(atom), 0)
+        #expect(context.watch(atom) == 0)
 
         context[atom] = 100
 
-        XCTAssertEqual(context.watch(atom), 100)
+        #expect(context.watch(atom) == 100)
 
         context.reset(atom)
 
-        XCTAssertEqual(context.read(atom), 0)
+        #expect(context.read(atom) == 0)
     }
 
     @MainActor
+    @Test
     func testWatch() {
         let atom = TestStateAtom(defaultValue: 100)
         let store = AtomStore()
@@ -93,14 +98,15 @@ final class AtomViewContextTests: XCTestCase {
             subscription: Subscription()
         )
 
-        XCTAssertEqual(context.watch(atom), 100)
+        #expect(context.watch(atom) == 100)
 
         context[atom] = 200
 
-        XCTAssertEqual(context.watch(atom), 200)
+        #expect(context.watch(atom) == 200)
     }
 
     @MainActor
+    @Test
     func testBinding() {
         let atom = TestStateAtom(defaultValue: 0)
         let store = AtomStore()
@@ -114,15 +120,16 @@ final class AtomViewContextTests: XCTestCase {
 
         let binding = context.binding(atom)
 
-        XCTAssertEqual(context.read(atom), 0)
+        #expect(context.read(atom) == 0)
 
         binding.wrappedValue = 100
 
-        XCTAssertEqual(binding.wrappedValue, 100)
-        XCTAssertEqual(context.read(atom), 100)
+        #expect(binding.wrappedValue == 100)
+        #expect(context.read(atom) == 100)
     }
 
     @MainActor
+    @Test
     func testSnapshot() {
         let store = AtomStore()
         let rootScopeToken = ScopeKey.Token()
@@ -153,15 +160,13 @@ final class AtomViewContextTests: XCTestCase {
 
         let snapshot = context.snapshot()
 
-        XCTAssertEqual(snapshot.dependencies, dependencies)
-        XCTAssertEqual(snapshot.children, children)
-        XCTAssertEqual(
-            snapshot.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> },
-            caches
-        )
+        #expect(snapshot.dependencies == dependencies)
+        #expect(snapshot.children == children)
+        #expect(snapshot.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } == caches)
     }
 
     @MainActor
+    @Test
     func testUnsubscription() {
         let atom = TestValueAtom(value: 100)
         let key = AtomKey(atom)
@@ -175,9 +180,9 @@ final class AtomViewContextTests: XCTestCase {
         )
 
         context.watch(atom)
-        XCTAssertNotNil(store.caches[key])
+        #expect(store.caches[key] != nil)
 
         subscriberState = nil
-        XCTAssertNil(store.caches[key])
+        #expect(store.caches[key] == nil)
     }
 }

--- a/Tests/AtomsTests/Core/Atom/ModifiedAtomTests.swift
+++ b/Tests/AtomsTests/Core/Atom/ModifiedAtomTests.swift
@@ -1,23 +1,25 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ModifiedAtomTests: XCTestCase {
+struct ModifiedAtomTests {
     @MainActor
+    @Test
     func testKey() {
         let base = TestAtom(value: 0)
         let modifier = ChangesOfModifier<Int, String>(keyPath: \.description)
         let atom = ModifiedAtom(atom: base, modifier: modifier)
 
-        XCTAssertEqual(atom.key, atom.key)
-        XCTAssertEqual(atom.key.hashValue, atom.key.hashValue)
-        XCTAssertNotEqual(AnyHashable(atom.key), AnyHashable(modifier.key))
-        XCTAssertNotEqual(AnyHashable(atom.key).hashValue, AnyHashable(modifier.key).hashValue)
-        XCTAssertNotEqual(AnyHashable(atom.key), AnyHashable(base.key))
-        XCTAssertNotEqual(AnyHashable(atom.key).hashValue, AnyHashable(base.key).hashValue)
+        #expect(atom.key == atom.key)
+        #expect(atom.key.hashValue == atom.key.hashValue)
+        #expect(AnyHashable(atom.key) != AnyHashable(modifier.key))
+        #expect(AnyHashable(atom.key).hashValue != AnyHashable(modifier.key).hashValue)
+        #expect(AnyHashable(atom.key) != AnyHashable(base.key))
+        #expect(AnyHashable(atom.key).hashValue != AnyHashable(base.key).hashValue)
     }
 
     @MainActor
+    @Test
     func testValue() async {
         let base = TestStateAtom(defaultValue: "test")
         let modifier = ChangesOfModifier<String, Int>(keyPath: \.count)
@@ -26,7 +28,7 @@ final class ModifiedAtomTests: XCTestCase {
 
         do {
             // Initial value
-            XCTAssertEqual(context.watch(atom), 4)
+            #expect(context.watch(atom) == 4)
         }
 
         do {
@@ -36,7 +38,7 @@ final class ModifiedAtomTests: XCTestCase {
             }
 
             await context.waitForUpdate()
-            XCTAssertEqual(context.watch(atom), 8)
+            #expect(context.watch(atom) == 8)
         }
 
         do {
@@ -46,7 +48,7 @@ final class ModifiedAtomTests: XCTestCase {
                 100
             }
 
-            XCTAssertEqual(context.watch(atom), 100)
+            #expect(context.watch(atom) == 100)
         }
     }
 }

--- a/Tests/AtomsTests/Core/AtomCacheTests.swift
+++ b/Tests/AtomsTests/Core/AtomCacheTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomCacheTests: XCTestCase {
+struct AtomCacheTests {
     @MainActor
+    @Test
     func testUpdated() {
         let atom = TestAtom(value: 0)
         let scopeToken = ScopeKey.Token()
@@ -16,16 +17,17 @@ final class AtomCacheTests: XCTestCase {
         let cache = AtomCache(atom: atom, value: 0, scopeValues: scopeValues)
         let updated = cache.updated(value: 1)
 
-        XCTAssertEqual(updated.atom, atom)
-        XCTAssertEqual(updated.value, 1)
-        XCTAssertEqual(updated.scopeValues?.key, scopeToken.key)
+        #expect(updated.atom == atom)
+        #expect(updated.value == 1)
+        #expect(updated.scopeValues?.key == scopeToken.key)
     }
 
     @MainActor
+    @Test
     func testDescription() {
         let atom = TestAtom(value: 0)
         let cache = AtomCache(atom: atom, value: 0)
 
-        XCTAssertEqual(cache.description, "0")
+        #expect(cache.description == "0")
     }
 }

--- a/Tests/AtomsTests/Core/AtomKeyTests.swift
+++ b/Tests/AtomsTests/Core/AtomKeyTests.swift
@@ -1,27 +1,30 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomKeyTests: XCTestCase {
+struct AtomKeyTests {
+    @Test
     func testKeyHashableForSameAtoms() {
         let atom = TestAtom(value: 0)
         let key0 = AtomKey(atom)
         let key1 = AtomKey(atom)
 
-        XCTAssertEqual(key0, key1)
-        XCTAssertEqual(key0.hashValue, key1.hashValue)
+        #expect(key0 == key1)
+        #expect(key0.hashValue == key1.hashValue)
     }
 
+    @Test
     func testKeyHashableForDifferentAtoms() {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
         let key0 = AtomKey(atom0)
         let key1 = AtomKey(atom1)
 
-        XCTAssertNotEqual(key0, key1)
-        XCTAssertNotEqual(key0.hashValue, key1.hashValue)
+        #expect(key0 != key1)
+        #expect(key0.hashValue != key1.hashValue)
     }
 
+    @Test
     func testDictionaryKey() {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
@@ -34,19 +37,20 @@ final class AtomKeyTests: XCTestCase {
         dictionary[key1] = 200
         dictionary[key2] = 300
 
-        XCTAssertEqual(dictionary[key0], 100)
-        XCTAssertEqual(dictionary[key1], 300)
-        XCTAssertEqual(dictionary[key2], 300)
+        #expect(dictionary[key0] == 100)
+        #expect(dictionary[key1] == 300)
+        #expect(dictionary[key2] == 300)
     }
 
     @MainActor
+    @Test
     func testDescription() {
         let atom = TestAtom(value: 0)
         let scopeToken = ScopeKey.Token()
         let key0 = AtomKey(atom)
         let key1 = AtomKey(atom, scopeKey: scopeToken.key)
 
-        XCTAssertEqual(key0.description, "TestAtom<Int>")
-        XCTAssertEqual(key1.description, "TestAtom<Int> scope:\(scopeToken.key.description)")
+        #expect(key0.description == "TestAtom<Int>")
+        #expect(key1.description == "TestAtom<Int> scope:\(scopeToken.key.description)")
     }
 }

--- a/Tests/AtomsTests/Core/AtomProducerContextTests.swift
+++ b/Tests/AtomsTests/Core/AtomProducerContextTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomProducerContextTests: XCTestCase {
+struct AtomProducerContextTests {
     @MainActor
+    @Test
     func testUpdate() {
         let atom = TestValueAtom(value: 0)
         let transactionState = TransactionState(key: AtomKey(atom))
@@ -15,26 +16,28 @@ final class AtomProducerContextTests: XCTestCase {
 
         context.update(with: 1)
 
-        XCTAssertEqual(updatedValue, 1)
+        #expect(updatedValue == 1)
     }
 
     @MainActor
+    @Test
     func testOnTermination() {
         let atom = TestValueAtom(value: 0)
         let transactionState = TransactionState(key: AtomKey(atom))
         let context = AtomProducerContext<Int>(store: .dummy, transactionState: transactionState) { _ in }
 
         context.onTermination = {}
-        XCTAssertNotNil(context.onTermination)
+        #expect(context.onTermination != nil)
 
         transactionState.terminate()
-        XCTAssertNil(context.onTermination)
+        #expect(context.onTermination == nil)
 
         context.onTermination = {}
-        XCTAssertNil(context.onTermination)
+        #expect(context.onTermination == nil)
     }
 
     @MainActor
+    @Test
     func testTransaction() {
         let atom = TestValueAtom(value: 0)
         var didBegin = false
@@ -47,11 +50,12 @@ final class AtomProducerContextTests: XCTestCase {
 
         context.transaction { _ in }
 
-        XCTAssertTrue(didBegin)
-        XCTAssertTrue(didCommit)
+        #expect(didBegin)
+        #expect(didCommit)
     }
 
     @MainActor
+    @Test
     func testAsyncTransaction() async {
         let atom = TestValueAtom(value: 0)
         var didBegin = false
@@ -66,7 +70,7 @@ final class AtomProducerContextTests: XCTestCase {
             try? await Task.sleep(seconds: 0)
         }
 
-        XCTAssertTrue(didBegin)
-        XCTAssertTrue(didCommit)
+        #expect(didBegin)
+        #expect(didCommit)
     }
 }

--- a/Tests/AtomsTests/Core/Effect/AtomEffectBuilderTests.swift
+++ b/Tests/AtomsTests/Core/Effect/AtomEffectBuilderTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class AtomEffectBuilderTests: XCTestCase {
+struct AtomEffectBuilderTests {
     @MainActor
+    @Test
     func testSingleBlock() {
         let expected = TestEffect()
 
@@ -15,13 +16,14 @@ final class AtomEffectBuilderTests: XCTestCase {
         let effect = build()
         effect.callAll()
 
-        XCTAssertEqual(expected.initializingCount, 1)
-        XCTAssertEqual(expected.initializedCount, 1)
-        XCTAssertEqual(expected.updatedCount, 1)
-        XCTAssertEqual(expected.releasedCount, 1)
+        #expect(expected.initializingCount == 1)
+        #expect(expected.initializedCount == 1)
+        #expect(expected.updatedCount == 1)
+        #expect(expected.releasedCount == 1)
     }
 
     @MainActor
+    @Test
     func testMultipleBlock() {
         let expected0 = TestEffect()
         let expected1 = TestEffect()
@@ -38,14 +40,15 @@ final class AtomEffectBuilderTests: XCTestCase {
         effect.callAll()
 
         for expected in [expected0, expected1, expected2] {
-            XCTAssertEqual(expected.initializingCount, 1)
-            XCTAssertEqual(expected.initializedCount, 1)
-            XCTAssertEqual(expected.updatedCount, 1)
-            XCTAssertEqual(expected.releasedCount, 1)
+            #expect(expected.initializingCount == 1)
+            #expect(expected.initializedCount == 1)
+            #expect(expected.updatedCount == 1)
+            #expect(expected.releasedCount == 1)
         }
     }
 
     @MainActor
+    @Test
     func testIf() {
         let expected = TestEffect()
         var condition = true
@@ -60,22 +63,23 @@ final class AtomEffectBuilderTests: XCTestCase {
         let effectTrue = build()
         effectTrue.callAll()
 
-        XCTAssertEqual(expected.initializingCount, 1)
-        XCTAssertEqual(expected.initializedCount, 1)
-        XCTAssertEqual(expected.updatedCount, 1)
-        XCTAssertEqual(expected.releasedCount, 1)
+        #expect(expected.initializingCount == 1)
+        #expect(expected.initializedCount == 1)
+        #expect(expected.updatedCount == 1)
+        #expect(expected.releasedCount == 1)
 
         condition = false
         let effectFalse = build()
         effectFalse.callAll()
 
-        XCTAssertEqual(expected.initializingCount, 1)
-        XCTAssertEqual(expected.initializedCount, 1)
-        XCTAssertEqual(expected.updatedCount, 1)
-        XCTAssertEqual(expected.releasedCount, 1)
+        #expect(expected.initializingCount == 1)
+        #expect(expected.initializedCount == 1)
+        #expect(expected.updatedCount == 1)
+        #expect(expected.releasedCount == 1)
     }
 
     @MainActor
+    @Test
     func testEither() {
         let expectedTrue = TestEffect()
         let expectedFalse = TestEffect()
@@ -94,28 +98,29 @@ final class AtomEffectBuilderTests: XCTestCase {
         let effectTrue = build()
         effectTrue.callAll()
 
-        XCTAssertEqual(expectedTrue.initializingCount, 1)
-        XCTAssertEqual(expectedTrue.initializedCount, 1)
-        XCTAssertEqual(expectedTrue.updatedCount, 1)
-        XCTAssertEqual(expectedTrue.releasedCount, 1)
-        XCTAssertEqual(expectedFalse.initializingCount, 0)
-        XCTAssertEqual(expectedFalse.initializedCount, 0)
-        XCTAssertEqual(expectedFalse.updatedCount, 0)
-        XCTAssertEqual(expectedFalse.releasedCount, 0)
+        #expect(expectedTrue.initializingCount == 1)
+        #expect(expectedTrue.initializedCount == 1)
+        #expect(expectedTrue.updatedCount == 1)
+        #expect(expectedTrue.releasedCount == 1)
+        #expect(expectedFalse.initializingCount == 0)
+        #expect(expectedFalse.initializedCount == 0)
+        #expect(expectedFalse.updatedCount == 0)
+        #expect(expectedFalse.releasedCount == 0)
 
         condition = false
         let effectFalse = build()
         effectFalse.callAll()
 
         for expected in [expectedTrue, expectedFalse] {
-            XCTAssertEqual(expected.initializingCount, 1)
-            XCTAssertEqual(expected.initializedCount, 1)
-            XCTAssertEqual(expected.updatedCount, 1)
-            XCTAssertEqual(expected.releasedCount, 1)
+            #expect(expected.initializingCount == 1)
+            #expect(expected.initializedCount == 1)
+            #expect(expected.updatedCount == 1)
+            #expect(expected.releasedCount == 1)
         }
     }
 
     @MainActor
+    @Test
     func testLimitedAvailability() {
         let expected = TestEffect()
 
@@ -136,21 +141,22 @@ final class AtomEffectBuilderTests: XCTestCase {
         let effectTrue = buildTrue()
         effectTrue.callAll()
 
-        XCTAssertEqual(expected.initializingCount, 1)
-        XCTAssertEqual(expected.initializedCount, 1)
-        XCTAssertEqual(expected.updatedCount, 1)
-        XCTAssertEqual(expected.releasedCount, 1)
+        #expect(expected.initializingCount == 1)
+        #expect(expected.initializedCount == 1)
+        #expect(expected.updatedCount == 1)
+        #expect(expected.releasedCount == 1)
 
         let effectFalse = buildFalse()
         effectFalse.callAll()
 
-        XCTAssertEqual(expected.initializingCount, 1)
-        XCTAssertEqual(expected.initializedCount, 1)
-        XCTAssertEqual(expected.updatedCount, 1)
-        XCTAssertEqual(expected.releasedCount, 1)
+        #expect(expected.initializingCount == 1)
+        #expect(expected.initializedCount == 1)
+        #expect(expected.updatedCount == 1)
+        #expect(expected.releasedCount == 1)
     }
 
     @MainActor
+    @Test
     func testMixed() {
         let expected0 = TestEffect()
         let expected1 = TestEffect()
@@ -205,17 +211,17 @@ final class AtomEffectBuilderTests: XCTestCase {
         ]
 
         for expected in expectedEffects {
-            XCTAssertEqual(expected.initializingCount, 1)
-            XCTAssertEqual(expected.initializedCount, 1)
-            XCTAssertEqual(expected.updatedCount, 1)
-            XCTAssertEqual(expected.releasedCount, 1)
+            #expect(expected.initializingCount == 1)
+            #expect(expected.initializedCount == 1)
+            #expect(expected.updatedCount == 1)
+            #expect(expected.releasedCount == 1)
         }
 
         for unexpected in unexpectedEffects {
-            XCTAssertEqual(unexpected.initializingCount, 0)
-            XCTAssertEqual(unexpected.initializedCount, 0)
-            XCTAssertEqual(unexpected.updatedCount, 0)
-            XCTAssertEqual(unexpected.releasedCount, 0)
+            #expect(unexpected.initializingCount == 0)
+            #expect(unexpected.initializedCount == 0)
+            #expect(unexpected.updatedCount == 0)
+            #expect(unexpected.releasedCount == 0)
         }
     }
 }

--- a/Tests/AtomsTests/Core/EnvironmentTests.swift
+++ b/Tests/AtomsTests/Core/EnvironmentTests.swift
@@ -1,10 +1,11 @@
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class EnvironmentTests: XCTestCase {
+struct EnvironmentTests {
     @MainActor
+    @Test
     func testStore() {
         let store = AtomStore()
         let scopeToken = ScopeKey.Token()
@@ -14,6 +15,6 @@ final class EnvironmentTests: XCTestCase {
         store.caches = [AtomKey(atom): AtomCache(atom: atom, value: 100)]
         environment.store = .root(store: store, scopeKey: scopeToken.key)
 
-        XCTAssertEqual(environment.store?.read(atom), 100)
+        #expect(environment.store?.read(atom) == 100)
     }
 }

--- a/Tests/AtomsTests/Core/OverrideContainerTests.swift
+++ b/Tests/AtomsTests/Core/OverrideContainerTests.swift
@@ -1,50 +1,51 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class OverrideContainerTests: XCTestCase {
+struct OverrideContainerTests {
     @MainActor
+    @Test
     func testGetOverride() {
         let atom = TestAtom(value: 0)
         let otherAtom = TestAtom(value: 1)
         var overrideContainer = OverrideContainer()
 
-        XCTAssertNil(overrideContainer.getOverride(for: atom))
-        XCTAssertNil(overrideContainer.getOverride(for: otherAtom))
+        #expect(overrideContainer.getOverride(for: atom) == nil)
+        #expect(overrideContainer.getOverride(for: otherAtom) == nil)
 
         overrideContainer.addOverride(for: TestAtom<Int>.self) { _ in
             0
         }
 
-        XCTAssertEqual(overrideContainer.getOverride(for: atom)?.getValue(atom), 0)
-        XCTAssertEqual(overrideContainer.getOverride(for: otherAtom)?.getValue(atom), 0)
+        #expect(overrideContainer.getOverride(for: atom)?.getValue(atom) == 0)
+        #expect(overrideContainer.getOverride(for: otherAtom)?.getValue(atom) == 0)
 
         overrideContainer.addOverride(for: TestAtom<Int>.self) { _ in
             1
         }
 
-        XCTAssertEqual(overrideContainer.getOverride(for: atom)?.getValue(atom), 1)
-        XCTAssertEqual(overrideContainer.getOverride(for: otherAtom)?.getValue(atom), 1)
+        #expect(overrideContainer.getOverride(for: atom)?.getValue(atom) == 1)
+        #expect(overrideContainer.getOverride(for: otherAtom)?.getValue(atom) == 1)
 
         overrideContainer.addOverride(for: atom) { _ in
             2
         }
 
-        XCTAssertEqual(overrideContainer.getOverride(for: atom)?.getValue(atom), 2)
-        XCTAssertEqual(overrideContainer.getOverride(for: otherAtom)?.getValue(atom), 1)
+        #expect(overrideContainer.getOverride(for: atom)?.getValue(atom) == 2)
+        #expect(overrideContainer.getOverride(for: otherAtom)?.getValue(atom) == 1)
 
         overrideContainer.addOverride(for: atom) { _ in
             3
         }
 
-        XCTAssertEqual(overrideContainer.getOverride(for: atom)?.getValue(atom), 3)
-        XCTAssertEqual(overrideContainer.getOverride(for: otherAtom)?.getValue(atom), 1)
+        #expect(overrideContainer.getOverride(for: atom)?.getValue(atom) == 3)
+        #expect(overrideContainer.getOverride(for: otherAtom)?.getValue(atom) == 1)
 
         overrideContainer.addOverride(for: otherAtom) { _ in
             4
         }
 
-        XCTAssertEqual(overrideContainer.getOverride(for: atom)?.getValue(atom), 3)
-        XCTAssertEqual(overrideContainer.getOverride(for: otherAtom)?.getValue(atom), 4)
+        #expect(overrideContainer.getOverride(for: atom)?.getValue(atom) == 3)
+        #expect(overrideContainer.getOverride(for: otherAtom)?.getValue(atom) == 4)
     }
 }

--- a/Tests/AtomsTests/Core/ScopeIDTests.swift
+++ b/Tests/AtomsTests/Core/ScopeIDTests.swift
@@ -1,16 +1,17 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ScopeIDTests: XCTestCase {
+struct ScopeIDTests {
+    @Test
     func testHashable() {
         let id0 = ScopeID(0)
         let id1 = id0
         let id2 = ScopeID(1)
 
-        XCTAssertEqual(id0, id1)
-        XCTAssertNotEqual(id1, id2)
-        XCTAssertEqual(id0.hashValue, id1.hashValue)
-        XCTAssertNotEqual(id1.hashValue, id2.hashValue)
+        #expect(id0 == id1)
+        #expect(id1 != id2)
+        #expect(id0.hashValue == id1.hashValue)
+        #expect(id1.hashValue != id2.hashValue)
     }
 }

--- a/Tests/AtomsTests/Core/ScopeKeyTests.swift
+++ b/Tests/AtomsTests/Core/ScopeKeyTests.swift
@@ -1,13 +1,14 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ScopeKeyTests: XCTestCase {
+struct ScopeKeyTests {
     @MainActor
+    @Test
     func testDescription() {
         let token = ScopeKey.Token()
         let objectAddress = String(UInt(bitPattern: ObjectIdentifier(token)), radix: 16)
 
-        XCTAssertEqual(token.key.description, "0x\(objectAddress)")
+        #expect(token.key.description == "0x\(objectAddress)")
     }
 }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -1000,13 +1000,13 @@ struct StoreContextTests {
         // Initialize the atom state in the scoped context.
         _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
 
-        // The scoped observer should recive the update event.
+        // The scoped observer should receive the update event.
         #expect(snapshots.map(\.dependencies) == [expectedDependencies])
         #expect(snapshots.map(\.children) == [expectedChildren])
 
         context.set(20, for: TestDependency2Atom())
 
-        // The scoped observer should recive the update event.
+        // The scoped observer should receive the update event.
         #expect(snapshots.map(\.dependencies) == [expectedDependencies, expectedDependencies])
         #expect(snapshots.map(\.children) == [expectedChildren, expectedChildren])
     }

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -1,10 +1,11 @@
 import Combine
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class StoreContextTests: XCTestCase {
+struct StoreContextTests {
     @MainActor
+    @Test
     func testRead() {
         let store = AtomStore()
         let atom = TestAtom(value: 0)
@@ -19,22 +20,23 @@ final class StoreContextTests: XCTestCase {
             overrideContainer: OverrideContainer()
         )
 
-        XCTAssertEqual(context.read(atom), 0)
-        XCTAssertNil(store.caches[key])
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(context.read(atom) == 0)
+        #expect(store.caches[key] == nil)
+        #expect(snapshots.isEmpty)
 
         snapshots.removeAll()
         store.children[key] = [AtomKey(TestAtom(value: 1))]
-        XCTAssertEqual(context.read(atom), 0)
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(context.read(atom) == 0)
+        #expect(snapshots.isEmpty)
 
         snapshots.removeAll()
         store.caches[key] = AtomCache(atom: atom, value: 1)
-        XCTAssertEqual(context.read(atom), 1)
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(context.read(atom) == 1)
+        #expect(snapshots.isEmpty)
     }
 
     @MainActor
+    @Test
     func testSet() {
         let store = AtomStore()
         let subscriberToken = SubscriberKey.Token()
@@ -52,10 +54,10 @@ final class StoreContextTests: XCTestCase {
         )
 
         context.set(1, for: atom)
-        XCTAssertEqual(updateCount, 0)
-        XCTAssertNil(store.states[key])
-        XCTAssertNil(store.caches[key])
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(updateCount == 0)
+        #expect(store.states[key] == nil)
+        #expect(store.caches[key] == nil)
+        #expect(snapshots.isEmpty)
 
         snapshots.removeAll()
         store.caches[key] = AtomCache(atom: atom, value: 0)
@@ -65,27 +67,22 @@ final class StoreContextTests: XCTestCase {
             update: { updateCount += 1 }
         )
         context.set(2, for: atom)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 2]]
-        )
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertNil(store.states[key]?.transactionState)
-        XCTAssertEqual((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value, 2)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 2]])
+        #expect(updateCount == 1)
+        #expect(store.states[key]?.transactionState == nil)
+        #expect((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value == 2)
 
         snapshots.removeAll()
         context.set(3, for: atom)
-        XCTAssertEqual(updateCount, 2)
-        XCTAssertNotNil(store.states[key])
-        XCTAssertNil(store.states[key]?.transactionState)
-        XCTAssertEqual((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value, 3)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 3]]
-        )
+        #expect(updateCount == 2)
+        #expect(store.states[key] != nil)
+        #expect(store.states[key]?.transactionState == nil)
+        #expect((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value == 3)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 3]])
     }
 
     @MainActor
+    @Test
     func testModify() {
         let store = AtomStore()
         let subscriberToken = SubscriberKey.Token()
@@ -103,10 +100,10 @@ final class StoreContextTests: XCTestCase {
         )
 
         context.modify(atom) { $0 = 1 }
-        XCTAssertEqual(updateCount, 0)
-        XCTAssertNil(store.states[key])
-        XCTAssertNil(store.caches[key])
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(updateCount == 0)
+        #expect(store.states[key] == nil)
+        #expect(store.caches[key] == nil)
+        #expect(snapshots.isEmpty)
 
         snapshots.removeAll()
         store.caches[key] = AtomCache(atom: atom, value: 0)
@@ -116,27 +113,22 @@ final class StoreContextTests: XCTestCase {
             update: { updateCount += 1 }
         )
         context.modify(atom) { $0 = 2 }
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertNil(store.states[key]?.transactionState)
-        XCTAssertEqual((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value, 2)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 2]]
-        )
+        #expect(updateCount == 1)
+        #expect(store.states[key]?.transactionState == nil)
+        #expect((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value == 2)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 2]])
 
         snapshots.removeAll()
         context.modify(atom) { $0 = 3 }
-        XCTAssertEqual(updateCount, 2)
-        XCTAssertNotNil(store.states[key])
-        XCTAssertNil(store.states[key]?.transactionState)
-        XCTAssertEqual((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value, 3)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 3]]
-        )
+        #expect(updateCount == 2)
+        #expect(store.states[key] != nil)
+        #expect(store.states[key]?.transactionState == nil)
+        #expect((store.caches[key] as? AtomCache<TestStateAtom<Int>>)?.value == 3)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 3]])
     }
 
     @MainActor
+    @Test
     func testWatch() {
         let store = AtomStore()
         let atom = TestAtom(value: 0)
@@ -156,24 +148,25 @@ final class StoreContextTests: XCTestCase {
             overrideContainer: OverrideContainer()
         )
 
-        XCTAssertEqual(context.watch(dependency0, in: transactionState), 0)
-        XCTAssertEqual(store.dependencies, [key: [dependency0Key]])
-        XCTAssertEqual(store.children, [dependency0Key: [key]])
-        XCTAssertEqual((store.caches[dependency0Key] as? AtomCache<TestStateAtom<Int>>)?.value, 0)
-        XCTAssertNotNil(store.states[dependency0Key])
-        XCTAssertTrue(snapshots.flatMap(\.caches).isEmpty)
+        #expect(context.watch(dependency0, in: transactionState) == 0)
+        #expect(store.dependencies == [key: [dependency0Key]])
+        #expect(store.children == [dependency0Key: [key]])
+        #expect((store.caches[dependency0Key] as? AtomCache<TestStateAtom<Int>>)?.value == 0)
+        #expect(store.states[dependency0Key] != nil)
+        #expect(snapshots.flatMap(\.caches).isEmpty)
 
         transactionState.terminate()
 
-        XCTAssertEqual(context.watch(dependency1, in: transactionState), 1)
-        XCTAssertEqual(store.dependencies, [key: [dependency0Key]])
-        XCTAssertEqual(store.children, [dependency0Key: [key]])
-        XCTAssertNil(store.caches[dependency1Key])
-        XCTAssertNil(store.states[dependency1Key])
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(context.watch(dependency1, in: transactionState) == 1)
+        #expect(store.dependencies == [key: [dependency0Key]])
+        #expect(store.children == [dependency0Key: [key]])
+        #expect(store.caches[dependency1Key] == nil)
+        #expect(store.states[dependency1Key] == nil)
+        #expect(snapshots.isEmpty)
     }
 
     @MainActor
+    @Test
     func testWatchFromView() {
         struct DependencyAtom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -213,35 +206,30 @@ final class StoreContextTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(initialValue, 0)
-        XCTAssertTrue(store.subscribes[subscriber.key]?.contains(key) ?? false)
-        XCTAssertNotNil(store.subscriptions[key]?[subscriber.key])
-        XCTAssertEqual((store.caches[key] as? AtomCache<TestAtom>)?.value, 0)
-        XCTAssertEqual((store.caches[dependencyKey] as? AtomCache<DependencyAtom>)?.value, 0)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 0, dependencyKey: 0]]
-        )
+        #expect(initialValue == 0)
+        #expect(store.subscribes[subscriber.key]?.contains(key) ?? false)
+        #expect(store.subscriptions[key]?[subscriber.key] != nil)
+        #expect((store.caches[key] as? AtomCache<TestAtom>)?.value == 0)
+        #expect((store.caches[dependencyKey] as? AtomCache<DependencyAtom>)?.value == 0)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 0, dependencyKey: 0]])
 
         snapshots.removeAll()
         store.subscriptions[key]?[subscriber.key]?.update()
         subscriberState = nil
 
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertNil(store.subscribes[subscriber.key])
-        XCTAssertNil(store.caches[key])
-        XCTAssertNil(store.states[key])
-        XCTAssertNil(store.subscriptions[key])
-        XCTAssertNil(store.caches[dependencyKey])
-        XCTAssertNil(store.states[dependencyKey])
-        XCTAssertNil(store.subscriptions[dependencyKey])
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[:]]
-        )
+        #expect(updateCount == 1)
+        #expect(store.subscribes[subscriber.key] == nil)
+        #expect(store.caches[key] == nil)
+        #expect(store.states[key] == nil)
+        #expect(store.subscriptions[key] == nil)
+        #expect(store.caches[dependencyKey] == nil)
+        #expect(store.states[dependencyKey] == nil)
+        #expect(store.subscriptions[dependencyKey] == nil)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[:]])
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let store = AtomStore()
         let subscriberState = SubscriberState()
@@ -259,10 +247,10 @@ final class StoreContextTests: XCTestCase {
         )
 
         let phase0 = await context.refresh(atom)
-        XCTAssertEqual(phase0.value, 0)
-        XCTAssertNil(store.caches[key])
-        XCTAssertNil(store.states[key])
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(phase0.value == 0)
+        #expect(store.caches[key] == nil)
+        #expect(store.states[key] == nil)
+        #expect(snapshots.isEmpty)
 
         var updateCount = 0
         let phase1 = context.watch(
@@ -273,19 +261,16 @@ final class StoreContextTests: XCTestCase {
             }
         )
 
-        XCTAssertTrue(phase1.isSuspending)
+        #expect(phase1.isSuspending)
 
         snapshots.removeAll()
 
         let phase2 = await context.refresh(atom)
-        XCTAssertEqual(phase2.value, 0)
-        XCTAssertNotNil(store.states[key])
-        XCTAssertEqual((store.caches[key] as? AtomCache<TestPublisherAtom<Just<Int>>>)?.value, .success(0))
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? AsyncPhase<Int, Never> } },
-            [[key: .success(0)]]
-        )
+        #expect(phase2.value == 0)
+        #expect(store.states[key] != nil)
+        #expect((store.caches[key] as? AtomCache<TestPublisherAtom<Just<Int>>>)?.value == .success(0))
+        #expect(updateCount == 1)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? AsyncPhase<Int, Never> } } == [[key: .success(0)]])
 
         let scopeToken = ScopeKey.Token()
         let overrideAtomKey = AtomKey(atom, scopeKey: scopeToken.key)
@@ -300,18 +285,16 @@ final class StoreContextTests: XCTestCase {
         )
 
         let phase3 = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
-        XCTAssertEqual(phase3.value, 1)
+        #expect(phase3.value == 1)
 
         let phase4 = await scopedContext.refresh(atom)
-        XCTAssertEqual(phase4.value, 1)
-        XCTAssertNotNil(store.states[overrideAtomKey])
-        XCTAssertEqual(
-            (store.caches[overrideAtomKey] as? AtomCache<TestPublisherAtom<Just<Int>>>)?.value,
-            .success(1)
-        )
+        #expect(phase4.value == 1)
+        #expect(store.states[overrideAtomKey] != nil)
+        #expect((store.caches[overrideAtomKey] as? AtomCache<TestPublisherAtom<Just<Int>>>)?.value == .success(1))
     }
 
     @MainActor
+    @Test
     func testRefreshNotCached() async {
         let store = AtomStore()
         let atom = TestAsyncPhaseAtom<Int, Never> { .success(0) }
@@ -331,10 +314,11 @@ final class StoreContextTests: XCTestCase {
             )
 
         let phase = await scopedContext.refresh(atom)
-        XCTAssertEqual(phase.value, 1)
+        #expect(phase.value == 1)
     }
 
     @MainActor
+    @Test
     func testReset() {
         let store = AtomStore()
         let subscriberState = SubscriberState()
@@ -352,9 +336,9 @@ final class StoreContextTests: XCTestCase {
         )
 
         context.reset(atom)
-        XCTAssertNil(store.caches[key])
-        XCTAssertNil(store.states[key])
-        XCTAssertTrue(snapshots.isEmpty)
+        #expect(store.caches[key] == nil)
+        #expect(store.states[key] == nil)
+        #expect(snapshots.isEmpty)
 
         var updateCount = 0
 
@@ -367,22 +351,17 @@ final class StoreContextTests: XCTestCase {
         )
         snapshots.removeAll()
         context.set(1, for: atom)
-        XCTAssertEqual(updateCount, 1)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 1]]
-        )
+        #expect(updateCount == 1)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 1]])
 
         snapshots.removeAll()
         context.reset(atom)
-        XCTAssertEqual(updateCount, 2)
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0.value as? Int } },
-            [[key: 0]]
-        )
+        #expect(updateCount == 2)
+        #expect(snapshots.map { $0.caches.mapValues { $0.value as? Int } } == [[key: 0]])
     }
 
     @MainActor
+    @Test
     func testUnwatch() {
         let store = AtomStore()
         let subscriberState = SubscriberState()
@@ -393,30 +372,19 @@ final class StoreContextTests: XCTestCase {
 
         _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
 
-        XCTAssertEqual(
-            store.caches.mapValues { $0.value as? Int },
-            [AtomKey(atom): 0]
-        )
+        #expect(store.caches.mapValues { $0.value as? Int } == [AtomKey(atom): 0])
 
-        XCTAssertEqual(
-            store.subscribes,
-            [subscriber.key: [AtomKey(atom)]]
-        )
+        #expect(store.subscribes == [subscriber.key: [AtomKey(atom)]])
 
         context.unwatch(atom, subscriber: subscriber)
 
-        XCTAssertEqual(
-            store.caches.mapValues { $0.value as? Int },
-            [:]
-        )
+        #expect(store.caches.mapValues { $0.value as? Int } == [:])
 
-        XCTAssertEqual(
-            store.subscribes,
-            [subscriber.key: []]
-        )
+        #expect(store.subscribes == [subscriber.key: []])
     }
 
     @MainActor
+    @Test
     func testSnapshotAndRestore() {
         let store = AtomStore()
         let rootScopeToken = ScopeKey.Token()
@@ -442,15 +410,13 @@ final class StoreContextTests: XCTestCase {
 
         let snapshot = context.snapshot()
 
-        XCTAssertEqual(snapshot.dependencies, dependencies)
-        XCTAssertEqual(snapshot.children, children)
-        XCTAssertEqual(
-            snapshot.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> },
-            caches
-        )
+        #expect(snapshot.dependencies == dependencies)
+        #expect(snapshot.children == children)
+        #expect(snapshot.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } == caches)
     }
 
     @MainActor
+    @Test
     func testOverride() {
         let store = AtomStore()
         let atom0 = TestAtom(value: 0)
@@ -488,13 +454,12 @@ final class StoreContextTests: XCTestCase {
                 }
         )
 
-        XCTAssertEqual(scoped1Context.watch(atom0, subscriber: subscriber, subscription: Subscription()), 10)
-        XCTAssertEqual(scoped1Context.watch(atom1, subscriber: subscriber, subscription: Subscription()), 20)
-        XCTAssertEqual(scoped2Context.watch(atom0, subscriber: subscriber, subscription: Subscription()), 30)
-        XCTAssertEqual(scoped2Context.watch(atom1, subscriber: subscriber, subscription: Subscription()), 30)
-        XCTAssertEqual(
-            store.caches.compactMapValues { $0 as? AtomCache<TestAtom<Int>> },
-            [
+        #expect(scoped1Context.watch(atom0, subscriber: subscriber, subscription: Subscription()) == 10)
+        #expect(scoped1Context.watch(atom1, subscriber: subscriber, subscription: Subscription()) == 20)
+        #expect(scoped2Context.watch(atom0, subscriber: subscriber, subscription: Subscription()) == 30)
+        #expect(scoped2Context.watch(atom1, subscriber: subscriber, subscription: Subscription()) == 30)
+        #expect(
+            store.caches.compactMapValues { $0 as? AtomCache<TestAtom<Int>> } == [
                 AtomKey(atom0): AtomCache(atom: atom0, value: 10),
                 AtomKey(atom1, scopeKey: scope1Token.key): AtomCache(atom: atom1, value: 20),
                 AtomKey(atom0, scopeKey: scope2Token.key): AtomCache(atom: atom0, value: 30),
@@ -504,6 +469,7 @@ final class StoreContextTests: XCTestCase {
     }
 
     @MainActor
+    @Test
     func testScopedOverride() async {
         struct TestDependency1Atom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -572,34 +538,22 @@ final class StoreContextTests: XCTestCase {
         )
 
         // Should return default values in the scope that atoms are not overridden.
-        XCTAssertEqual(
-            context.watch(dependency1Atom, subscriber: subscriber, subscription: Subscription()),
-            1
-        )
-        XCTAssertEqual(
-            context.watch(dependency2Atom, subscriber: subscriber, subscription: Subscription()),
-            2
-        )
-        XCTAssertEqual(
-            scoped1Context.watch(dependency1Atom, subscriber: subscriber, subscription: Subscription()),
-            10
-        )
-        XCTAssertEqual(
-            scoped2Context.watch(dependency2Atom, subscriber: subscriber, subscription: Subscription()),
-            20
-        )
+        #expect(context.watch(dependency1Atom, subscriber: subscriber, subscription: Subscription()) == 1)
+        #expect(context.watch(dependency2Atom, subscriber: subscriber, subscription: Subscription()) == 2)
+        #expect(scoped1Context.watch(dependency1Atom, subscriber: subscriber, subscription: Subscription()) == 10)
+        #expect(scoped2Context.watch(dependency2Atom, subscriber: subscriber, subscription: Subscription()) == 20)
 
         // Shouldn't set the value in the scope that atoms are not overridden.
         scoped1Context.set(100, for: dependency1Atom)
-        XCTAssertEqual(context.read(dependency1Atom), 1)
+        #expect(context.read(dependency1Atom) == 1)
 
         // Shouldn't modify the value in the scope that atoms are not overridden.
         scoped1Context.modify(dependency1Atom) { $0 = 1000 }
-        XCTAssertEqual(context.read(dependency1Atom), 1)
+        #expect(context.read(dependency1Atom) == 1)
 
         // Shouldn't reset the value in the scope that atoms are not overridden.
         context.reset(dependency1Atom)
-        XCTAssertEqual(scoped1Context.read(dependency1Atom), 1000)
+        #expect(scoped1Context.read(dependency1Atom) == 1000)
 
         context.unwatch(dependency1Atom, subscriber: subscriber)
         context.unwatch(dependency2Atom, subscriber: subscriber)
@@ -607,8 +561,8 @@ final class StoreContextTests: XCTestCase {
         scoped2Context.unwatch(dependency2Atom, subscriber: subscriber)
 
         // Override for `scoped1Context` shouldn't inherited to `scoped2Context`.
-        XCTAssertEqual(scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()), 21)
-        XCTAssertEqual(scoped2Context.watch(publisherAtom, subscriber: subscriber, subscription: Subscription()), .suspending)
+        #expect(scoped2Context.watch(atom, subscriber: subscriber, subscription: Subscription()) == 21)
+        #expect(scoped2Context.watch(publisherAtom, subscriber: subscriber, subscription: Subscription()) == .suspending)
 
         // Should set the value and then update the dependent atoms transitively.
         scoped2Context.set(20, for: dependency1Atom)
@@ -617,44 +571,43 @@ final class StoreContextTests: XCTestCase {
         context.set(30, for: dependency1Atom)
 
         // Should return overridden values.
-        XCTAssertEqual(scoped2Context.read(atom), 50)
-        XCTAssertEqual(scoped2Context.read(dependency1Atom), 30)
-        XCTAssertEqual(scoped2Context.read(dependency2Atom), 20)
+        #expect(scoped2Context.read(atom) == 50)
+        #expect(scoped2Context.read(dependency1Atom) == 30)
+        #expect(scoped2Context.read(dependency2Atom) == 20)
 
         // Should return the value cached when accessed via the `scoped2Context` as it's cached as a shared value.
-        XCTAssertEqual(context.read(atom), 50)
+        #expect(context.read(atom) == 50)
 
         // Should modify the value because the `atom` depends on the shared `dependency1Atom`
         // and the `dependency1Atom` is scoped for `scoped2Context`.
         scoped2Context.modify(dependency1Atom) { $0 = 40 }
-        XCTAssertEqual(scoped2Context.read(dependency1Atom), 40)
+        #expect(scoped2Context.read(dependency1Atom) == 40)
 
         // Shouldn't modify the value because `dependency2Atom` is scoped for `scoped2Context`.
         context.modify(dependency2Atom) { $0 = 50 }
-        XCTAssertEqual(scoped2Context.read(dependency2Atom), 20)
-        XCTAssertEqual(scoped2Context.read(atom), 60)
+        #expect(scoped2Context.read(dependency2Atom) == 20)
+        #expect(scoped2Context.read(atom) == 60)
 
         do {
             let phase = await scoped2Context.refresh(publisherAtom)
-            XCTAssertEqual(phase, .success(60))
+            #expect(phase == .success(60))
         }
 
         // Should reset the value.
         scoped2Context.reset(dependency1Atom)
-        XCTAssertEqual(scoped2Context.read(dependency1Atom), 1)
-        XCTAssertEqual(scoped2Context.read(atom), 21)
+        #expect(scoped2Context.read(dependency1Atom) == 1)
+        #expect(scoped2Context.read(atom) == 21)
 
         do {
             let phase = await scoped2Context.refresh(publisherAtom)
-            XCTAssertEqual(phase, .success(21))
+            #expect(phase == .success(21))
         }
 
         // Should add 'atom' as a dependency of `transactionAtom`.
-        XCTAssertEqual(scoped2Context.watch(atom, in: transactionState), 21)
+        #expect(scoped2Context.watch(atom, in: transactionState) == 21)
 
-        XCTAssertEqual(
-            store.dependencies,
-            [
+        #expect(
+            store.dependencies == [
                 AtomKey(transactionAtom): [
                     AtomKey(atom)
                 ],
@@ -668,9 +621,8 @@ final class StoreContextTests: XCTestCase {
                 ],
             ]
         )
-        XCTAssertEqual(
-            store.children,
-            [
+        #expect(
+            store.children == [
                 AtomKey(atom): [
                     AtomKey(transactionAtom)
                 ],
@@ -684,36 +636,32 @@ final class StoreContextTests: XCTestCase {
                 ],
             ]
         )
-        XCTAssertEqual(
-            store.caches.mapValues { $0 as? AtomCache<TestAtom> },
-            [
+        #expect(
+            store.caches.mapValues { $0 as? AtomCache<TestAtom> } == [
                 AtomKey(publisherAtom): nil,
                 AtomKey(atom): AtomCache(atom: atom, value: 21),
                 AtomKey(dependency1Atom): nil,
                 AtomKey(dependency2Atom, scopeKey: scope2Token.key): nil,
             ]
         )
-        XCTAssertEqual(
-            store.caches.mapValues { $0 as? AtomCache<TestPublisherAtom> },
-            [
+        #expect(
+            store.caches.mapValues { $0 as? AtomCache<TestPublisherAtom> } == [
                 AtomKey(publisherAtom): AtomCache(atom: publisherAtom, value: .success(21)),
                 AtomKey(atom): nil,
                 AtomKey(dependency1Atom): nil,
                 AtomKey(dependency2Atom, scopeKey: scope2Token.key): nil,
             ]
         )
-        XCTAssertEqual(
-            store.caches.mapValues { $0 as? AtomCache<TestDependency1Atom> },
-            [
+        #expect(
+            store.caches.mapValues { $0 as? AtomCache<TestDependency1Atom> } == [
                 AtomKey(publisherAtom): nil,
                 AtomKey(atom): nil,
                 AtomKey(dependency1Atom): AtomCache(atom: dependency1Atom, value: 1),
                 AtomKey(dependency2Atom, scopeKey: scope2Token.key): nil,
             ]
         )
-        XCTAssertEqual(
-            store.caches.mapValues { $0 as? AtomCache<TestDependency2Atom> },
-            [
+        #expect(
+            store.caches.mapValues { $0 as? AtomCache<TestDependency2Atom> } == [
                 AtomKey(publisherAtom): nil,
                 AtomKey(atom): nil,
                 AtomKey(dependency1Atom): nil,
@@ -721,9 +669,8 @@ final class StoreContextTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(
-            store.subscribes,
-            [
+        #expect(
+            store.subscribes == [
                 subscriber.key: [
                     AtomKey(atom),
                     AtomKey(publisherAtom),
@@ -733,6 +680,7 @@ final class StoreContextTests: XCTestCase {
     }
 
     @MainActor
+    @Test
     func testOverrideCrossScopeBoundary() async {
         struct TestDependency1Atom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -788,20 +736,14 @@ final class StoreContextTests: XCTestCase {
         _ = context.watch(TestDependency4Atom(), subscriber: subscriber, subscription: Subscription())
 
         // Initialize the atom state in the scoped context.
-        XCTAssertEqual(
-            scopedContext.watch(TestAtom(), subscriber: subscriber, subscription: Subscription()),
-            24
-        )
+        #expect(scopedContext.watch(TestAtom(), subscriber: subscriber, subscription: Subscription()) == 24)
 
         await Task.yield {
             context.read(TestDependency4Atom()).isSuccess
         }
 
         // The updated value should reflect the scoped overrides.
-        XCTAssertEqual(
-            scopedContext.watch(TestAtom(), subscriber: subscriber, subscription: Subscription()),
-            28
-        )
+        #expect(scopedContext.watch(TestAtom(), subscriber: subscriber, subscription: Subscription()) == 28)
 
         // Update one of the dependency atoms from non-scoped context.
         context.set(10, for: TestDependency1Atom())
@@ -811,13 +753,11 @@ final class StoreContextTests: XCTestCase {
         }
 
         // The updated value should reflect the scoped overrides.
-        XCTAssertEqual(
-            scopedContext.watch(TestAtom(), subscriber: subscriber, subscription: Subscription()),
-            37
-        )
+        #expect(scopedContext.watch(TestAtom(), subscriber: subscriber, subscription: Subscription()) == 37)
     }
 
     @MainActor
+    @Test
     func testRelease() {
         let store = AtomStore()
         let rootScopeToken = ScopeKey.Token()
@@ -829,13 +769,14 @@ final class StoreContextTests: XCTestCase {
         let subscriber = Subscriber(subscriberState)
 
         _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
-        XCTAssertNotNil(store.caches[key])
+        #expect(store.caches[key] != nil)
 
         context.unwatch(atom, subscriber: subscriber)
-        XCTAssertNil(store.caches[key])
+        #expect(store.caches[key] == nil)
     }
 
     @MainActor
+    @Test
     func testObservers() {
         let subscriberState = SubscriberState()
         let subscriber = Subscriber(subscriberState)
@@ -876,9 +817,8 @@ final class StoreContextTests: XCTestCase {
         _ = context.watch(atom1, subscriber: subscriber, subscription: Subscription())
         _ = context.watch(atom2, subscriber: subscriber, subscription: Subscription())
 
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
-            [
+        #expect(
+            snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } } == [
                 [
                     AtomKey(atom0): AtomCache(atom: atom0, value: 0)
                 ],
@@ -899,9 +839,8 @@ final class StoreContextTests: XCTestCase {
                 ],
             ]
         )
-        XCTAssertEqual(
-            scopedSnapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
-            [
+        #expect(
+            scopedSnapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } } == [
                 [
                     AtomKey(atom0): AtomCache(atom: atom0, value: 0)
                 ],
@@ -920,9 +859,8 @@ final class StoreContextTests: XCTestCase {
         scoped2Context.reset(atom1)
         context.reset(atom2)
 
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
-            [
+        #expect(
+            snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } } == [
                 [
                     AtomKey(atom0): AtomCache(atom: atom0, value: 0),
                     AtomKey(atom1, scopeKey: scope2Token.key): AtomCache(atom: atom1, value: 100),
@@ -943,9 +881,8 @@ final class StoreContextTests: XCTestCase {
                 ],
             ]
         )
-        XCTAssertEqual(
-            scopedSnapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
-            [
+        #expect(
+            scopedSnapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } } == [
                 [
                     AtomKey(atom0): AtomCache(atom: atom0, value: 0),
                     AtomKey(atom1, scopeKey: scope2Token.key): AtomCache(atom: atom1, value: 100),
@@ -969,9 +906,8 @@ final class StoreContextTests: XCTestCase {
         scoped2Context.unwatch(atom1, subscriber: subscriber)
         context.unwatch(atom2, subscriber: subscriber)
 
-        XCTAssertEqual(
-            snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
-            [
+        #expect(
+            snapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } } == [
                 [
                     AtomKey(atom1, scopeKey: scope2Token.key): AtomCache(atom: atom1, value: 100),
                     AtomKey(atom1): AtomCache(atom: atom1, value: 1),
@@ -988,9 +924,8 @@ final class StoreContextTests: XCTestCase {
                 ],
             ]
         )
-        XCTAssertEqual(
-            scopedSnapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } },
-            [
+        #expect(
+            scopedSnapshots.map { $0.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } } == [
                 [
 
                     AtomKey(atom1): AtomCache(atom: atom1, value: 1),
@@ -1001,6 +936,7 @@ final class StoreContextTests: XCTestCase {
     }
 
     @MainActor
+    @Test
     func testObserversCrossScopeBoundary() async {
         struct TestDependency1Atom: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -1065,17 +1001,18 @@ final class StoreContextTests: XCTestCase {
         _ = scopedContext.watch(atom, subscriber: subscriber, subscription: Subscription())
 
         // The scoped observer should recive the update event.
-        XCTAssertEqual(snapshots.map(\.dependencies), [expectedDependencies])
-        XCTAssertEqual(snapshots.map(\.children), [expectedChildren])
+        #expect(snapshots.map(\.dependencies) == [expectedDependencies])
+        #expect(snapshots.map(\.children) == [expectedChildren])
 
         context.set(20, for: TestDependency2Atom())
 
         // The scoped observer should recive the update event.
-        XCTAssertEqual(snapshots.map(\.dependencies), [expectedDependencies, expectedDependencies])
-        XCTAssertEqual(snapshots.map(\.children), [expectedChildren, expectedChildren])
+        #expect(snapshots.map(\.dependencies) == [expectedDependencies, expectedDependencies])
+        #expect(snapshots.map(\.children) == [expectedChildren, expectedChildren])
     }
 
     @MainActor
+    @Test
     func testRestore() {
         let store = AtomStore()
         let rootScopeToken = ScopeKey.Token()
@@ -1115,14 +1052,13 @@ final class StoreContextTests: XCTestCase {
         context.restore(snapshot)
 
         // Notifies updated only for the subscriptions of the atoms that are restored.
-        XCTAssertEqual(updated, [AtomKey(atom0), AtomKey(atom1)])
-        XCTAssertEqual(store.dependencies, [AtomKey(atom0): [AtomKey(atom1)]])
-        XCTAssertEqual(store.children, [AtomKey(atom1): [AtomKey(atom0)]])
+        #expect(updated == [AtomKey(atom0), AtomKey(atom1)])
+        #expect(store.dependencies == [AtomKey(atom0): [AtomKey(atom1)]])
+        #expect(store.children == [AtomKey(atom1): [AtomKey(atom0)]])
 
         // Do not delete caches added after the snapshot was taken.
-        XCTAssertEqual(
-            store.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> },
-            [
+        #expect(
+            store.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } == [
                 AtomKey(atom0): AtomCache(atom: atom0, value: 0),
                 AtomKey(atom1): AtomCache(atom: atom1, value: 1),
                 AtomKey(atom2): AtomCache(atom: atom2, value: 2),
@@ -1133,21 +1069,21 @@ final class StoreContextTests: XCTestCase {
         store.subscriptions.removeAll()
         context.restore(snapshot)
 
-        XCTAssertEqual(store.dependencies, [:])
-        XCTAssertEqual(store.children, [:])
+        #expect(store.dependencies == [:])
+        #expect(store.children == [:])
 
         // Caches added after the snapshot was taken are not forcibly released by restore,
         // but this is not a problem since the cache should originally be released
         // when the subscription is released.
-        XCTAssertEqual(
-            store.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> },
-            [
+        #expect(
+            store.caches.mapValues { $0 as? AtomCache<TestAtom<Int>> } == [
                 AtomKey(atom2): AtomCache(atom: atom2, value: 2)
             ]
         )
     }
 
     @MainActor
+    @Test
     func testEffect() {
         let store = AtomStore()
         let rootScopeToken = ScopeKey.Token()
@@ -1162,56 +1098,57 @@ final class StoreContextTests: XCTestCase {
         _ = context.watch(atom, subscriber: subscriber, subscription: Subscription())
         _ = context.watch(upstreamAtom, in: TransactionState(key: key))
 
-        XCTAssertTrue((store.states[key]?.effect as? TestEffect) === effect)
-        XCTAssertEqual(effect.initializingCount, 1)
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 0)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect((store.states[key]?.effect as? TestEffect) === effect)
+        #expect(effect.initializingCount == 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 0)
+        #expect(effect.releasedCount == 0)
 
         context.set(1, for: atom)
 
-        XCTAssertTrue((store.states[key]?.effect as? TestEffect) === effect)
-        XCTAssertEqual(effect.initializingCount, 1)
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 1)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect((store.states[key]?.effect as? TestEffect) === effect)
+        #expect(effect.initializingCount == 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 1)
+        #expect(effect.releasedCount == 0)
 
         context.set(2, for: atom)
         context.set(3, for: atom)
         context.set(4, for: atom)
 
-        XCTAssertTrue((store.states[key]?.effect as? TestEffect) === effect)
-        XCTAssertEqual(effect.initializingCount, 1)
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 4)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect((store.states[key]?.effect as? TestEffect) === effect)
+        #expect(effect.initializingCount == 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 4)
+        #expect(effect.releasedCount == 0)
 
         context.set("Updated", for: upstreamAtom)
 
-        XCTAssertTrue((store.states[key]?.effect as? TestEffect) === effect)
-        XCTAssertEqual(effect.initializingCount, 1)
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 5)
-        XCTAssertEqual(effect.releasedCount, 0)
+        #expect((store.states[key]?.effect as? TestEffect) === effect)
+        #expect(effect.initializingCount == 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 5)
+        #expect(effect.releasedCount == 0)
 
         context.unwatch(atom, subscriber: subscriber)
 
-        XCTAssertNil(store.states[key])
-        XCTAssertEqual(effect.initializingCount, 1)
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 5)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(store.states[key] == nil)
+        #expect(effect.initializingCount == 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 5)
+        #expect(effect.releasedCount == 1)
 
         context.set(5, for: atom)
 
-        XCTAssertNil(store.states[key])
-        XCTAssertEqual(effect.initializingCount, 1)
-        XCTAssertEqual(effect.initializedCount, 1)
-        XCTAssertEqual(effect.updatedCount, 5)
-        XCTAssertEqual(effect.releasedCount, 1)
+        #expect(store.states[key] == nil)
+        #expect(effect.initializingCount == 1)
+        #expect(effect.initializedCount == 1)
+        #expect(effect.updatedCount == 5)
+        #expect(effect.releasedCount == 1)
     }
 
     @MainActor
+    @Test
     func testEffectCrossScopeBoundary() async {
         struct TestDependencyAtom: ValueAtom, Hashable {
             func value(context: Context) -> Int {
@@ -1295,22 +1232,22 @@ final class StoreContextTests: XCTestCase {
         let testAtom = TestAtom(testEffect: testEffect)
         let testAsyncAtom = TestAsyncAtom(testEffect: testEffect)
 
-        func assert(file: StaticString = #filePath, line: UInt = #line) {
-            XCTAssertEqual(testEffect.value1, 1, file: file, line: line)
-            XCTAssertEqual(testEffect.value2, 1, file: file, line: line)
+        func assert(sourceLocation: Testing.SourceLocation = #_sourceLocation) {
+            #expect(testEffect.value1 == 1, sourceLocation: sourceLocation)
+            #expect(testEffect.value2 == 1, sourceLocation: sourceLocation)
         }
 
         let value0 = context.read(testAtom)
         assert()
-        XCTAssertEqual(value0, 1)
+        #expect(value0 == 1)
 
         let value1 = context.watch(testAtom, subscriber: subscriber, subscription: Subscription())
         assert()
-        XCTAssertEqual(value1, 1)
+        #expect(value1 == 1)
 
         let value2 = context.watch(testAsyncAtom, subscriber: subscriber, subscription: Subscription())
         assert()
-        XCTAssertEqual(value2, .suspending)
+        #expect(value2 == .suspending)
 
         scopedContext.set(1, for: testAtom)
         assert()
@@ -1320,7 +1257,7 @@ final class StoreContextTests: XCTestCase {
 
         let value3 = await scopedContext.refresh(testAsyncAtom)
         assert()
-        XCTAssertEqual(value3, .success(1))
+        #expect(value3 == .success(1))
 
         scopedContext.reset(testAsyncAtom)
         assert()
@@ -1330,6 +1267,7 @@ final class StoreContextTests: XCTestCase {
     }
 
     @MainActor
+    @Test
     func testUpdateInTopologicalOrder() {
         struct TestAtom1: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -1373,17 +1311,18 @@ final class StoreContextTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(value0, 0)
-        XCTAssertEqual(updateCount, 0)
+        #expect(value0 == 0)
+        #expect(updateCount == 0)
 
         context.set(1, for: TestAtom1())
         let value1 = context.read(TestAtom4())
 
-        XCTAssertEqual(value1, 6)
-        XCTAssertEqual(updateCount, 1)
+        #expect(value1 == 6)
+        #expect(updateCount == 1)
     }
 
     @MainActor
+    @Test
     func testUpdatePropagation() {
         struct TestAtom1: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -1412,23 +1351,24 @@ final class StoreContextTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(value0, 0)
-        XCTAssertEqual(updateCount, 0)
+        #expect(value0 == 0)
+        #expect(updateCount == 0)
 
         context.set(1, for: TestAtom1())
         let value1 = context.read(TestAtom2())
 
-        XCTAssertEqual(value1, 1)
-        XCTAssertEqual(updateCount, 1)
+        #expect(value1 == 1)
+        #expect(updateCount == 1)
 
         context.set(1, for: TestAtom1())
         let value2 = context.read(TestAtom2())
 
-        XCTAssertEqual(value2, 1)
-        XCTAssertEqual(updateCount, 1)
+        #expect(value2 == 1)
+        #expect(updateCount == 1)
     }
 
     @MainActor
+    @Test
     func testUpdateSkipping() {
         struct TestAtom1: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -1488,34 +1428,35 @@ final class StoreContextTests: XCTestCase {
                 }
             )
 
-            XCTAssertEqual(value0, 0)
-            XCTAssertEqual(value1, 0)
-            XCTAssertEqual(value2, 0)
-            XCTAssertEqual(updateCount, 0)
+            #expect(value0 == 0)
+            #expect(value1 == 0)
+            #expect(value2 == 0)
+            #expect(updateCount == 0)
 
             context.set(1, for: TestAtom1())
             let value3 = context.read(TestAtom2().changes)
             let value4 = context.read(TestAtom3().changes)
             let value5 = context.read(TestAtom4())
 
-            XCTAssertEqual(value3, 1)
-            XCTAssertEqual(value4, 1)
-            XCTAssertEqual(value5, 1)
-            XCTAssertEqual(updateCount, 1)
+            #expect(value3 == 1)
+            #expect(value4 == 1)
+            #expect(value5 == 1)
+            #expect(updateCount == 1)
 
             context.set(1, for: TestAtom1())
             let value6 = context.read(TestAtom2().changes)
             let value7 = context.read(TestAtom3().changes)
             let value8 = context.read(TestAtom4())
 
-            XCTAssertEqual(value6, 1)
-            XCTAssertEqual(value7, 1)
-            XCTAssertEqual(value8, 1)
-            XCTAssertEqual(updateCount, 2)
+            #expect(value6 == 1)
+            #expect(value7 == 1)
+            #expect(value8 == 1)
+            #expect(updateCount == 2)
         }
     }
 
     @MainActor
+    @Test
     func testUpdateSkipping2() {
         struct TestAtom1: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
@@ -1575,35 +1516,36 @@ final class StoreContextTests: XCTestCase {
                 }
             )
 
-            XCTAssertEqual(value0, 0)
-            XCTAssertEqual(value1, 0)
-            XCTAssertEqual(value2, 0)
-            XCTAssertEqual(updateCount, 0)
+            #expect(value0 == 0)
+            #expect(value1 == 0)
+            #expect(value2 == 0)
+            #expect(updateCount == 0)
 
             context.set(1, for: TestAtom1())
             let value3 = context.read(TestAtom2().changes)
             let value4 = context.read(TestAtom3().changes)
             let value5 = context.read(TestAtom4())
 
-            XCTAssertEqual(value3, 1)
-            XCTAssertEqual(value4, 1)
-            XCTAssertEqual(value5, 2)
-            XCTAssertEqual(updateCount, 1)
+            #expect(value3 == 1)
+            #expect(value4 == 1)
+            #expect(value5 == 2)
+            #expect(updateCount == 1)
 
             context.set(1, for: TestAtom1())
             let value6 = context.read(TestAtom2().changes)
             let value7 = context.read(TestAtom3().changes)
             let value8 = context.read(TestAtom4())
 
-            XCTAssertEqual(value6, 1)
-            XCTAssertEqual(value7, 1)
-            XCTAssertEqual(value8, 2)
-            XCTAssertEqual(updateCount, 1)
+            #expect(value6 == 1)
+            #expect(value7 == 1)
+            #expect(value8 == 2)
+            #expect(updateCount == 1)
         }
     }
 
     @MainActor
-    func testUnsubscribeOnBackgroundThread() {
+    @Test
+    func testUnsubscribeOnBackgroundThread() async {
         struct TestAtom1: StateAtom, Hashable {
             func defaultValue(context: Context) -> Int {
                 0
@@ -1636,41 +1578,31 @@ final class StoreContextTests: XCTestCase {
                 subscription: Subscription()
             )
 
-            let expectation = expectation(description: #function)
-            expectation.expectedFulfillmentCount = 3
-
             // Release the subscriber state on the detached background thread.
-            Task.detached {
+            let releaseTask = Task.detached {
                 host.subscriberState = nil
-                expectation.fulfill()
             }
 
-            // Set a new value to the root atom.
+            // Set a new value to the root atom concurrently.
             // This causes data race in the internal mechanism
             // if main actor isolation is not working correctly.
-            Task {
+            let setTask = Task {
                 context.set(100, for: TestAtom1())
-                expectation.fulfill()
             }
+
+            _ = await (releaseTask.value, setTask.value)
 
             // Waits until unsubscription is performed.
-            Task.detached {
-                for _ in 0... {
-                    if await context.lookup(TestAtom1()) == nil {
-                        expectation.fulfill()
-                        break
-                    }
-                }
-            }
+            await Task.yield(until: { context.lookup(TestAtom1()) == nil })
 
-            wait(for: [expectation], timeout: 0.5)
-            XCTAssertNil(context.lookup(TestAtom1()))
-            XCTAssertNil(context.lookup(TestAtom2()))
-            XCTAssertTrue(store.subscriptions.isEmpty)
+            #expect(context.lookup(TestAtom1()) == nil)
+            #expect(context.lookup(TestAtom2()) == nil)
+            #expect(store.subscriptions.isEmpty)
         }
     }
 
     @MainActor
+    @Test
     func testComplexDependencies() async {
         enum Phase {
             case first
@@ -1778,17 +1710,14 @@ final class StoreContextTests: XCTestCase {
 
             let value = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
 
-            XCTAssertEqual(value, 0)
-            XCTAssertNil(store.children[AtomKey(d)])
-            XCTAssertEqual(
-                store.dependencies[AtomKey(atom)],
-                [AtomKey(phase), AtomKey(a), AtomKey(b), AtomKey(c)]
-            )
+            #expect(value == 0)
+            #expect(store.children[AtomKey(d)] == nil)
+            #expect(store.dependencies[AtomKey(atom)] == [AtomKey(phase), AtomKey(a), AtomKey(b), AtomKey(c)])
 
             let state = store.states[AtomKey(atom)]
 
             // TestAtom's Task cancellation
-            XCTAssertNotNil(state?.transactionState?.onTermination)
+            #expect(state?.transactionState?.onTermination != nil)
         }
 
         do {
@@ -1806,18 +1735,15 @@ final class StoreContextTests: XCTestCase {
             let before = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
             let after = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
 
-            XCTAssertEqual(before, 0)
-            XCTAssertEqual(after, 1)
-            XCTAssertNil(store.children[AtomKey(c)])
-            XCTAssertEqual(
-                store.dependencies[AtomKey(atom)],
-                [AtomKey(phase), AtomKey(a), AtomKey(d), AtomKey(b)]
-            )
+            #expect(before == 0)
+            #expect(after == 1)
+            #expect(store.children[AtomKey(c)] == nil)
+            #expect(store.dependencies[AtomKey(atom)] == [AtomKey(phase), AtomKey(a), AtomKey(d), AtomKey(b)])
 
             let state = store.states[AtomKey(atom)]
 
             // TestAtom's Task cancellation
-            XCTAssertNotNil(state?.transactionState?.onTermination)
+            #expect(state?.transactionState?.onTermination != nil)
         }
 
         do {
@@ -1834,26 +1760,23 @@ final class StoreContextTests: XCTestCase {
             let before = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
             let after = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
 
-            XCTAssertEqual(before, 1)
-            XCTAssertEqual(after, 3)
-            XCTAssertNil(store.children[AtomKey(a)])
-            XCTAssertEqual(
-                store.dependencies[AtomKey(atom)],
-                [AtomKey(phase), AtomKey(b), AtomKey(c), AtomKey(d)]
-            )
+            #expect(before == 1)
+            #expect(after == 3)
+            #expect(store.children[AtomKey(a)] == nil)
+            #expect(store.dependencies[AtomKey(atom)] == [AtomKey(phase), AtomKey(b), AtomKey(c), AtomKey(d)])
 
             let state = store.states[AtomKey(atom)]
 
             // TestAtom's Task cancellation
-            XCTAssertNotNil(state?.transactionState?.onTermination)
+            #expect(state?.transactionState?.onTermination != nil)
         }
 
         do {
             subscriberState = nil
             let key = AtomKey(atom)
 
-            XCTAssertNil(store.caches[key])
-            XCTAssertNil(store.states[key])
+            #expect(store.caches[key] == nil)
+            #expect(store.states[key] == nil)
         }
     }
 }

--- a/Tests/AtomsTests/Core/SubscriberKeyTests.swift
+++ b/Tests/AtomsTests/Core/SubscriberKeyTests.swift
@@ -1,22 +1,24 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class SubscriberKeyTests: XCTestCase {
+struct SubscriberKeyTests {
     @MainActor
+    @Test
     func testKeyHashableForSameToken() {
         let token = SubscriberKey.Token()
 
-        XCTAssertEqual(token.key, token.key)
-        XCTAssertEqual(token.key.hashValue, token.key.hashValue)
+        #expect(token.key == token.key)
+        #expect(token.key.hashValue == token.key.hashValue)
     }
 
     @MainActor
+    @Test
     func testKeyHashableForDifferentToken() {
         let token0 = SubscriberKey.Token()
         let token1 = SubscriberKey.Token()
 
-        XCTAssertNotEqual(token0.key, token1.key)
-        XCTAssertNotEqual(token0.key.hashValue, token1.key.hashValue)
+        #expect(token0.key != token1.key)
+        #expect(token0.key.hashValue != token1.key.hashValue)
     }
 }

--- a/Tests/AtomsTests/Core/SubscriberStateTests.swift
+++ b/Tests/AtomsTests/Core/SubscriberStateTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class SubscriberStateTests: XCTestCase {
+struct SubscriberStateTests {
     @MainActor
+    @Test
     func testUnsubscribeOnDeinit() {
         var subscriberState: SubscriberState? = SubscriberState()
         var unsubscribedCount = 0
@@ -14,6 +15,6 @@ final class SubscriberStateTests: XCTestCase {
 
         subscriberState = nil
 
-        XCTAssertEqual(unsubscribedCount, 1)
+        #expect(unsubscribedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Core/SubscriberTests.swift
+++ b/Tests/AtomsTests/Core/SubscriberTests.swift
@@ -1,29 +1,22 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class SubscriberTests: XCTestCase {
+struct SubscriberTests {
     @MainActor
+    @Test
     func testKey() {
         let state0 = SubscriberState()
         let state1 = state0
         let state2 = SubscriberState()
 
-        XCTAssertEqual(
-            Subscriber(state0).key,
-            Subscriber(state0).key
-        )
-        XCTAssertEqual(
-            Subscriber(state0).key,
-            Subscriber(state1).key
-        )
-        XCTAssertNotEqual(
-            Subscriber(state0).key,
-            Subscriber(state2).key
-        )
+        #expect(Subscriber(state0).key == Subscriber(state0).key)
+        #expect(Subscriber(state0).key == Subscriber(state1).key)
+        #expect(Subscriber(state0).key != Subscriber(state2).key)
     }
 
     @MainActor
+    @Test
     func testUnsubscribe() {
         var state: SubscriberState? = SubscriberState()
         let subscriber = Subscriber(state!)
@@ -35,12 +28,12 @@ final class SubscriberTests: XCTestCase {
 
         state?.unsubscribe?()
 
-        XCTAssertTrue(isUnsubscribed)
+        #expect(isUnsubscribed)
 
         state = nil
         isUnsubscribed = false
         subscriber.unsubscribe?()
 
-        XCTAssertFalse(isUnsubscribed)
+        #expect(!(isUnsubscribed))
     }
 }

--- a/Tests/AtomsTests/Core/TopologicalSortTests.swift
+++ b/Tests/AtomsTests/Core/TopologicalSortTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class TopologicalSortTests: XCTestCase {
+struct TopologicalSortTests {
     @MainActor
+    @Test
     func testSort() {
         let store = AtomStore()
         let key0 = AtomKey(TestAtom(value: 0))
@@ -79,7 +80,7 @@ final class TopologicalSortTests: XCTestCase {
             ],
         ]
 
-        XCTAssertTrue(expectedEdges.contains(Array(sorted.edges)))
-        XCTAssertTrue(expectedRedundants.contains(sorted.redundantDependencies))
+        #expect(expectedEdges.contains(Array(sorted.edges)))
+        #expect(expectedRedundants.contains(sorted.redundantDependencies))
     }
 }

--- a/Tests/AtomsTests/Core/TransactionTests.swift
+++ b/Tests/AtomsTests/Core/TransactionTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class TransactionTests: XCTestCase {
+struct TransactionTests {
     @MainActor
+    @Test
     func testCommit() {
         let key = AtomKey(TestValueAtom(value: 0))
         var beginCount = 0
@@ -13,49 +14,51 @@ final class TransactionTests: XCTestCase {
             return { commitCount += 1 }
         }
 
-        XCTAssertEqual(beginCount, 0)
-        XCTAssertEqual(commitCount, 0)
+        #expect(beginCount == 0)
+        #expect(commitCount == 0)
 
         transactionState.commit()
 
-        XCTAssertEqual(beginCount, 0)
-        XCTAssertEqual(commitCount, 0)
+        #expect(beginCount == 0)
+        #expect(commitCount == 0)
 
         transactionState.begin()
 
-        XCTAssertEqual(beginCount, 1)
-        XCTAssertEqual(commitCount, 0)
+        #expect(beginCount == 1)
+        #expect(commitCount == 0)
 
         transactionState.commit()
 
-        XCTAssertEqual(beginCount, 1)
-        XCTAssertEqual(commitCount, 1)
+        #expect(beginCount == 1)
+        #expect(commitCount == 1)
 
         transactionState.begin()
         transactionState.commit()
 
-        XCTAssertEqual(beginCount, 1)
-        XCTAssertEqual(commitCount, 1)
+        #expect(beginCount == 1)
+        #expect(commitCount == 1)
     }
 
     @MainActor
+    @Test
     func testOnTermination() {
         let key = AtomKey(TestValueAtom(value: 0))
         let transactionState = TransactionState(key: key)
 
-        XCTAssertNil(transactionState.onTermination)
+        #expect(transactionState.onTermination == nil)
 
         transactionState.onTermination = {}
-        XCTAssertNotNil(transactionState.onTermination)
+        #expect(transactionState.onTermination != nil)
 
         transactionState.terminate()
-        XCTAssertNil(transactionState.onTermination)
+        #expect(transactionState.onTermination == nil)
 
         transactionState.onTermination = {}
-        XCTAssertNil(transactionState.onTermination)
+        #expect(transactionState.onTermination == nil)
     }
 
     @MainActor
+    @Test
     func testTerminate() {
         let key = AtomKey(TestValueAtom(value: 0))
         var didBegin = false
@@ -70,27 +73,27 @@ final class TransactionTests: XCTestCase {
             didTerminate = true
         }
 
-        XCTAssertFalse(didBegin)
-        XCTAssertFalse(didCommit)
-        XCTAssertFalse(didTerminate)
-        XCTAssertFalse(transactionState.isTerminated)
-        XCTAssertNotNil(transactionState.onTermination)
+        #expect(!(didBegin))
+        #expect(!(didCommit))
+        #expect(!(didTerminate))
+        #expect(!(transactionState.isTerminated))
+        #expect(transactionState.onTermination != nil)
 
         transactionState.begin()
         transactionState.terminate()
 
-        XCTAssertTrue(didBegin)
-        XCTAssertTrue(didCommit)
-        XCTAssertTrue(didTerminate)
-        XCTAssertTrue(transactionState.isTerminated)
-        XCTAssertNil(transactionState.onTermination)
+        #expect(didBegin)
+        #expect(didCommit)
+        #expect(didTerminate)
+        #expect(transactionState.isTerminated)
+        #expect(transactionState.onTermination == nil)
 
         didTerminate = false
         transactionState.onTermination = {
             didTerminate = true
         }
 
-        XCTAssertTrue(didTerminate)
-        XCTAssertNil(transactionState.onTermination)
+        #expect(didTerminate)
+        #expect(transactionState.onTermination == nil)
     }
 }

--- a/Tests/AtomsTests/Effect/InitializeEffectTests.swift
+++ b/Tests/AtomsTests/Effect/InitializeEffectTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class InitializeEffectTests: XCTestCase {
+struct InitializeEffectTests {
     @MainActor
+    @Test
     func testEvent() {
         let context = AtomCurrentContext(store: .dummy)
         var performedCount = 0
@@ -12,15 +13,15 @@ final class InitializeEffectTests: XCTestCase {
         }
 
         effect.initializing(context: context)
-        XCTAssertEqual(performedCount, 0)
+        #expect(performedCount == 0)
 
         effect.initialized(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
 
         effect.updated(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
 
         effect.released(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Effect/InitializingEffectTests.swift
+++ b/Tests/AtomsTests/Effect/InitializingEffectTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class InitializingEffectTests: XCTestCase {
+struct InitializingEffectTests {
     @MainActor
+    @Test
     func testEvent() {
         let context = AtomCurrentContext(store: .dummy)
         var performedCount = 0
@@ -12,15 +13,15 @@ final class InitializingEffectTests: XCTestCase {
         }
 
         effect.initializing(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
 
         effect.initialized(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
 
         effect.updated(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
 
         effect.released(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Effect/ReleaseEffectTests.swift
+++ b/Tests/AtomsTests/Effect/ReleaseEffectTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ReleaseEffectTests: XCTestCase {
+struct ReleaseEffectTests {
     @MainActor
+    @Test
     func testEvent() {
         let context = AtomCurrentContext(store: .dummy)
         var performedCount = 0
@@ -12,15 +13,15 @@ final class ReleaseEffectTests: XCTestCase {
         }
 
         effect.initializing(context: context)
-        XCTAssertEqual(performedCount, 0)
+        #expect(performedCount == 0)
 
         effect.initialized(context: context)
-        XCTAssertEqual(performedCount, 0)
+        #expect(performedCount == 0)
 
         effect.updated(context: context)
-        XCTAssertEqual(performedCount, 0)
+        #expect(performedCount == 0)
 
         effect.released(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Effect/UpdateEffectTests.swift
+++ b/Tests/AtomsTests/Effect/UpdateEffectTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class UpdateEffectTests: XCTestCase {
+struct UpdateEffectTests {
     @MainActor
+    @Test
     func testEvent() {
         let context = AtomCurrentContext(store: .dummy)
         var performedCount = 0
@@ -12,15 +13,15 @@ final class UpdateEffectTests: XCTestCase {
         }
 
         effect.initializing(context: context)
-        XCTAssertEqual(performedCount, 0)
+        #expect(performedCount == 0)
 
         effect.initialized(context: context)
-        XCTAssertEqual(performedCount, 0)
+        #expect(performedCount == 0)
 
         effect.updated(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
 
         effect.released(context: context)
-        XCTAssertEqual(performedCount, 1)
+        #expect(performedCount == 1)
     }
 }

--- a/Tests/AtomsTests/Modifier/ChangesModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/ChangesModifierTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ChangesModifierTests: XCTestCase {
+struct ChangesModifierTests {
     @MainActor
+    @Test
     func testChanges() {
         let atom = TestStateAtom(defaultValue: "")
         let context = AtomTestContext()
@@ -13,25 +14,26 @@ final class ChangesModifierTests: XCTestCase {
             updatedCount += 1
         }
 
-        XCTAssertEqual(updatedCount, 0)
-        XCTAssertEqual(context.watch(atom.changes), "")
+        #expect(updatedCount == 0)
+        #expect(context.watch(atom.changes) == "")
 
         context[atom] = "modified"
 
-        XCTAssertEqual(updatedCount, 1)
-        XCTAssertEqual(context.watch(atom.changes), "modified")
+        #expect(updatedCount == 1)
+        #expect(context.watch(atom.changes) == "modified")
 
         context[atom] = "modified"
 
         // Should not be updated with an equivalent value.
-        XCTAssertEqual(updatedCount, 1)
+        #expect(updatedCount == 1)
     }
 
     @MainActor
+    @Test
     func testKey() {
         let modifier = ChangesModifier<Int>()
 
-        XCTAssertEqual(modifier.key, modifier.key)
-        XCTAssertEqual(modifier.key.hashValue, modifier.key.hashValue)
+        #expect(modifier.key == modifier.key)
+        #expect(modifier.key.hashValue == modifier.key.hashValue)
     }
 }

--- a/Tests/AtomsTests/Modifier/ChangesOfModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/ChangesOfModifierTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class ChangesOfModifierTests: XCTestCase {
+struct ChangesOfModifierTests {
     @MainActor
+    @Test
     func testChangesOf() {
         let atom = TestStateAtom(defaultValue: "")
         let context = AtomTestContext()
@@ -13,26 +14,27 @@ final class ChangesOfModifierTests: XCTestCase {
             updatedCount += 1
         }
 
-        XCTAssertEqual(updatedCount, 0)
-        XCTAssertEqual(context.watch(atom.changes(of: \.count)), 0)
+        #expect(updatedCount == 0)
+        #expect(context.watch(atom.changes(of: \.count)) == 0)
 
         context[atom] = "modified"
 
-        XCTAssertEqual(updatedCount, 1)
-        XCTAssertEqual(context.watch(atom.changes(of: \.count)), 8)
+        #expect(updatedCount == 1)
+        #expect(context.watch(atom.changes(of: \.count)) == 8)
         context[atom] = "modified"
 
         // Should not be updated with an equivalent value.
-        XCTAssertEqual(updatedCount, 1)
+        #expect(updatedCount == 1)
     }
 
+    @Test
     func testKey() {
         let modifier0 = ChangesOfModifier<Int, Int>(keyPath: \.byteSwapped)
         let modifier1 = ChangesOfModifier<Int, Int>(keyPath: \.leadingZeroBitCount)
 
-        XCTAssertEqual(modifier0.key, modifier0.key)
-        XCTAssertEqual(modifier0.key.hashValue, modifier0.key.hashValue)
-        XCTAssertNotEqual(modifier0.key, modifier1.key)
-        XCTAssertNotEqual(modifier0.key.hashValue, modifier1.key.hashValue)
+        #expect(modifier0.key == modifier0.key)
+        #expect(modifier0.key.hashValue == modifier0.key.hashValue)
+        #expect(modifier0.key != modifier1.key)
+        #expect(modifier0.key.hashValue != modifier1.key.hashValue)
     }
 }

--- a/Tests/AtomsTests/Modifier/LatestModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/LatestModifierTests.swift
@@ -1,8 +1,8 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class LatestModifierTests: XCTestCase {
+struct LatestModifierTests {
     struct Item {
         var id: Int
         var isValid: Bool
@@ -10,61 +10,64 @@ final class LatestModifierTests: XCTestCase {
     }
 
     @MainActor
+    @Test
     func testLatest() {
         let atom = TestStateAtom(defaultValue: Item(id: 1, isValid: false))
         let context = AtomTestContext()
 
         // Initially nil because isValid is false
-        XCTAssertNil(context.watch(atom.latest(\.isValid)))
+        #expect(context.watch(atom.latest(\.isValid)) == nil)
 
         // Update with valid item
         context[atom] = Item(id: 2, isValid: true)
 
         // Should return the valid item
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 2)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 2)
 
         // Update with invalid item
         context[atom] = Item(id: 3, isValid: false)
 
         // Should still return the last valid item
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 2)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 2)
 
         // Update with another valid item
         context[atom] = Item(id: 4, isValid: true)
 
         // Should return the new valid item
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 4)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 4)
 
         // Update with invalid item again
         context[atom] = Item(id: 5, isValid: false)
 
         // Should still return the last valid item
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 4)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 4)
     }
 
     @MainActor
+    @Test
     func testLatestWithMultipleWatchers() {
         let atom = TestStateAtom(defaultValue: Item(id: 1, isValid: false))
         let context = AtomTestContext()
 
         // Watch both current and latest
-        XCTAssertEqual(context.watch(atom).id, 1)
-        XCTAssertNil(context.watch(atom.latest(\.isValid)))
+        #expect(context.watch(atom).id == 1)
+        #expect(context.watch(atom.latest(\.isValid)) == nil)
 
         // Update with valid item
         context[atom] = Item(id: 2, isValid: true)
 
-        XCTAssertEqual(context.watch(atom).id, 2)
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 2)
+        #expect(context.watch(atom).id == 2)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 2)
 
         // Update with invalid item
         context[atom] = Item(id: 3, isValid: false)
 
-        XCTAssertEqual(context.watch(atom).id, 3)
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 2)
+        #expect(context.watch(atom).id == 3)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 2)
     }
 
     @MainActor
+    @Test
     func testLatestUpdatesDownstream() {
         let atom = TestStateAtom(defaultValue: Item(id: 1, isValid: false))
         let context = AtomTestContext()
@@ -75,56 +78,59 @@ final class LatestModifierTests: XCTestCase {
         }
 
         // Initial watch
-        XCTAssertEqual(updatedCount, 0)
-        XCTAssertNil(context.watch(atom.latest(\.isValid)))
+        #expect(updatedCount == 0)
+        #expect(context.watch(atom.latest(\.isValid)) == nil)
 
         // Update with valid item - should trigger update
         context[atom] = Item(id: 2, isValid: true)
-        XCTAssertEqual(updatedCount, 1)
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 2)
+        #expect(updatedCount == 1)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 2)
 
         // Update with invalid item - should still trigger update
         context[atom] = Item(id: 3, isValid: false)
-        XCTAssertEqual(updatedCount, 2)
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 2)
+        #expect(updatedCount == 2)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 2)
 
         // Update with another valid item - should trigger update
         context[atom] = Item(id: 4, isValid: true)
-        XCTAssertEqual(updatedCount, 3)
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 4)
+        #expect(updatedCount == 3)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 4)
     }
 
     @MainActor
+    @Test
     func testKey() {
         let modifier1 = LatestModifier<Item>(keyPath: \.isValid)
         let modifier2 = LatestModifier<Item>(keyPath: \.isValid)
 
-        XCTAssertEqual(modifier1.key, modifier2.key)
-        XCTAssertEqual(modifier1.key.hashValue, modifier2.key.hashValue)
+        #expect(modifier1.key == modifier2.key)
+        #expect(modifier1.key.hashValue == modifier2.key.hashValue)
     }
 
     @MainActor
+    @Test
     func testLatestWithBoolValue() {
         let atom = TestStateAtom(defaultValue: true)
         let context = AtomTestContext()
 
         // Initially should return the value if it's true
-        XCTAssertEqual(context.watch(atom.latest(\.self)), true)
+        #expect(context.watch(atom.latest(\.self)) == true)
 
         // Update to false
         context[atom] = false
 
         // Should still return the last true value
-        XCTAssertEqual(context.watch(atom.latest(\.self)), true)
+        #expect(context.watch(atom.latest(\.self)) == true)
 
         // Update to true again
         context[atom] = true
 
         // Should return the new true value
-        XCTAssertEqual(context.watch(atom.latest(\.self)), true)
+        #expect(context.watch(atom.latest(\.self)) == true)
     }
 
     @MainActor
+    @Test
     func testLatestIsolatedPerScope() {
         struct ScopedItemAtom: StateAtom, Scoped, Hashable, @unchecked Sendable {
             let key = UniqueKey()
@@ -147,34 +153,33 @@ final class LatestModifierTests: XCTestCase {
         let atom = ScopedItemAtom()
 
         // Drive `latest` in scope1 so its StorageAtom retains a valid item.
-        XCTAssertNil(scope1.watch(atom.latest(\.isValid), subscriber: subscriber1, subscription: Subscription()))
+        #expect(scope1.watch(atom.latest(\.isValid), subscriber: subscriber1, subscription: Subscription()) == nil)
         scope1.set(Item(id: 10, isValid: true), for: atom)
-        XCTAssertEqual(
-            scope1.watch(atom.latest(\.isValid), subscriber: subscriber1, subscription: Subscription())?.id,
-            10
-        )
+        #expect(scope1.watch(atom.latest(\.isValid), subscriber: subscriber1, subscription: Subscription())?.id == 10)
 
         // First read of `latest` in scope2. With un-scoped storage this would
         // leak scope1's id=10; with per-scope storage it must be nil.
-        XCTAssertNil(scope2.watch(atom.latest(\.isValid), subscriber: subscriber2, subscription: Subscription()))
+        #expect(scope2.watch(atom.latest(\.isValid), subscriber: subscriber2, subscription: Subscription()) == nil)
     }
 
     @MainActor
+    @Test
     func testLatestIsolatedPerKeyPath() {
         let atom = TestStateAtom(defaultValue: Item(id: 0, isValid: false, isUnique: false))
         let context = AtomTestContext()
 
         // Drive A through a valid emission so any shared storage now retains id=10.
-        XCTAssertNil(context.watch(atom.latest(\.isValid)))
+        #expect(context.watch(atom.latest(\.isValid)) == nil)
         context[atom] = Item(id: 10, isValid: true, isUnique: false)
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 10)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 10)
 
         // First read of B — has never seen a B-valid value. With shared storage
         // it would leak A's id=10; with per-(base, keyPath) storage it must be nil.
-        XCTAssertNil(context.watch(atom.latest(\.isUnique)))
+        #expect(context.watch(atom.latest(\.isUnique)) == nil)
     }
 
     @MainActor
+    @Test
     func testLatestIsolatedPerBaseAtomInstance() {
         struct ItemAtom: StateAtom, Hashable {
             let id: Int
@@ -190,27 +195,28 @@ final class LatestModifierTests: XCTestCase {
 
         // Drive `a.latest` so that — under the shared-storage bug —
         // the StorageAtom now retains `Item(id: 10, isValid: true)`.
-        XCTAssertNil(context.watch(a.latest(\.isValid)))
+        #expect(context.watch(a.latest(\.isValid)) == nil)
         context[a] = Item(id: 10, isValid: true)
-        XCTAssertEqual(context.watch(a.latest(\.isValid))?.id, 10)
+        #expect(context.watch(a.latest(\.isValid))?.id == 10)
 
         // First read of `b.latest`. With shared storage this would leak
         // `a`'s last valid item; with per-base storage it must be nil.
-        XCTAssertNil(context.watch(b.latest(\.isValid)))
+        #expect(context.watch(b.latest(\.isValid)) == nil)
     }
 
     @MainActor
+    @Test
     func testLatestWithInitialValidValue() {
         let atom = TestStateAtom(defaultValue: Item(id: 1, isValid: true))
         let context = AtomTestContext()
 
         // Should immediately return the initial valid value
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 1)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 1)
 
         // Update with invalid item
         context[atom] = Item(id: 2, isValid: false)
 
         // Should still return the initial valid value
-        XCTAssertEqual(context.watch(atom.latest(\.isValid))?.id, 1)
+        #expect(context.watch(atom.latest(\.isValid))?.id == 1)
     }
 }

--- a/Tests/AtomsTests/Modifier/PreviousModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/PreviousModifierTests.swift
@@ -1,58 +1,61 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class PreviousModifierTests: XCTestCase {
+struct PreviousModifierTests {
     @MainActor
+    @Test
     func testPrevious() {
         let atom = TestStateAtom(defaultValue: "initial")
         let context = AtomTestContext()
 
-        XCTAssertNil(context.watch(atom.previous))
+        #expect(context.watch(atom.previous) == nil)
 
         // Update the atom value
         context[atom] = "second"
 
         // Now previous should return the initial value
-        XCTAssertEqual(context.watch(atom.previous), "initial")
+        #expect(context.watch(atom.previous) == "initial")
 
         // Update again
         context[atom] = "third"
 
         // Previous should now return "second"
-        XCTAssertEqual(context.watch(atom.previous), "second")
+        #expect(context.watch(atom.previous) == "second")
 
         // Another update
         context[atom] = "fourth"
 
         // Previous should now return "third"
-        XCTAssertEqual(context.watch(atom.previous), "third")
+        #expect(context.watch(atom.previous) == "third")
     }
 
     @MainActor
+    @Test
     func testPreviousWithMultipleWatchers() {
         let atom = TestStateAtom(defaultValue: 100)
         let context = AtomTestContext()
 
         // Watch both current and previous
-        XCTAssertEqual(context.watch(atom), 100)
-        XCTAssertNil(context.watch(atom.previous))
+        #expect(context.watch(atom) == 100)
+        #expect(context.watch(atom.previous) == nil)
 
         // Update the value
         context[atom] = 200
 
         // Check both watchers
-        XCTAssertEqual(context.watch(atom), 200)
-        XCTAssertEqual(context.watch(atom.previous), 100)
+        #expect(context.watch(atom) == 200)
+        #expect(context.watch(atom.previous) == 100)
 
         // Update again
         context[atom] = 300
 
-        XCTAssertEqual(context.watch(atom), 300)
-        XCTAssertEqual(context.watch(atom.previous), 200)
+        #expect(context.watch(atom) == 300)
+        #expect(context.watch(atom.previous) == 200)
     }
 
     @MainActor
+    @Test
     func testPreviousUpdatesDownstream() {
         let atom = TestStateAtom(defaultValue: 0)
         let context = AtomTestContext()
@@ -63,29 +66,31 @@ final class PreviousModifierTests: XCTestCase {
         }
 
         // Initial watch
-        XCTAssertEqual(updatedCount, 0)
-        XCTAssertNil(context.watch(atom.previous))
+        #expect(updatedCount == 0)
+        #expect(context.watch(atom.previous) == nil)
 
         // First update
         context[atom] = 1
-        XCTAssertEqual(updatedCount, 1)
-        XCTAssertEqual(context.watch(atom.previous), 0)
+        #expect(updatedCount == 1)
+        #expect(context.watch(atom.previous) == 0)
 
         // Second update
         context[atom] = 2
-        XCTAssertEqual(updatedCount, 2)
-        XCTAssertEqual(context.watch(atom.previous), 1)
+        #expect(updatedCount == 2)
+        #expect(context.watch(atom.previous) == 1)
     }
 
     @MainActor
+    @Test
     func testKey() {
         let modifier = PreviousModifier<Int>()
 
-        XCTAssertEqual(modifier.key, modifier.key)
-        XCTAssertEqual(modifier.key.hashValue, modifier.key.hashValue)
+        #expect(modifier.key == modifier.key)
+        #expect(modifier.key.hashValue == modifier.key.hashValue)
     }
 
     @MainActor
+    @Test
     func testPreviousIsolatedPerScope() {
         struct ScopedIntAtom: StateAtom, Scoped, Hashable, @unchecked Sendable {
             let key = UniqueKey()
@@ -106,16 +111,17 @@ final class PreviousModifierTests: XCTestCase {
         let atom = ScopedIntAtom()
 
         // Drive `previous` in scope1 so its StorageAtom holds the latest value.
-        XCTAssertNil(scope1.watch(atom.previous, subscriber: subscriber1, subscription: Subscription()))
+        #expect(scope1.watch(atom.previous, subscriber: subscriber1, subscription: Subscription()) == nil)
         scope1.set(1, for: atom)
-        XCTAssertEqual(scope1.watch(atom.previous, subscriber: subscriber1, subscription: Subscription()), 0)
+        #expect(scope1.watch(atom.previous, subscriber: subscriber1, subscription: Subscription()) == 0)
 
         // First read of `previous` in scope2. With un-scoped storage this would
         // leak scope1's value; with per-scope storage it must be nil.
-        XCTAssertNil(scope2.watch(atom.previous, subscriber: subscriber2, subscription: Subscription()))
+        #expect(scope2.watch(atom.previous, subscriber: subscriber2, subscription: Subscription()) == nil)
     }
 
     @MainActor
+    @Test
     func testPreviousIsolatedPerBaseAtomInstance() {
         struct ItemAtom: StateAtom, Hashable {
             let id: Int
@@ -131,12 +137,12 @@ final class PreviousModifierTests: XCTestCase {
 
         // Drive `a.previous` so that — under the shared-storage bug —
         // the StorageAtom's `previous` now holds `"a-new"`.
-        XCTAssertNil(context.watch(a.previous))
+        #expect(context.watch(a.previous) == nil)
         context[a] = "a-new"
-        XCTAssertEqual(context.watch(a.previous), "initial-1")
+        #expect(context.watch(a.previous) == "initial-1")
 
         // First read of `b.previous`. With shared storage this would leak
         // `"a-new"`; with per-base storage it must be nil.
-        XCTAssertNil(context.watch(b.previous))
+        #expect(context.watch(b.previous) == nil)
     }
 }

--- a/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/TaskPhaseModifierTests.swift
@@ -1,37 +1,40 @@
 import Combine
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class TaskPhaseModifierTests: XCTestCase {
+struct TaskPhaseModifierTests {
     @MainActor
+    @Test
     func testPhase() async {
         let atom = TestTaskAtom { 0 }.phase
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom), .suspending)
+        #expect(context.watch(atom) == .suspending)
 
         await context.wait(for: atom, until: \.isSuccess)
 
-        XCTAssertEqual(context.watch(atom), .success(0))
+        #expect(context.watch(atom) == .success(0))
     }
 
     @MainActor
+    @Test
     func testRefresh() async {
         let atom = TestTaskAtom { 0 }.phase
         let context = AtomTestContext()
 
-        XCTAssertEqual(context.watch(atom), .suspending)
+        #expect(context.watch(atom) == .suspending)
 
         let phase = await context.refresh(atom)
-        XCTAssertEqual(phase, .success(0))
-        XCTAssertEqual(context.watch(atom), .success(0))
+        #expect(phase == .success(0))
+        #expect(context.watch(atom) == .success(0))
     }
 
+    @Test
     func testKey() {
         let modifier = TaskPhaseModifier<Int, Never>()
 
-        XCTAssertEqual(modifier.key, modifier.key)
-        XCTAssertEqual(modifier.key.hashValue, modifier.key.hashValue)
+        #expect(modifier.key == modifier.key)
+        #expect(modifier.key.hashValue == modifier.key.hashValue)
     }
 }

--- a/Tests/AtomsTests/SnapshotTests.swift
+++ b/Tests/AtomsTests/SnapshotTests.swift
@@ -1,9 +1,10 @@
-import XCTest
+import Testing
 
 @testable import Atoms
 
-final class SnapshotTests: XCTestCase {
+struct SnapshotTests {
     @MainActor
+    @Test
     func testLookup() {
         let atom0 = TestAtom(value: 0)
         let atom1 = TestAtom(value: 1)
@@ -17,10 +18,11 @@ final class SnapshotTests: XCTestCase {
             subscriptions: [:]
         )
 
-        XCTAssertEqual(snapshot.lookup(atom0), 0)
-        XCTAssertNil(snapshot.lookup(atom1))
+        #expect(snapshot.lookup(atom0) == 0)
+        #expect(snapshot.lookup(atom1) == nil)
     }
 
+    @Test
     func testEmptyGraphDescription() {
         let snapshot = Snapshot(
             dependencies: [:],
@@ -29,10 +31,11 @@ final class SnapshotTests: XCTestCase {
             subscriptions: [:]
         )
 
-        XCTAssertEqual(snapshot.graphDescription(), "digraph {}")
+        #expect(snapshot.graphDescription() == "digraph {}")
     }
 
     @MainActor
+    @Test
     func testGraphDescription() {
         struct Value0: Hashable {}
         struct Value1: Hashable {}
@@ -82,25 +85,24 @@ final class SnapshotTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(
-            snapshot.graphDescription(),
-            """
-            digraph {
-              node [shape=box]
-              "Module/View.swift" [style=filled]
-              "TestAtom<Value0>"
-              "TestAtom<Value0>" -> "TestAtom<Value1>"
-              "TestAtom<Value1>"
-              "TestAtom<Value1>" -> "TestAtom<Value2>"
-              "TestAtom<Value2>"
-              "TestAtom<Value2>" -> "Module/View.swift" [label="line:10"]
-              "TestAtom<Value2>" -> "TestAtom<Value3>"
-              "TestAtom<Value3>"
-              "TestAtom<Value3>" -> "Module/View.swift" [label="line:10"]
-              "TestAtom<Value4> scope:\(scopeToken.key.description)"
-              "TestAtom<Value4> scope:\(scopeToken.key.description)" -> "Module/View.swift" [label="line:10"]
-            }
-            """
+        #expect(
+            snapshot.graphDescription() == """
+                digraph {
+                  node [shape=box]
+                  "Module/View.swift" [style=filled]
+                  "TestAtom<Value0>"
+                  "TestAtom<Value0>" -> "TestAtom<Value1>"
+                  "TestAtom<Value1>"
+                  "TestAtom<Value1>" -> "TestAtom<Value2>"
+                  "TestAtom<Value2>"
+                  "TestAtom<Value2>" -> "Module/View.swift" [label="line:10"]
+                  "TestAtom<Value2>" -> "TestAtom<Value3>"
+                  "TestAtom<Value3>"
+                  "TestAtom<Value3>" -> "Module/View.swift" [label="line:10"]
+                  "TestAtom<Value4> scope:\(scopeToken.key.description)"
+                  "TestAtom<Value4> scope:\(scopeToken.key.description)" -> "Module/View.swift" [label="line:10"]
+                }
+                """
         )
     }
 }


### PR DESCRIPTION
## Summary

Migrate the entire test suite (library tests and example app tests) from XCTest to Swift Testing.

- Replace `import XCTest` with `import Testing`, and add the `Foundation` / `Combine` / `UIKit` imports that XCTest previously provided implicitly (for `URLError`, `UUID`, `ObservableObject`, `UIImage`, etc.).
- Convert `XCTestCase` subclasses to `struct`s and annotate test methods with `@Test`.
- Convert `XCTAssert*` / `XCTFail` to `#expect` / `Issue.record`.
- Split `XCTContext.runActivity` blocks into separate `@Test` functions in `ScopedTests`, `KeepAliveTests`, and `AsyncPhaseTests` (Swift Testing has no direct equivalent).
- Replace `XCTestExpectation` / `wait(for:)` in `StoreContextTests.testUnsubscribeOnBackgroundThread` with structured concurrency using `Task` and the existing `Task.yield(until:)` helper.

`Benchmarks/Tests` intentionally keeps using XCTest because it relies on `measure`, which Swift Testing does not provide.

## Flakiness fix

Swift Testing runs tests in parallel by default, whereas XCTest ran them serially. This exposed a pre-existing timing dependency in `AtomTestContextTests.testWaitFor`: under parallel CPU contention, the three increment tasks could all complete before `wait(for:)` started observing, causing `wait(for:)` to return `false` for an already-satisfied predicate.

The delay margin was widened (`Double(i) / 100` → `Double(i) / 10`) so the increments reliably occur after observation starts. The expected outcomes of the test are unchanged.

## Verification

- All library tests pass (169 tests, 41 suites).
- Example app tests pass on the iOS simulator and on macOS.
- The full library suite was run 50+ times under parallel execution with no failures after the flakiness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)