### PR TITLE
Remove unused attachDependencies helper

### DIFF
--- a/Sources/Atoms/Core/StoreContext.swift
+++ b/Sources/Atoms/Core/StoreContext.swift
@@ -460,16 +460,6 @@ private extension StoreContext {
         return dependencies
     }
 
-    func attachDependencies(_ dependencies: Set<AtomKey>, for key: AtomKey) {
-        // Set dependencies.
-        store.dependencies[key] = dependencies
-
-        // Attach the atom to its children.
-        for dependency in dependencies {
-            store.children[dependency]?.insert(key)
-        }
-    }
-
     func unsubscribeAll(for subscriberKey: SubscriberKey) {
         let keys = store.subscribes.removeValue(forKey: subscriberKey)
 


### PR DESCRIPTION
## Summary

`StoreContext.attachDependencies(_:for:)` has no call sites — only its counterpart `detachDependencies(for:)` is used. This removes the dead code.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)