### PR TITLE
Add debounce modifier

### DIFF
--- a/Sources/Atoms/Atoms.docc/Atoms.md
+++ b/Sources/Atoms/Atoms.docc/Atoms.md
@@ -32,6 +32,7 @@ Building state by compositing atoms automatically optimizes rendering based on i
 - ``Atom/latest(_:)``
 - ``Atom/changes``
 - ``Atom/changes(of:)``
+- ``Atom/debounce(for:)``
 - ``Atom/animation(_:)``
 - ``TaskAtom/phase``
 - ``ThrowingTaskAtom/phase``
@@ -90,6 +91,7 @@ Building state by compositing atoms automatically optimizes rendering based on i
 - ``LatestModifier``
 - ``ChangesModifier``
 - ``ChangesOfModifier``
+- ``DebounceModifier``
 - ``TaskPhaseModifier``
 - ``AnimationModifier``
 - ``AtomProducer``

--- a/Sources/Atoms/Modifier/DebounceModifier.swift
+++ b/Sources/Atoms/Modifier/DebounceModifier.swift
@@ -1,0 +1,146 @@
+public extension Atom {
+    /// Delays delivering the value of the atom until it stops changing for the specified
+    /// duration.
+    ///
+    /// Each time the original atom updates, the previously delivered value is kept until
+    /// no further updates occur for `duration` seconds, at which point the latest value is
+    /// delivered. This is useful to defer reacting to a value that changes rapidly, such as
+    /// debouncing a search query while the user is typing. The initial value is delivered
+    /// immediately without being debounced.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// struct QueryAtom: StateAtom, Hashable {
+    ///     func defaultValue(context: Context) -> String {
+    ///         ""
+    ///     }
+    /// }
+    ///
+    /// struct ExampleView: View {
+    ///     @Watch(QueryAtom().debounce(for: 0.3))
+    ///     var query
+    ///
+    ///     var body: some View {
+    ///         Text(query)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter duration: The duration, in seconds, that the value must remain unchanged
+    ///                       before an update is delivered.
+    ///
+    /// - Returns: An atom that delivers the original value after it settles.
+    func debounce(for duration: Double) -> ModifiedAtom<Self, DebounceModifier<Produced>> {
+        modifier(DebounceModifier(duration: duration))
+    }
+}
+
+/// A modifier that delays delivering the value of the atom until it stops changing for the
+/// specified duration.
+///
+/// Use ``Atom/debounce(for:)`` instead of using this modifier directly.
+public struct DebounceModifier<Produced>: AtomModifier {
+    /// A type of base value to be modified.
+    public typealias Base = Produced
+
+    /// A type of value the modified atom produces.
+    public typealias Produced = Produced
+
+    /// A type representing the stable identity of this modifier.
+    public struct Key: Hashable, Sendable {
+        private let duration: Double
+
+        fileprivate init(duration: Double) {
+            self.duration = duration
+        }
+    }
+
+    private let duration: Double
+
+    internal init(duration: Double) {
+        self.duration = duration
+    }
+
+    /// A unique value used to identify the modifier internally.
+    public var key: Key {
+        Key(duration: duration)
+    }
+
+    /// A producer that produces the value of this atom.
+    public func producer(atom: some Atom<Base>) -> AtomProducer<Produced> {
+        AtomProducer { context in
+            context.transaction { inner in
+                let value = inner.watch(atom)
+                let storage = inner.watch(StorageAtom(base: atom, modifier: self))
+
+                // Deliver the first value immediately without debouncing.
+                guard case .settled(let settledValue) = storage.state else {
+                    storage.state = .settled(value)
+                    return value
+                }
+
+                // Deliver the latest value once it stays unchanged for the duration. A
+                // pending delivery is cancelled when the atom is recomputed or released.
+                let task = Task {
+                    try? await Task.sleep(seconds: duration)
+
+                    if !Task.isCancelled {
+                        storage.state = .settled(value)
+                        context.update(with: value)
+                    }
+                }
+
+                context.onTermination = task.cancel
+                return settledValue
+            }
+        }
+    }
+}
+
+private extension DebounceModifier {
+    @MainActor
+    final class Storage {
+        // Holds `Base` directly to avoid a double-optional when `Base` is itself optional.
+        enum State {
+            case empty
+            case settled(Base)
+        }
+
+        var state = State.empty
+    }
+
+    struct StorageAtom<Node: Atom>: ValueAtom {
+        struct Key: Hashable, Sendable {
+            private let baseKey: Node.Key
+            private let modifierKey: DebounceModifier.Key
+
+            init(baseKey: Node.Key, modifierKey: DebounceModifier.Key) {
+                self.baseKey = baseKey
+                self.modifierKey = modifierKey
+            }
+        }
+
+        private let base: Node
+        private let modifier: DebounceModifier
+
+        var key: Key {
+            Key(baseKey: base.key, modifierKey: modifier.key)
+        }
+
+        init(base: Node, modifier: DebounceModifier) {
+            self.base = base
+            self.modifier = modifier
+        }
+
+        func value(context: Context) -> Storage {
+            Storage()
+        }
+    }
+}
+
+extension DebounceModifier.StorageAtom: Scoped where Node: Scoped {
+    var scopeID: Node.ScopeID {
+        base.scopeID
+    }
+}

