### PR TITLE
Reflect recent changes in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,36 @@ struct CountDisplayView: View {
 
 </details>
 
+#### [debounce(for:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atom/debounce(for:))
+
+|               |Description|
+|:--------------|:----------|
+|Summary        |Delays delivering the atom's value until it stops changing for the specified duration. The initial value is delivered immediately.|
+|Output         |`T`|
+|Compatible     |All atom types.|
+|Use Case       |Deferring reaction to a rapidly changing value, such as a search query while typing|
+
+<details><summary><code>📖 Example</code></summary>
+
+```swift
+struct QueryAtom: StateAtom, Hashable {
+    func defaultValue(context: Context) -> String {
+        ""
+    }
+}
+
+struct SearchView: View {
+    @Watch(QueryAtom().debounce(for: 0.3))
+    var query  // : String
+
+    var body: some View {
+        Text(query)
+    }
+}
+```
+
+</details>
+
 #### [animation(_:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atom/animation(_:))
 
 |               |Description|
@@ -1241,7 +1271,9 @@ A context that can simulate any scenarios in which atoms are used from a view or
 |[unwatch(_:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/unwatch(_:))|Simulates a scenario in which the atom is no longer watched.|
 |[override(_:with:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/override(_:with:)-82t4q)|Overwrites the output of a specific atom or all atoms of the given type with the fixed value.|
 |[waitForUpdate(timeout:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/waitforupdate(timeout:))|Waits until any of the atoms watched through this context have been updated.|
+|[waitForUpdate(within:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/waitforupdate(within:))|Waits for an update within the duration, throwing an error if it elapses first.|
 |[wait(for:timeout:until:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/wait(for:timeout:until:))|Waits for the given atom until it will be a certain state.|
+|[wait(for:within:until:)](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/wait(for:within:until:))|Waits for the given atom to reach a certain state, throwing an error if the duration elapses first.|
 |[onUpdate](https://ra1028.github.io/swiftui-atom-properties/documentation/atoms/atomtestcontext/onupdate)|Sets a closure that notifies there has been an update to one of the atoms.|
 
 <details><summary><code>📖 Example</code></summary>
@@ -1267,9 +1299,10 @@ struct FetchMusicsAtom: ThrowingTaskAtom, Hashable {
     }
 }
 
-@MainActor
-class FetchMusicsTests: XCTestCase {
-    func testFetchMusicsAtom() async throws {
+struct FetchMusicsTests {
+    @MainActor
+    @Test
+    func fetchMusicsAtom() async throws {
         let context = AtomTestContext()
 
         context.override(APIClientAtom()) { _ in
@@ -1278,7 +1311,7 @@ class FetchMusicsTests: XCTestCase {
 
         let musics = try await context.watch(FetchMusicsAtom()).value
 
-        XCTAssertTrue(musics.isEmpty)
+        #expect(musics.isEmpty)
     }
 }
 ```
@@ -1570,9 +1603,10 @@ struct FetchBookAtom: ThrowingTaskAtom, Hashable {
 
 ```swift
 
-class FetchBookTests: XCTestCase {
+struct FetchBookTests {
     @MainActor
-    func testFetch() async throws {
+    @Test
+    func fetch() async throws {
         let context = AtomTestContext()
         let api = MockAPIClient()
 
@@ -1588,7 +1622,7 @@ class FetchBookTests: XCTestCase {
 
         let book = try await context.watch(FetchBookAtom(isbn: "ISBN000–0–0000–0000–0")).value
 
-        XCTAssertEqual(book, expected)
+        #expect(book == expected)
     }
 }
 ```

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -28,6 +28,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// specified timeout, and then returns a boolean value indicating whether an update has happened.
     ///
     /// ```swift
+    /// @MainActor
     /// @Test
     /// func asyncUpdate() async {
     ///     let context = AtomTestContext()
@@ -84,6 +85,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// of being silently ignored.
     ///
     /// ```swift
+    /// @MainActor
     /// @Test
     /// func asyncUpdate() async throws {
     ///     let context = AtomTestContext()
@@ -130,6 +132,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// and then returns a boolean value indicating whether an update has happened.
     ///
     /// ```swift
+    /// @MainActor
     /// @Test
     /// func asyncUpdate() async {
     ///     let context = AtomTestContext()
@@ -212,6 +215,7 @@ public struct AtomTestContext: AtomWatchableContext {
     /// returns immediately without waiting for an update.
     ///
     /// ```swift
+    /// @MainActor
     /// @Test
     /// func asyncUpdate() async throws {
     ///     let context = AtomTestContext()

--- a/Sources/Atoms/Context/AtomTestContext.swift
+++ b/Sources/Atoms/Context/AtomTestContext.swift
@@ -28,17 +28,18 @@ public struct AtomTestContext: AtomWatchableContext {
     /// specified timeout, and then returns a boolean value indicating whether an update has happened.
     ///
     /// ```swift
-    /// func testAsyncUpdate() async {
+    /// @Test
+    /// func asyncUpdate() async {
     ///     let context = AtomTestContext()
     ///
     ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
-    ///     XCTAssertEqual(initialPhase, .suspending)
+    ///     #expect(initialPhase == .suspending)
     ///
     ///     let didUpdate = await context.waitForUpdate()
     ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
     ///
-    ///     XCTAssertTure(didUpdate)
-    ///     XCTAssertEqual(currentPhase, .success(123))
+    ///     #expect(didUpdate)
+    ///     #expect(currentPhase == .success(123))
     /// }
     /// ```
     ///
@@ -83,16 +84,17 @@ public struct AtomTestContext: AtomWatchableContext {
     /// of being silently ignored.
     ///
     /// ```swift
-    /// func testAsyncUpdate() async throws {
+    /// @Test
+    /// func asyncUpdate() async throws {
     ///     let context = AtomTestContext()
     ///
     ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
-    ///     XCTAssertEqual(initialPhase, .suspending)
+    ///     #expect(initialPhase == .suspending)
     ///
     ///     try await context.waitForUpdate(within: 1)
     ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
     ///
-    ///     XCTAssertEqual(currentPhase, .success(123))
+    ///     #expect(currentPhase == .success(123))
     /// }
     /// ```
     ///
@@ -128,17 +130,18 @@ public struct AtomTestContext: AtomWatchableContext {
     /// and then returns a boolean value indicating whether an update has happened.
     ///
     /// ```swift
-    /// func testAsyncUpdate() async {
+    /// @Test
+    /// func asyncUpdate() async {
     ///     let context = AtomTestContext()
     ///
     ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
-    ///     XCTAssertEqual(initialPhase, .suspending)
+    ///     #expect(initialPhase == .suspending)
     ///
     ///     let didUpdate = await context.wait(for: AsyncCalculationAtom().phase, until: \.isSuccess)
     ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
     ///
-    ///     XCTAssertTure(didUpdate)
-    ///     XCTAssertEqual(currentPhase, .success(123))
+    ///     #expect(didUpdate)
+    ///     #expect(currentPhase == .success(123))
     /// }
     /// ```
     ///
@@ -209,16 +212,17 @@ public struct AtomTestContext: AtomWatchableContext {
     /// returns immediately without waiting for an update.
     ///
     /// ```swift
-    /// func testAsyncUpdate() async throws {
+    /// @Test
+    /// func asyncUpdate() async throws {
     ///     let context = AtomTestContext()
     ///
     ///     let initialPhase = context.watch(AsyncCalculationAtom().phase)
-    ///     XCTAssertEqual(initialPhase, .suspending)
+    ///     #expect(initialPhase == .suspending)
     ///
     ///     try await context.wait(for: AsyncCalculationAtom().phase, within: 1, until: \.isSuccess)
     ///     let currentPhase = context.watch(AsyncCalculationAtom().phase)
     ///
-    ///     XCTAssertEqual(currentPhase, .success(123))
+    ///     #expect(currentPhase == .success(123))
     /// }
     /// ```
     ///

--- a/Sources/Atoms/PropertyWrapper/ViewContext.swift
+++ b/Sources/Atoms/PropertyWrapper/ViewContext.swift
@@ -109,18 +109,6 @@ private extension ViewContext {
                     }
                 }
                 ```
-
-                The modal screen presented by the `.sheet` modifier or etc, propagates the environment values,
-                but only in iOS14, there is a bug where the environment values will be dismantled during it is
-                dismissing. This also can be avoided by using `AtomDerivedScope` to explicitly propagate it.
-
-                ```
-                .sheet(isPresented: ...) {
-                    AtomDerivedScope(context) {
-                        ExampleView()
-                    }
-                }
-                ```
                 """,
                 file: file,
                 line: location.line


### PR DESCRIPTION
## Summary

Update the documentation to follow recent changes and API additions. Docs only.

### README
- Document the new `debounce(for:)` modifier.
- Document the throwing `waitForUpdate(within:)` and `wait(for:within:until:)` variants on `AtomTestContext`.
- Update the testing examples to Swift Testing (`@Test` / `#expect`).

### Source doc comments
- Convert the `AtomTestContext` doc-comment examples (`waitForUpdate` / `wait`) from XCTest to Swift Testing, matching the migrated test suite (also fixes the `XCTAssertTure` typo).
- Remove the stale iOS 14 `.sheet` environment-propagation note from the `@ViewContext` "store is nil" diagnostic, which no longer applies now that the minimum deployment target is iOS 17. The still-relevant guidance about UIKit-hosted views is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)