### PR TITLE
Harden timing-sensitive tests against parallel-execution flakiness

### DIFF
--- a/Tests/AtomsTests/Context/AtomTestContextTests.swift
+++ b/Tests/AtomsTests/Context/AtomTestContextTests.swift
@@ -62,18 +62,19 @@ struct AtomTestContextTests {
 
         context.watch(atom)
 
-        for i in 1...3 {
-            Task {
-                try? await Task.sleep(seconds: Double(i) / 10)
-                context[atom] += 1
-            }
-        }
-
+        // Already satisfied, so no update is awaited.
         let didUpdate0 = await context.wait(for: atom) {
             $0 == 0
         }
 
-        #expect(!(didUpdate0))
+        #expect(!didUpdate0)
+
+        // The update is delayed so it lands after the wait starts observing, and is
+        // scheduled right before the wait so its timing is independent of the test's start.
+        Task {
+            try? await Task.sleep(seconds: 0.1)
+            context[atom] = 3
+        }
 
         let didUpdate1 = await context.wait(for: atom) {
             $0 == 3
@@ -81,17 +82,19 @@ struct AtomTestContextTests {
 
         #expect(didUpdate1)
 
+        // Never satisfied, so it returns after the timeout elapses.
         let didUpdate2 = await context.wait(for: atom, timeout: 0.1) {
             $0 == 100
         }
 
-        #expect(!(didUpdate2))
+        #expect(!didUpdate2)
 
+        // Already satisfied, so no update is awaited.
         let didUpdate3 = await context.wait(for: atom) {
             $0 == 3
         }
 
-        #expect(!(didUpdate3))
+        #expect(!didUpdate3)
     }
 
     @MainActor
@@ -106,8 +109,10 @@ struct AtomTestContextTests {
             context[atom] = 1
         }
 
-        // Returns normally when an update happens within the timeout.
-        try await context.waitForUpdate(within: 1)
+        // Returns normally once the update is observed. The timeout is generous so a
+        // slow, contended CI host doesn't cause a spurious failure; it only fails if the
+        // update never arrives.
+        try await context.waitForUpdate(within: 10)
 
         // Throws when no update happens within the timeout.
         let error = await #expect(throws: AtomTestContextTimeoutError.self) {

--- a/Tests/AtomsTests/Core/StoreContextTests.swift
+++ b/Tests/AtomsTests/Core/StoreContextTests.swift
@@ -1701,7 +1701,10 @@ struct StoreContextTests {
         }
 
         struct TestAtom: TaskAtom {
-            let pipe: AsyncThrowingStreamPipe<Void>
+            // Two one-way channels avoid the test and the atom consuming each other's
+            // signals from a shared buffer, which otherwise races under load.
+            let reachedSuspension: AsyncThrowingStreamPipe<Void>
+            let resume: AsyncThrowingStreamPipe<Void>
 
             var key: UniqueKey {
                 UniqueKey()
@@ -1719,8 +1722,8 @@ struct StoreContextTests {
                     let b = context.watch(BAtom())
                     let c = context.watch(CAtom())
 
-                    pipe.continuation.yield()
-                    await pipe.stream.next()
+                    reachedSuspension.continuation.yield()
+                    await resume.stream.next()
 
                     return a + b + c
 
@@ -1728,8 +1731,8 @@ struct StoreContextTests {
                     let a = context.watch(AAtom())
                     let d = context.watch(DAtom())
 
-                    pipe.continuation.yield()
-                    await pipe.stream.next()
+                    reachedSuspension.continuation.yield()
+                    await resume.stream.next()
 
                     let b = context.watch(BAtom())
                     return a + d + b
@@ -1738,8 +1741,8 @@ struct StoreContextTests {
                     let b = context.watch(BAtom())
                     let d = context.watch(DAtom())
 
-                    pipe.continuation.yield()
-                    await pipe.stream.next()
+                    reachedSuspension.continuation.yield()
+                    await resume.stream.next()
 
                     let c = context.watch(CAtom())
                     return b + c + d
@@ -1752,8 +1755,9 @@ struct StoreContextTests {
         let atomStore = StoreContext.root(store: store, scopeKey: rootScopeToken.key)
         var subscriberState: SubscriberState? = SubscriberState()
         let subscriber = Subscriber(subscriberState!)
-        let pipe = AsyncThrowingStreamPipe<Void>()
-        let atom = TestAtom(pipe: pipe)
+        let reachedSuspension = AsyncThrowingStreamPipe<Void>()
+        let resume = AsyncThrowingStreamPipe<Void>()
+        let atom = TestAtom(reachedSuspension: reachedSuspension, resume: resume)
         let a = AAtom()
         let b = BAtom()
         let c = CAtom()
@@ -1764,8 +1768,8 @@ struct StoreContextTests {
             // first
 
             Task {
-                await pipe.stream.next()
-                pipe.continuation.yield()
+                await reachedSuspension.stream.next()
+                resume.continuation.yield()
             }
 
             let value = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
@@ -1784,12 +1788,13 @@ struct StoreContextTests {
             // second
 
             Task {
-                await pipe.stream.next()
+                await reachedSuspension.stream.next()
                 atomStore.set(1, for: d)
-                pipe.continuation.yield()
+                resume.continuation.yield()
             }
 
-            pipe.reset()
+            reachedSuspension.reset()
+            resume.reset()
             atomStore.set(.second, for: phase)
 
             let before = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
@@ -1810,12 +1815,13 @@ struct StoreContextTests {
             // third
 
             Task {
-                await pipe.stream.next()
+                await reachedSuspension.stream.next()
                 atomStore.set(2, for: b)
-                pipe.continuation.yield()
+                resume.continuation.yield()
             }
 
-            pipe.reset()
+            reachedSuspension.reset()
+            resume.reset()
             atomStore.set(.third, for: phase)
             let before = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value
             let after = await atomStore.watch(atom, subscriber: subscriber, subscription: Subscription()).value


### PR DESCRIPTION
## Summary

Three tests flaked intermittently on CI after the migration to Swift Testing, which runs tests in parallel by default. On slow, contended simulators (especially watchOS) the parallel execution starved timing-sensitive async work, surfacing latent fragility that was masked by XCTest's serial execution. The failing tests don't depend on the change being a behavior regression — they fail purely due to scheduling delays under load.

This PR hardens the three tests. No production code changes.

## Changes

- **`testWaitFor`** (`AtomTestContextTests`): the updates were scheduled relative to the test's start, so if the `wait(for:)` subscription was delayed past all of them, the predicate was already satisfied and the wait returned `false`. Now a single update is scheduled right before the wait and delayed so it lands after the wait starts observing — its timing is independent of the test's start.
- **`testWaitForUpdateWithinTimeout`** (`AtomTestContextTests`): the success case used a tight `within: 1` timeout that a contended host could exceed. It now uses a generous timeout, so it only fails if the update never arrives. The timeout-throwing case keeps its small timeout (it deterministically times out because no update happens).
- **`testComplexDependencies`** (`StoreContextTests`): the test and the atom used a single stream to hand off control in both directions. Under load the atom could consume its own signal from the shared buffer and proceed before the test updated a dependency (causing e.g. `after == 0` instead of `1`). It now uses two one-way channels (`reachedSuspension`, `resume`) so neither side consumes the other's signal.

## Verification

Reproduced the original flakiness by running the suite under CPU contention: the old tests failed intermittently (e.g. `testComplexDependencies`), while the hardened tests passed across many runs, including under heavy load (2× cores of CPU stress). `make format` / `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)