--- a/Tests/AtomsTests/Modifier/DebounceModifierTests.swift
+++ b/Tests/AtomsTests/Modifier/DebounceModifierTests.swift
@@ -1,0 +1,211 @@
+import Testing
+
+@testable import Atoms
+
+struct DebounceModifierTests {
+    @MainActor
+    @Test
+    func testDebounce() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let debounced = atom.debounce(for: 0.05)
+        let context = AtomTestContext()
+
+        // The initial value is delivered immediately.
+        #expect(context.watch(debounced) == 0)
+
+        // While the value keeps changing, the delivered value stays the previous one.
+        context[atom] = 1
+        context[atom] = 2
+        context[atom] = 3
+
+        #expect(context.watch(debounced) == 0)
+
+        // Once the value settles, the latest value is delivered.
+        await context.wait(for: debounced, until: { $0 == 3 })
+
+        #expect(context.watch(debounced) == 3)
+    }
+
+    @MainActor
+    @Test
+    func testDebounceDeliversOnlyTheLatestValue() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let debounced = atom.debounce(for: 0.05)
+        let context = AtomTestContext()
+        var delivered = [Int]()
+
+        context.onUpdate = {
+            delivered.append(context.read(debounced))
+        }
+
+        #expect(context.watch(debounced) == 0)
+
+        context[atom] = 1
+        context[atom] = 2
+        context[atom] = 3
+
+        await context.wait(for: debounced, until: { $0 == 3 })
+
+        // Superseded values are never delivered; only the latest settled value is.
+        #expect(!delivered.contains(1))
+        #expect(!delivered.contains(2))
+        #expect(delivered.last == 3)
+    }
+
+    @MainActor
+    @Test
+    func testResetDuringDebounce() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let debounced = atom.debounce(for: 0.05)
+        let context = AtomTestContext()
+
+        context.watch(atom)
+        #expect(context.watch(debounced) == 0)
+
+        // Reset while a delivery is pending; this must cancel it, re-debounce cleanly,
+        // and not deliver a stale value.
+        context[atom] = 1
+        context.reset(debounced)
+
+        await context.wait(for: debounced, until: { $0 == 1 })
+
+        #expect(context.watch(debounced) == 1)
+    }
+
+    @MainActor
+    @Test
+    func testDebounceWithChangesSkipsRedundantUpdates() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let debounced = atom.debounce(for: 0.05).changes
+        let context = AtomTestContext()
+        var updatedCount = 0
+
+        context.onUpdate = {
+            updatedCount += 1
+        }
+
+        // Composing with `changes` suppresses the redundant deliveries during the debounce.
+        #expect(context.watch(debounced) == 0)
+        #expect(updatedCount == 0)
+
+        context[atom] = 1
+        context[atom] = 2
+        context[atom] = 3
+
+        #expect(updatedCount == 0)
+
+        await context.wait(for: debounced, until: { $0 == 3 })
+
+        #expect(context.watch(debounced) == 3)
+        #expect(updatedCount == 1)
+    }
+
+    @MainActor
+    @Test
+    func testUnwatchDuringDebounceCancelsDelivery() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let debounced = atom.debounce(for: 0.05)
+        let context = AtomTestContext()
+
+        // Keep the base alive so releasing the debounced atom doesn't reset it.
+        context.watch(atom)
+        #expect(context.watch(debounced) == 0)
+
+        // Schedule a pending delivery, then release the debounced atom before it fires.
+        context[atom] = 1
+        context.unwatch(debounced)
+
+        // Give the cancelled delivery time to (not) fire; this must not crash or leave
+        // stale state behind.
+        try? await Task.sleep(seconds: 0.15)
+
+        // Re-watching re-initializes cleanly and delivers the current base value immediately.
+        #expect(context.watch(debounced) == 1)
+    }
+
+    @MainActor
+    @Test
+    func testDebounceWithOptionalValue() async {
+        let atom = TestStateAtom<Int?>(defaultValue: nil)
+        let debounced = atom.debounce(for: 0.05)
+        let context = AtomTestContext()
+
+        // The initial nil is delivered immediately.
+        #expect(context.watch(debounced) == nil)
+
+        context[atom] = 5
+        #expect(context.watch(debounced) == nil)
+        await context.wait(for: debounced, until: { $0 == 5 })
+        #expect(context.watch(debounced) == 5)
+
+        // Settling back to nil must be debounced and delivered, not treated as "no value".
+        context[atom] = nil
+        #expect(context.watch(debounced) == 5)
+        await context.wait(for: debounced, until: { $0 == nil })
+        #expect(context.watch(debounced) == nil)
+
+        // A value following the nil must still be debounced, proving the settled nil was
+        // not mistaken for an uninitialized state.
+        context[atom] = 9
+        #expect(context.watch(debounced) == nil)
+        await context.wait(for: debounced, until: { $0 == 9 })
+        #expect(context.watch(debounced) == 9)
+    }
+
+    @MainActor
+    @Test
+    func testDebounceDeliversSettledValueToDependent() async {
+        struct BaseAtom: StateAtom, Hashable {
+            func defaultValue(context: Context) -> Int {
+                0
+            }
+        }
+
+        struct DependentAtom: ValueAtom, Hashable {
+            func value(context: Context) -> Int {
+                context.watch(BaseAtom().debounce(for: 0.05)) + 1
+            }
+        }
+
+        let context = AtomTestContext()
+
+        #expect(context.watch(DependentAtom()) == 1)
+
+        // The dependent keeps observing the previous settled value during the debounce.
+        context[BaseAtom()] = 10
+        context[BaseAtom()] = 20
+
+        #expect(context.watch(DependentAtom()) == 1)
+
+        // Once settled, the delivery propagates to the dependent.
+        await context.wait(for: DependentAtom(), until: { $0 == 21 })
+
+        #expect(context.watch(DependentAtom()) == 21)
+    }
+
+    @MainActor
+    @Test
+    func testDebounceWithZeroDuration() async {
+        let atom = TestStateAtom(defaultValue: 0)
+        let debounced = atom.debounce(for: 0)
+        let context = AtomTestContext()
+
+        #expect(context.watch(debounced) == 0)
+
+        context[atom] = 1
+        await context.wait(for: debounced, until: { $0 == 1 })
+
+        #expect(context.watch(debounced) == 1)
+    }
+
+    @Test
+    func testKey() {
+        let modifier0 = DebounceModifier<Int>(duration: 0.1)
+        let modifier1 = DebounceModifier<Int>(duration: 0.2)
+
+        #expect(modifier0.key == modifier0.key)
+        #expect(modifier0.key.hashValue == modifier0.key.hashValue)
+        #expect(modifier0.key != modifier1.key)
+        #expect(modifier0.key.hashValue != modifier1.key.hashValue)
+    }
+}


