### PR TITLE
Add throwing timeout variants of AtomTestContext wait functions

### DIFF
--- a/Sources/Atoms/AtomTestContextTimeoutError.swift
+++ b/Sources/Atoms/AtomTestContextTimeoutError.swift
@@ -16,6 +16,7 @@ public struct AtomTestContextTimeoutError: Error, CustomStringConvertible {
         self.timeout = timeout
     }
 
+    /// A textual representation of the timeout error.
     public var description: String {
         "The wait timed out after \(timeout) second(s)."
     }

--- a/Sources/Atoms/AtomTestContextTimeoutError.swift
+++ b/Sources/Atoms/AtomTestContextTimeoutError.swift
@@ -1,0 +1,22 @@
+/// An error indicating that an awaited condition was not met within the specified timeout
+/// while interacting with atoms through ``AtomTestContext``.
+///
+/// This error is thrown by the throwing `within:` variants of the wait functions on
+/// ``AtomTestContext`` such as ``AtomTestContext/waitForUpdate(within:)`` and
+/// ``AtomTestContext/wait(for:within:until:)`` when the timeout elapses before the
+/// expected update or state is observed.
+public struct AtomTestContextTimeoutError: Error, CustomStringConvertible {
+    /// The timeout duration, in seconds, that the wait was allowed before timing out.
+    public let timeout: Double
+
+    /// Creates a new timeout error with the given timeout duration.
+    ///
+    /// - Parameter timeout: The timeout duration, in seconds, that elapsed before timing out.
+    public init(timeout: Double) {
+        self.timeout = timeout
+    }
+
+    public var description: String {
+        "The wait timed out after \(timeout) second(s)."
+    }
+}

--- a/Sources/Atoms/Atoms.docc/Atoms.md
+++ b/Sources/Atoms/Atoms.docc/Atoms.md
@@ -94,4 +94,5 @@ Building state by compositing atoms automatically optimizes rendering based on i
 - ``AnimationModifier``
 - ``AtomProducer``
 - ``AtomRefreshProducer``
+- ``AtomTestContextTimeoutError``
 

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -75,6 +75,55 @@ public struct AtomTestContext: AtomWatchableContext {
         }
     }
 
+    /// Waits until any of the atoms watched through this context have been updated within the
+    /// specified timeout, throwing an error if the timeout elapses first.
+    ///
+    /// Unlike ``waitForUpdate(timeout:)`` which returns a boolean value, this throwing variant
+    /// surfaces a timeout as an ``AtomTestContextTimeoutError`` so that it fails the test instead
+    /// of being silently ignored.
+    ///
+    /// ```swift
+    /// func testAsyncUpdate() async throws {
+    ///     let context = AtomTestContext()
+    ///
+    ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
+    ///     XCTAssertEqual(initialPhase, .suspending)
+    ///
+    ///     try await context.waitForUpdate(within: 1)
+    ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
+    ///
+    ///     XCTAssertEqual(currentPhase, .success(123))
+    /// }
+    /// ```
+    ///
+    /// - Parameter timeout: The maximum duration, in seconds, that this function waits for
+    ///                      the next update.
+    ///
+    /// - Throws: ``AtomTestContextTimeoutError`` if no update happens within the timeout.
+    ///           A `CancellationError` is thrown if the current task is cancelled.
+    @inlinable
+    public func waitForUpdate(within timeout: Double) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            let updates = _state.makeUpdateStream()
+
+            group.addTask(priority: .high) { @MainActor @Sendable in
+                for await _ in updates {
+                    return
+                }
+                // The update stream only finishes when the task is cancelled.
+                try Task.checkCancellation()
+            }
+
+            group.addTask(priority: .high) {
+                try await Task.sleep(seconds: timeout)
+                throw AtomTestContextTimeoutError(timeout: timeout)
+            }
+
+            defer { group.cancelAll() }
+            try await group.next()
+        }
+    }
+
     /// Waits for the given atom until it will be in a certain state within a specified timeout,
     /// and then returns a boolean value indicating whether an update has happened.
     ///
@@ -148,6 +197,80 @@ public struct AtomTestContext: AtomWatchableContext {
             }
 
             return false
+        }
+    }
+
+    /// Waits for the given atom until it will be in a certain state within a specified timeout,
+    /// throwing an error if the timeout elapses first.
+    ///
+    /// Unlike ``wait(for:timeout:until:)`` which returns a boolean value, this throwing variant
+    /// surfaces a timeout as an ``AtomTestContextTimeoutError`` so that it fails the test instead
+    /// of being silently ignored. If the atom already satisfies the predicate, this function
+    /// returns immediately without waiting for an update.
+    ///
+    /// ```swift
+    /// func testAsyncUpdate() async throws {
+    ///     let context = AtomTestContext()
+    ///
+    ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
+    ///     XCTAssertEqual(initialPhase, .suspending)
+    ///
+    ///     try await context.wait(for: AsyncCalculationAtom().phase, within: 1, until: \.isSuccess)
+    ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
+    ///
+    ///     XCTAssertEqual(currentPhase, .success(123))
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - atom: An atom expecting an update to a certain state.
+    ///   - timeout: The maximum duration, in seconds, that this function waits until
+    ///              the atom satisfies the predicate.
+    ///   - predicate: A predicate that determines when to stop waiting.
+    ///
+    /// - Throws: ``AtomTestContextTimeoutError`` if the atom does not satisfy the predicate
+    ///           within the timeout. A `CancellationError` is thrown if the current task is
+    ///           cancelled.
+    @inlinable
+    public func wait<Node: Atom>(
+        for atom: Node,
+        within timeout: Double,
+        until predicate: @escaping (Node.Produced) -> Bool
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            @MainActor
+            func check() -> Bool {
+                guard let value = lookup(atom) else {
+                    return false
+                }
+
+                return predicate(value)
+            }
+
+            let updates = _state.makeUpdateStream()
+
+            group.addTask(priority: .high) { @MainActor @Sendable in
+                guard !check() else {
+                    return
+                }
+
+                for await _ in updates {
+                    if check() {
+                        return
+                    }
+                }
+
+                // The update stream only finishes when the task is cancelled.
+                try Task.checkCancellation()
+            }
+
+            group.addTask(priority: .high) {
+                try await Task.sleep(seconds: timeout)
+                throw AtomTestContextTimeoutError(timeout: timeout)
+            }
+
+            defer { group.cancelAll() }
+            try await group.next()
         }
     }
 

--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -96,6 +96,61 @@ struct AtomTestContextTests {
 
     @MainActor
     @Test
+    func testWaitForUpdateWithinTimeout() async throws {
+        let atom = TestStateAtom(defaultValue: 0)
+        let context = AtomTestContext()
+
+        context.watch(atom)
+
+        Task {
+            context[atom] = 1
+        }
+
+        // Returns normally when an update happens within the timeout.
+        try await context.waitForUpdate(within: 1)
+
+        // Throws when no update happens within the timeout.
+        let error = await #expect(throws: AtomTestContextTimeoutError.self) {
+            try await context.waitForUpdate(within: 0.1)
+        }
+
+        #expect(error?.timeout == 0.1)
+    }
+
+    @MainActor
+    @Test
+    func testWaitForWithinTimeout() async throws {
+        let atom = TestStateAtom(defaultValue: 0)
+        let context = AtomTestContext()
+
+        context.watch(atom)
+
+        // Returns immediately when the predicate is already satisfied.
+        try await context.wait(for: atom, within: 1) {
+            $0 == 0
+        }
+
+        Task {
+            context[atom] = 1
+        }
+
+        // Returns normally when the atom reaches the expected state within the timeout.
+        try await context.wait(for: atom, within: 1) {
+            $0 == 1
+        }
+
+        // Throws when the atom does not reach the expected state within the timeout.
+        let error = await #expect(throws: AtomTestContextTimeoutError.self) {
+            try await context.wait(for: atom, within: 0.1) {
+                $0 == 100
+            }
+        }
+
+        #expect(error?.timeout == 0.1)
+    }
+
+    @MainActor
+    @Test
     func testOverride() {
         let atom0 = TestValueAtom(value: 100)
         let atom1 = TestStateAtom(defaultValue: 200)


### PR DESCRIPTION
## Summary

Add `within:`-labeled throwing overloads to `AtomTestContext` that surface a timeout as a thrown error, instead of the silently ignorable `Bool` returned by the existing functions.

```swift
// New (throwing) — timeout surfaces as an error
try await context.waitForUpdate(within: 1)
try await context.wait(for: atom, within: 1, until: \.isSuccess)

// Existing (best-effort, returns whether it happened) — unchanged
let didUpdate = await context.waitForUpdate(timeout: 1)
let didUpdate = await context.wait(for: atom, timeout: 1, until: \.isSuccess)
```

## Motivation

The existing `wait`/`waitForUpdate` return `false` on timeout, so a timeout is silently ignored unless the caller inspects the return value. The throwing variants make a timeout fail the test by default.

## Design notes

- **Naming**: keeps the same base names (`wait` / `waitForUpdate`) and distinguishes the throwing variants by a shared `within:` label (required `Double`). This reads as a variant of the existing `wait` family and avoids any clash with Swift Testing's `#expect` / `#require` macros. The label difference (`timeout:` optional + `Bool` vs `within:` required + `throws`) mirrors the behavioral difference (best-effort vs enforced).
- **Error type**: a new public `AtomTestContextTimeoutError: Error, CustomStringConvertible` carrying the `timeout` duration for diagnostics.
- **Cancellation**: a real task cancellation propagates as `CancellationError`, never as a timeout. The timeout error is only thrown after `Task.sleep` completes normally, so on cancellation `Task.sleep` throws `CancellationError` before the timeout error is reached.
- **Already-satisfied**: `wait(for:within:until:)` returns immediately without throwing when the atom already satisfies the predicate.

## Verification

- New tests cover the success path, the already-satisfied path, and the timeout-throws path (asserting the `timeout` property).
- Full library suite passes and was run 10 times under parallel execution with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)