### PR DESCRIPTION
## Summary

Add a `.debounce(for:)` modifier that delays delivering the atom's value until it stops changing for the specified duration — useful for deferring reaction to rapidly changing values, such as a search query while typing.

```swift
@Watch(QueryAtom().debounce(for: 0.3))
var query
```

## Behavior

- The initial value is delivered immediately (not debounced).
- While the value keeps changing, the previously delivered value is kept; once no further change occurs for `duration`, the latest value is delivered.
- Only the latest value is ever delivered — superseded pending deliveries are cancelled.

## Design notes

- Its sole responsibility is to delay value delivery. It does **not** deduplicate equivalent values, so there is no `Equatable` constraint; compose with `.changes` (`atom.debounce(for: 0.3).changes`) when dedup is desired.
- Implemented like other stateful modifiers (`PreviousModifier`): the modified atom watches the base atom and a private storage atom. The pending delivery is a `Task` cancelled via `context.onTermination` whenever the atom is recomputed or released, so rapid updates restart the timer and never deliver stale values.
- Storage holds the settled value through an `enum { case empty; case settled(Base) }` rather than an optional, so it stays correct when `Base` is itself optional (a settled `nil` is not mistaken for "uninitialized").

## Tests

Nine tests cover: initial immediate delivery, value lag then settle, delivering only the latest value (superseded values never delivered), propagation to a dependent atom, cancellation on unwatch and on reset, optional base values (including settling to `nil`), composition with `.changes`, zero duration, and key identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)